### PR TITLE
feat(compiler): heavy-compilation DX with provideHttpClient, UrlTree, ModuleDependencyGraph, and SC2008/SC3013 diagnostics

### DIFF
--- a/packages/app/src/http_client.test.ts
+++ b/packages/app/src/http_client.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import { HttpParams } from "./http_params";
+import { HttpHeaders } from "./http_headers";
+import { HttpContext, HttpContextToken } from "./http_context";
+import {
+  HttpClient,
+  HttpErrorResponse,
+  HTTP_CLIENT_CONFIG,
+  HTTP_INTERCEPTORS,
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from "./http_client";
+import { createEnvironmentInjector } from "./inject";
+import { TestBed } from "./testing";
+
+describe("Angular-inspired HttpParams and HttpHeaders", () => {
+  test("HttpParams provides immutable query parameter construction", () => {
+    const params = new HttpParams({ fromString: "filter=active&sort=desc&tag=a&tag=b" });
+    expect(params.get("filter")).toBe("active");
+    expect(params.get("sort")).toBe("desc");
+    expect(params.getAll("tag")).toEqual(["a", "b"]);
+    expect(params.has("sort")).toBe(true);
+    expect(params.has("unknown")).toBe(false);
+
+    // Immutability check: set returns a new instance
+    const updated = params.set("sort", "asc");
+    expect(params.get("sort")).toBe("desc");
+    expect(updated.get("sort")).toBe("asc");
+
+    // append adds a value to the key
+    const appended = updated.append("tag", "c");
+    expect(appended.getAll("tag")).toEqual(["a", "b", "c"]);
+    expect(updated.getAll("tag")).toEqual(["a", "b"]);
+
+    // delete removes a specific value or the entire key
+    const deletedValue = appended.delete("tag", "b");
+    expect(deletedValue.getAll("tag")).toEqual(["a", "c"]);
+
+    const deletedKey = deletedValue.delete("filter");
+    expect(deletedKey.has("filter")).toBe(false);
+    expect(deletedValue.has("filter")).toBe(true);
+
+    // construction fromObject
+    const fromObj = new HttpParams({
+      fromObject: {
+        page: 1,
+        active: true,
+        ids: ["10", "20"],
+      },
+    });
+    expect(fromObj.get("page")).toBe("1");
+    expect(fromObj.get("active")).toBe("true");
+    expect(fromObj.getAll("ids")).toEqual(["10", "20"]);
+    expect(fromObj.toString()).toBe("page=1&active=true&ids=10&ids=20");
+  });
+
+  test("HttpHeaders provides immutable case-insensitive HTTP header management", () => {
+    const headers = new HttpHeaders({
+      "Content-Type": "application/json",
+      "X-Custom-Header": "value1",
+    });
+
+    expect(headers.has("content-type")).toBe(true);
+    expect(headers.has("CONTENT-TYPE")).toBe(true);
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("x-custom-header")).toBe("value1");
+
+    // Immutability check: set returns new instance
+    const updated = headers.set("Authorization", "Bearer secret");
+    expect(headers.has("authorization")).toBe(false);
+    expect(updated.has("authorization")).toBe(true);
+    expect(updated.get("authorization")).toBe("Bearer secret");
+
+    // append combines header values
+    const appended = updated.append("Accept", "text/html").append("Accept", "application/xhtml+xml");
+    expect(appended.getAll("accept")).toEqual(["text/html", "application/xhtml+xml"]);
+    expect(appended.toObject()["Accept"]).toBe("text/html, application/xhtml+xml");
+
+    // delete removes header case-insensitively
+    const deleted = appended.delete("x-custom-header");
+    expect(deleted.has("x-custom-header")).toBe(false);
+    expect(appended.has("x-custom-header")).toBe(true);
+  });
+
+  test("HttpContext and HttpContextToken store strongly-typed request metadata", () => {
+    const IS_CACHE_ENABLED = new HttpContextToken<boolean>(() => true);
+    const RETRY_COUNT = new HttpContextToken<number>(() => 3);
+
+    const context = new HttpContext();
+    expect(context.get(IS_CACHE_ENABLED)).toBe(true);
+    expect(context.get(RETRY_COUNT)).toBe(3);
+    expect(context.has(IS_CACHE_ENABLED)).toBe(false);
+
+    context.set(RETRY_COUNT, 5);
+    expect(context.has(RETRY_COUNT)).toBe(true);
+    expect(context.get(RETRY_COUNT)).toBe(5);
+
+    context.delete(RETRY_COUNT);
+    expect(context.has(RETRY_COUNT)).toBe(false);
+    expect(context.get(RETRY_COUNT)).toBe(3);
+  });
+});
+
+describe("Angular 15+ provideHttpClient and HttpClient", () => {
+  test("executes GET requests through mock fetch and functional interceptors", async () => {
+    const mockFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      expect(url).toBe("https://api.supacloud.dev/users?role=admin");
+      const reqHeaders = (init?.headers as Record<string, string>) ?? {};
+      expect(reqHeaders["authorization"]).toBe("Bearer test-token");
+      return new Response(JSON.stringify([{ id: 1, name: "Admin" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const authInterceptor = async (req: any, next: any) => {
+      req.headers["authorization"] = "Bearer test-token";
+      return next(req);
+    };
+
+    const env = createEnvironmentInjector([
+      provideHttpClient(
+        withFetch(mockFetch as any),
+        withInterceptors(authInterceptor),
+      ),
+    ]);
+
+    const client = env.get(HttpClient);
+    expect(client).toBeDefined();
+
+    const users = await client.get<Array<{ id: number; name: string }>>(
+      "https://api.supacloud.dev/users",
+      {
+        params: { role: "admin" },
+      },
+    );
+
+    expect(users).toEqual([{ id: 1, name: "Admin" }]);
+  });
+
+  test("executes POST, PUT, DELETE, and PATCH requests with JSON bodies and params", async () => {
+    let lastMethod = "";
+    let lastBody = "";
+    let lastUrl = "";
+
+    const mockFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      lastUrl = String(input);
+      lastMethod = init?.method ?? "GET";
+      lastBody = String(init?.body ?? "");
+      return new Response(JSON.stringify({ success: true, method: lastMethod }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const client = new HttpClient(
+      { baseUrl: "https://api.supacloud.dev/v1", fetch: mockFetch as any },
+      [],
+    );
+
+    const postRes = await client.post<{ success: boolean; method: string }>(
+      "items",
+      { title: "Item 1" },
+    );
+    expect(postRes.success).toBe(true);
+    expect(lastMethod).toBe("POST");
+    expect(lastUrl).toBe("https://api.supacloud.dev/v1/items");
+    expect(JSON.parse(lastBody)).toEqual({ title: "Item 1" });
+
+    const putRes = await client.put<{ success: boolean; method: string }>(
+      "/items/123",
+      { title: "Item 1 Updated" },
+    );
+    expect(putRes.method).toBe("PUT");
+    expect(lastUrl).toBe("https://api.supacloud.dev/v1/items/123");
+
+    const patchRes = await client.patch<{ success: boolean; method: string }>(
+      "/items/123",
+      { active: false },
+    );
+    expect(patchRes.method).toBe("PATCH");
+
+    const deleteRes = await client.delete<{ success: boolean; method: string }>(
+      "/items/123",
+    );
+    expect(deleteRes.method).toBe("DELETE");
+  });
+
+  test("throws HttpErrorResponse on non-2xx HTTP responses", async () => {
+    const mockFetch = async () => {
+      return new Response(JSON.stringify({ message: "Not Found", code: "NOT_FOUND" }), {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    const client = new HttpClient({ fetch: mockFetch as any }, []);
+
+    try {
+      await client.get("https://api.supacloud.dev/unknown");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err instanceof HttpErrorResponse).toBe(true);
+      const httpErr = err as HttpErrorResponse;
+      expect(httpErr.status).toBe(404);
+      expect(httpErr.statusText).toBe("Not Found");
+      expect(httpErr.error).toEqual({ message: "Not Found", code: "NOT_FOUND" });
+    }
+  });
+
+  test("supports observe: 'response' and HttpContext in interceptor", async () => {
+    const SKIP_AUTH = new HttpContextToken<boolean>(() => false);
+    let interceptorSawSkipAuth = false;
+
+    const mockFetch = async () => {
+      return new Response("OK", {
+        status: 200,
+        headers: { "x-total-count": "42" },
+      });
+    };
+
+    const contextInterceptor = async (req: any, next: any) => {
+      if (req.context?.get(SKIP_AUTH)) {
+        interceptorSawSkipAuth = true;
+      }
+      return next(req);
+    };
+
+    const client = new HttpClient({ fetch: mockFetch as any }, [contextInterceptor]);
+    const ctx = new HttpContext().set(SKIP_AUTH, true);
+
+    const response = await client.get<Response>("https://api.supacloud.dev/status", {
+      context: ctx,
+      observe: "response",
+    });
+
+    expect(interceptorSawSkipAuth).toBe(true);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-total-count")).toBe("42");
+    expect(await response.text()).toBe("OK");
+  });
+});

--- a/packages/app/src/http_client.ts
+++ b/packages/app/src/http_client.ts
@@ -1,0 +1,268 @@
+import { Injectable } from "./decorators";
+import { HttpContext } from "./http_context";
+import { HttpHeaders } from "./http_headers";
+import { HttpParams } from "./http_params";
+import { type HttpInterceptorFn, type HttpRequestPayload } from "./interceptor";
+import { InjectionToken } from "./token";
+import { inject, injectAll } from "./inject";
+import { makeEnvironmentProviders, type EnvironmentProviders, type Provider } from "./provider";
+
+export interface HttpClientConfig {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export const HTTP_CLIENT_CONFIG = new InjectionToken<HttpClientConfig>(
+  "HTTP_CLIENT_CONFIG",
+  { scope: "application", factory: () => ({}) },
+);
+
+export const HTTP_INTERCEPTORS = new InjectionToken<HttpInterceptorFn[]>(
+  "HTTP_INTERCEPTORS",
+  { scope: "application", factory: () => [] },
+);
+
+export class HttpErrorResponse extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly url: string | null;
+  readonly error: unknown;
+
+  constructor(init: { error?: unknown; status?: number; statusText?: string; url?: string }) {
+    super(`Http failure response for ${init.url ?? "unknown"}: ${init.status ?? 0} ${init.statusText ?? "Unknown Error"}`);
+    this.name = "HttpErrorResponse";
+    this.status = init.status ?? 0;
+    this.statusText = init.statusText ?? "Unknown Error";
+    this.url = init.url ?? null;
+    this.error = init.error ?? null;
+  }
+}
+
+export interface HttpRequestOptions {
+  headers?: HttpHeaders | Record<string, string | string[]>;
+  params?: HttpParams | Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
+  body?: unknown;
+  context?: HttpContext;
+  observe?: "body" | "response";
+  responseType?: "json" | "text" | "blob";
+  signal?: AbortSignal;
+}
+
+export type HttpClientFeatureKind = "Fetch" | "Interceptors" | "ParentRequests";
+
+export interface HttpClientFeature {
+  kind: HttpClientFeatureKind;
+  providers: Provider[];
+}
+
+export function withFetch(customFetch?: typeof fetch): HttpClientFeature {
+  return {
+    kind: "Fetch",
+    providers: [
+      {
+        provide: HTTP_CLIENT_CONFIG,
+        useFactory: () => ({ fetch: customFetch ?? (typeof globalThis.fetch === "function" ? globalThis.fetch.bind(globalThis) : undefined) }),
+      },
+    ],
+  };
+}
+
+export function withInterceptors(...interceptors: (HttpInterceptorFn | HttpInterceptorFn[])[]): HttpClientFeature {
+  const flattened = interceptors.flat();
+  return {
+    kind: "Interceptors",
+    providers: [
+      {
+        provide: HTTP_INTERCEPTORS,
+        useValue: flattened,
+        multi: true,
+      },
+    ],
+  };
+}
+
+export function withRequestsMadeViaParent(): HttpClientFeature {
+  return {
+    kind: "ParentRequests",
+    providers: [],
+  };
+}
+
+export function provideHttpClient(...features: HttpClientFeature[]): EnvironmentProviders {
+  const providers: Provider[] = [
+    HttpClient,
+  ];
+  for (const feature of features) {
+    providers.push(...feature.providers);
+  }
+  return makeEnvironmentProviders(providers);
+}
+
+@Injectable({ providedIn: "root" })
+export class HttpClient {
+  private config: HttpClientConfig;
+  private interceptors: HttpInterceptorFn[];
+
+  constructor(config?: HttpClientConfig, interceptors?: HttpInterceptorFn[]) {
+    if (config) {
+      this.config = config;
+    } else {
+      try {
+        this.config = inject(HTTP_CLIENT_CONFIG, { optional: true }) ?? {};
+      } catch {
+        this.config = {};
+      }
+    }
+
+    if (interceptors) {
+      this.interceptors = [...interceptors];
+    } else {
+      try {
+        const resolved = injectAll(HTTP_INTERCEPTORS);
+        this.interceptors = resolved.flat();
+      } catch {
+        this.interceptors = [];
+      }
+    }
+  }
+
+  get<T = unknown>(url: string, options?: HttpRequestOptions): Promise<T> {
+    return this.request<T>("GET", url, options);
+  }
+
+  post<T = unknown>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
+    return this.request<T>("POST", url, { ...options, body });
+  }
+
+  put<T = unknown>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
+    return this.request<T>("PUT", url, { ...options, body });
+  }
+
+  delete<T = unknown>(url: string, options?: HttpRequestOptions): Promise<T> {
+    return this.request<T>("DELETE", url, options);
+  }
+
+  patch<T = unknown>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
+    return this.request<T>("PATCH", url, { ...options, body });
+  }
+
+  async request<T = unknown>(method: string, url: string, options?: HttpRequestOptions): Promise<T> {
+    let targetUrl = url;
+    if (this.config.baseUrl && !/^https?:\/\//i.test(targetUrl)) {
+      const base = this.config.baseUrl.endsWith("/") ? this.config.baseUrl.slice(0, -1) : this.config.baseUrl;
+      const rel = targetUrl.startsWith("/") ? targetUrl : `/${targetUrl}`;
+      targetUrl = `${base}${rel}`;
+    }
+
+    if (options?.params) {
+      const params = options.params instanceof HttpParams
+        ? options.params
+        : new HttpParams({ fromObject: options.params as Record<string, string | number | boolean> });
+      const qs = params.toString();
+      if (qs.length > 0) {
+        targetUrl += targetUrl.includes("?") ? `&${qs}` : `?${qs}`;
+      }
+    }
+
+    let headers: Record<string, string> = {};
+    if (options?.headers) {
+      if (options.headers instanceof HttpHeaders) {
+        headers = options.headers.toObject();
+      } else {
+        for (const [k, v] of Object.entries(options.headers)) {
+          if (v !== undefined && v !== null) {
+            headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
+          }
+        }
+      }
+    }
+
+    let body = options?.body;
+    if (
+      body !== undefined &&
+      body !== null &&
+      typeof body === "object" &&
+      !(body instanceof FormData) &&
+      !(body instanceof Blob) &&
+      !(body instanceof URLSearchParams) &&
+      !(body instanceof ArrayBuffer)
+    ) {
+      body = JSON.stringify(body);
+      const hasContentType = Object.keys(headers).some((k) => k.toLowerCase() === "content-type");
+      if (!hasContentType) {
+        headers["content-type"] = "application/json";
+      }
+    }
+
+    const payload: HttpRequestPayload = {
+      method: method.toUpperCase(),
+      url: targetUrl,
+      headers,
+      body,
+      context: options?.context,
+    };
+
+    const fetchFn = this.config.fetch ?? (typeof globalThis.fetch === "function" ? globalThis.fetch.bind(globalThis) : undefined);
+    if (!fetchFn) {
+      throw new Error("No fetch implementation available. Provide withFetch() in provideHttpClient or run in an environment with global fetch.");
+    }
+
+    const finalHandler = async (req: HttpRequestPayload): Promise<Response> => {
+      return fetchFn(req.url, {
+        method: req.method,
+        headers: req.headers,
+        body: (req.body as any) ?? undefined,
+        signal: options?.signal,
+      });
+    };
+
+    const pipeline = this.interceptors.reduceRight<typeof finalHandler>(
+      (next, interceptor) => (req) => interceptor(req, next),
+      finalHandler,
+    );
+
+    const response = await pipeline(payload);
+
+    if (options?.observe === "response") {
+      return response as unknown as T;
+    }
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await response.json();
+      } catch {
+        try {
+          errorBody = await response.text();
+        } catch {
+          errorBody = null;
+        }
+      }
+      throw new HttpErrorResponse({
+        url: response.url || targetUrl,
+        status: response.status,
+        statusText: response.statusText,
+        error: errorBody,
+      });
+    }
+
+    if (options?.responseType === "text") {
+      return (await response.text()) as unknown as T;
+    }
+    if (options?.responseType === "blob") {
+      return (await response.blob()) as unknown as T;
+    }
+
+    const contentType = response.headers?.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await response.json()) as unknown as T;
+    }
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  }
+}

--- a/packages/app/src/http_context.ts
+++ b/packages/app/src/http_context.ts
@@ -1,0 +1,37 @@
+/**
+ * Angular-inspired typed HTTP context token and context bag.
+ * Modeled after Angular's @angular/common/http HttpContext and HttpContextToken API.
+ */
+
+export class HttpContextToken<T> {
+  constructor(readonly defaultValue: () => T) {}
+}
+
+export class HttpContext {
+  private readonly map = new Map<HttpContextToken<unknown>, unknown>();
+
+  set<T>(token: HttpContextToken<T>, value: T): this {
+    this.map.set(token as HttpContextToken<unknown>, value);
+    return this;
+  }
+
+  get<T>(token: HttpContextToken<T>): T {
+    if (this.map.has(token as HttpContextToken<unknown>)) {
+      return this.map.get(token as HttpContextToken<unknown>) as T;
+    }
+    return token.defaultValue();
+  }
+
+  delete(token: HttpContextToken<unknown>): this {
+    this.map.delete(token);
+    return this;
+  }
+
+  has(token: HttpContextToken<unknown>): boolean {
+    return this.map.has(token);
+  }
+
+  keys(): IterableIterator<HttpContextToken<unknown>> {
+    return this.map.keys();
+  }
+}

--- a/packages/app/src/http_headers.ts
+++ b/packages/app/src/http_headers.ts
@@ -1,0 +1,110 @@
+/**
+ * Angular-inspired immutable HttpHeaders builder.
+ * Modeled after Angular's @angular/common/http HttpHeaders API.
+ * Header names are treated case-insensitively.
+ */
+
+export class HttpHeaders {
+  private readonly headersMap: Map<string, string[]>;
+  private readonly originalNames: Map<string, string>;
+
+  constructor(headers?: Record<string, string | string[]> | HttpHeaders) {
+    this.headersMap = new Map<string, string[]>();
+    this.originalNames = new Map<string, string>();
+    if (!headers) return;
+
+    if (headers instanceof HttpHeaders) {
+      for (const [k, v] of headers.headersMap.entries()) {
+        this.headersMap.set(k, [...v]);
+        this.originalNames.set(k, headers.originalNames.get(k) ?? k);
+      }
+      return;
+    }
+
+    for (const [key, value] of Object.entries(headers)) {
+      if (value === undefined || value === null) continue;
+      const lower = key.toLowerCase();
+      this.originalNames.set(lower, key);
+      if (Array.isArray(value)) {
+        this.headersMap.set(lower, [...value]);
+      } else {
+        this.headersMap.set(lower, [String(value)]);
+      }
+    }
+  }
+
+  private clone(newMap: Map<string, string[]>, newNames: Map<string, string>): HttpHeaders {
+    const clone = new HttpHeaders();
+    for (const [k, v] of newMap.entries()) {
+      (clone.headersMap as Map<string, string[]>).set(k, [...v]);
+    }
+    for (const [k, v] of newNames.entries()) {
+      (clone.originalNames as Map<string, string>).set(k, v);
+    }
+    return clone;
+  }
+
+  has(name: string): boolean {
+    return this.headersMap.has(name.toLowerCase());
+  }
+
+  get(name: string): string | null {
+    const values = this.headersMap.get(name.toLowerCase());
+    return values && values.length > 0 ? values[0] : null;
+  }
+
+  getAll(name: string): string[] | null {
+    const values = this.headersMap.get(name.toLowerCase());
+    return values ? [...values] : null;
+  }
+
+  keys(): string[] {
+    return Array.from(this.originalNames.values());
+  }
+
+  set(name: string, value: string | string[]): HttpHeaders {
+    const lower = name.toLowerCase();
+    const newMap = new Map(this.headersMap);
+    const newNames = new Map(this.originalNames);
+    const valArray = Array.isArray(value) ? [...value] : [String(value)];
+    newMap.set(lower, valArray);
+    newNames.set(lower, name);
+    return this.clone(newMap, newNames);
+  }
+
+  append(name: string, value: string | string[]): HttpHeaders {
+    const lower = name.toLowerCase();
+    const newMap = new Map(this.headersMap);
+    const newNames = new Map(this.originalNames);
+    const existing = newMap.get(lower) ? [...newMap.get(lower)!] : [];
+    if (Array.isArray(value)) {
+      existing.push(...value);
+    } else {
+      existing.push(String(value));
+    }
+    newMap.set(lower, existing);
+    if (!newNames.has(lower)) {
+      newNames.set(lower, name);
+    }
+    return this.clone(newMap, newNames);
+  }
+
+  delete(name: string): HttpHeaders {
+    const lower = name.toLowerCase();
+    if (!this.headersMap.has(lower)) return this;
+    const newMap = new Map(this.headersMap);
+    const newNames = new Map(this.originalNames);
+    newMap.delete(lower);
+    newNames.delete(lower);
+    return this.clone(newMap, newNames);
+  }
+
+  toObject(): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [lower, values] of this.headersMap.entries()) {
+      const originalName = this.originalNames.get(lower) ?? lower;
+      result[originalName] = values.join(", ");
+    }
+    return result;
+  }
+}

--- a/packages/app/src/http_params.ts
+++ b/packages/app/src/http_params.ts
@@ -1,0 +1,117 @@
+/**
+ * Angular-inspired immutable HttpParams query parameter builder.
+ * Modeled after Angular's @angular/common/http HttpParams API.
+ */
+
+export interface HttpParamsOptions {
+  /** String in standard query string format (e.g. 'a=1&b=2') */
+  fromString?: string;
+  /** Object mapping parameter names to primitive values or arrays */
+  fromObject?: Record<string, string | number | boolean | ReadonlyArray<string | number | boolean>>;
+}
+
+export class HttpParams {
+  private readonly map: Map<string, string[]>;
+
+  constructor(options?: HttpParamsOptions) {
+    this.map = new Map<string, string[]>();
+    if (!options) return;
+
+    if (options.fromString) {
+      const raw = options.fromString.startsWith("?") ? options.fromString.slice(1) : options.fromString;
+      if (raw.length > 0) {
+        const pairs = raw.split("&");
+        for (const pair of pairs) {
+          if (!pair) continue;
+          const eqIndex = pair.indexOf("=");
+          const rawKey = eqIndex >= 0 ? pair.slice(0, eqIndex) : pair;
+          const rawVal = eqIndex >= 0 ? pair.slice(eqIndex + 1) : "";
+          const key = decodeURIComponent(rawKey.replace(/\+/g, " "));
+          const val = decodeURIComponent(rawVal.replace(/\+/g, " "));
+          const existing = this.map.get(key) ?? [];
+          existing.push(val);
+          this.map.set(key, existing);
+        }
+      }
+    }
+
+    if (options.fromObject) {
+      for (const [key, val] of Object.entries(options.fromObject)) {
+        if (val === undefined || val === null) continue;
+        if (Array.isArray(val)) {
+          this.map.set(key, val.map((v) => String(v)));
+        } else {
+          this.map.set(key, [String(val)]);
+        }
+      }
+    }
+  }
+
+  private clone(newMap: Map<string, string[]>): HttpParams {
+    const clone = new HttpParams();
+    for (const [k, v] of newMap.entries()) {
+      (clone.map as Map<string, string[]>).set(k, [...v]);
+    }
+    return clone;
+  }
+
+  has(param: string): boolean {
+    return this.map.has(param);
+  }
+
+  get(param: string): string | null {
+    const values = this.map.get(param);
+    return values && values.length > 0 ? values[0] : null;
+  }
+
+  getAll(param: string): string[] | null {
+    const values = this.map.get(param);
+    return values ? [...values] : null;
+  }
+
+  keys(): string[] {
+    return Array.from(this.map.keys());
+  }
+
+  set(param: string, value: string | number | boolean): HttpParams {
+    const newMap = new Map(this.map);
+    newMap.set(param, [String(value)]);
+    return this.clone(newMap);
+  }
+
+  append(param: string, value: string | number | boolean): HttpParams {
+    const newMap = new Map(this.map);
+    const existing = newMap.get(param) ? [...newMap.get(param)!] : [];
+    existing.push(String(value));
+    newMap.set(param, existing);
+    return this.clone(newMap);
+  }
+
+  delete(param: string, value?: string | number | boolean): HttpParams {
+    if (!this.map.has(param)) return this;
+    const newMap = new Map(this.map);
+    if (value === undefined) {
+      newMap.delete(param);
+    } else {
+      const target = String(value);
+      const existing = newMap.get(param)!.filter((v) => v !== target);
+      if (existing.length === 0) {
+        newMap.delete(param);
+      } else {
+        newMap.set(param, existing);
+      }
+    }
+    return this.clone(newMap);
+  }
+
+  toString(): string {
+    const parts: string[] = [];
+    for (const [key, values] of this.map.entries()) {
+      const encodedKey = encodeURIComponent(key);
+      for (const val of values) {
+        parts.push(`${encodedKey}=${encodeURIComponent(val)}`);
+      }
+    }
+    return parts.join("&");
+  }
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -200,3 +200,29 @@ export {
   isPlatformServer,
 } from "./platform";
 export type { PlatformId } from "./platform";
+export { HttpParams } from "./http_params";
+export type { HttpParamsOptions } from "./http_params";
+export { HttpHeaders } from "./http_headers";
+export { HttpContext, HttpContextToken } from "./http_context";
+export {
+  HTTP_CLIENT_CONFIG,
+  HTTP_INTERCEPTORS,
+  HttpClient,
+  HttpErrorResponse,
+  provideHttpClient,
+  withFetch,
+  withRequestsMadeViaParent,
+} from "./http_client";
+export type {
+  HttpClientConfig,
+  HttpClientFeature,
+  HttpClientFeatureKind,
+  HttpRequestOptions,
+} from "./http_client";
+export {
+  DefaultUrlSerializer,
+  UrlSegmentGroup,
+  UrlSerializer,
+  UrlTree,
+} from "./url_tree";
+export type { UrlSegment } from "./url_tree";

--- a/packages/app/src/interceptor.ts
+++ b/packages/app/src/interceptor.ts
@@ -1,3 +1,5 @@
+import type { HttpContext } from "./http_context";
+
 /**
  * Angular-inspired functional HTTP interceptor pipeline.
  * Modeled after Angular 15+ HttpInterceptorFn and withInterceptors API.
@@ -8,6 +10,7 @@ export interface HttpRequestPayload {
   url: string;
   headers: Record<string, string>;
   body?: unknown;
+  context?: HttpContext;
 }
 
 export type HttpInterceptorFn = (

--- a/packages/app/src/url_tree.test.ts
+++ b/packages/app/src/url_tree.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DefaultUrlSerializer,
+  UrlSegmentGroup,
+  UrlTree,
+} from "./url_tree";
+
+describe("Angular-inspired UrlTree and DefaultUrlSerializer", () => {
+  const serializer = new DefaultUrlSerializer();
+
+  test("parses standard URLs with path, query params, and fragment", () => {
+    const url = "/users/42?tab=profile&view=summary#details";
+    const tree = serializer.parse(url);
+
+    expect(tree.root.segments.length).toBe(2);
+    expect(tree.root.segments[0].path).toBe("users");
+    expect(tree.root.segments[1].path).toBe("42");
+    expect(tree.queryParams).toEqual({
+      tab: "profile",
+      view: "summary",
+    });
+    expect(tree.fragment).toBe("details");
+    expect(tree.queryParamMap.get("tab")).toBe("profile");
+    expect(tree.queryParamMap.get("view")).toBe("summary");
+    expect(tree.queryParamMap.has("unknown")).toBe(false);
+
+    const serialized = serializer.serialize(tree);
+    expect(serialized).toBe("/users/42?tab=profile&view=summary#details");
+    expect(tree.toString()).toBe("/users/42?tab=profile&view=summary#details");
+  });
+
+  test("parses URLs with matrix parameters", () => {
+    const url = "/items;category=books;format=hardcover/101";
+    const tree = serializer.parse(url);
+
+    expect(tree.root.segments.length).toBe(2);
+    expect(tree.root.segments[0].path).toBe("items");
+    expect(tree.root.segments[0].parameters).toEqual({
+      category: "books",
+      format: "hardcover",
+    });
+    expect(tree.root.segments[1].path).toBe("101");
+    expect(tree.root.segments[1].parameters).toEqual({});
+
+    const serialized = serializer.serialize(tree);
+    expect(serialized).toBe("/items;category=books;format=hardcover/101");
+  });
+
+  test("handles empty and root paths correctly", () => {
+    const tree1 = serializer.parse("/");
+    expect(tree1.root.segments).toEqual([]);
+    expect(tree1.queryParams).toEqual({});
+    expect(tree1.fragment).toBeNull();
+    expect(serializer.serialize(tree1)).toBe("/");
+
+    const tree2 = serializer.parse("/?debug=true");
+    expect(tree2.root.segments).toEqual([]);
+    expect(tree2.queryParams).toEqual({ debug: "true" });
+    expect(serializer.serialize(tree2)).toBe("/?debug=true");
+  });
+});

--- a/packages/app/src/url_tree.ts
+++ b/packages/app/src/url_tree.ts
@@ -1,0 +1,129 @@
+/**
+ * Angular-inspired UrlTree and UrlSerializer for structured URL manipulation.
+ * Modeled after Angular's @angular/router UrlTree and DefaultUrlSerializer API.
+ */
+
+export interface UrlSegment {
+  path: string;
+  parameters: Record<string, string>;
+}
+
+export class UrlSegmentGroup {
+  segments: UrlSegment[];
+  children: Record<string, UrlSegmentGroup>;
+  parent: UrlSegmentGroup | null = null;
+
+  constructor(segments: UrlSegment[], children: Record<string, UrlSegmentGroup> = {}) {
+    this.segments = segments;
+    this.children = children;
+    for (const child of Object.values(children)) {
+      child.parent = this;
+    }
+  }
+
+  hasChildren(): boolean {
+    return Object.keys(this.children).length > 0;
+  }
+}
+
+export class UrlTree {
+  root: UrlSegmentGroup;
+  queryParams: Record<string, string>;
+  fragment: string | null;
+
+  constructor(root: UrlSegmentGroup, queryParams: Record<string, string> = {}, fragment: string | null = null) {
+    this.root = root;
+    this.queryParams = queryParams;
+    this.fragment = fragment;
+  }
+
+  get queryParamMap(): Map<string, string> {
+    return new Map(Object.entries(this.queryParams));
+  }
+
+  toString(): string {
+    return new DefaultUrlSerializer().serialize(this);
+  }
+}
+
+export abstract class UrlSerializer {
+  abstract parse(url: string): UrlTree;
+  abstract serialize(tree: UrlTree): string;
+}
+
+export class DefaultUrlSerializer implements UrlSerializer {
+  parse(url: string): UrlTree {
+    let remaining = url.trim();
+    let fragment: string | null = null;
+    const fragIndex = remaining.indexOf("#");
+    if (fragIndex >= 0) {
+      fragment = decodeURIComponent(remaining.slice(fragIndex + 1));
+      remaining = remaining.slice(0, fragIndex);
+    }
+
+    const queryParams: Record<string, string> = {};
+    const queryIndex = remaining.indexOf("?");
+    if (queryIndex >= 0) {
+      const rawQuery = remaining.slice(queryIndex + 1);
+      remaining = remaining.slice(0, queryIndex);
+      if (rawQuery.length > 0) {
+        for (const pair of rawQuery.split("&")) {
+          if (!pair) continue;
+          const eq = pair.indexOf("=");
+          const rawKey = eq >= 0 ? pair.slice(0, eq) : pair;
+          const rawVal = eq >= 0 ? pair.slice(eq + 1) : "";
+          queryParams[decodeURIComponent(rawKey.replace(/\+/g, " "))] = decodeURIComponent(rawVal.replace(/\+/g, " "));
+        }
+      }
+    }
+
+    const rawSegments = remaining.split("/").filter((s) => s.length > 0);
+    const segments: UrlSegment[] = [];
+    for (const rawSeg of rawSegments) {
+      const matrixParts = rawSeg.split(";");
+      const path = decodeURIComponent(matrixParts[0]);
+      const parameters: Record<string, string> = {};
+      for (let i = 1; i < matrixParts.length; i++) {
+        const part = matrixParts[i];
+        if (!part) continue;
+        const eq = part.indexOf("=");
+        const pKey = eq >= 0 ? part.slice(0, eq) : part;
+        const pVal = eq >= 0 ? part.slice(eq + 1) : "";
+        parameters[decodeURIComponent(pKey)] = decodeURIComponent(pVal);
+      }
+      segments.push({ path, parameters });
+    }
+
+    const root = new UrlSegmentGroup(segments);
+    return new UrlTree(root, queryParams, fragment);
+  }
+
+  serialize(tree: UrlTree): string {
+    const segmentStrings: string[] = [];
+    for (const seg of tree.root.segments) {
+      let segStr = encodeURIComponent(seg.path);
+      const paramKeys = Object.keys(seg.parameters).sort();
+      for (const pk of paramKeys) {
+        segStr += `;${encodeURIComponent(pk)}=${encodeURIComponent(seg.parameters[pk])}`;
+      }
+      segmentStrings.push(segStr);
+    }
+
+    let path = "/" + segmentStrings.join("/");
+    if (segmentStrings.length === 0) {
+      path = "/";
+    }
+
+    const qKeys = Object.keys(tree.queryParams).sort();
+    if (qKeys.length > 0) {
+      const qParts = qKeys.map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(tree.queryParams[k])}`);
+      path += `?${qParts.join("&")}`;
+    }
+
+    if (tree.fragment !== null && tree.fragment !== undefined) {
+      path += `#${encodeURIComponent(tree.fragment)}`;
+    }
+
+    return path;
+  }
+}

--- a/packages/compiler/src/incremental.test.ts
+++ b/packages/compiler/src/incremental.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { appendFile, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createDependencyGraphCache, createIncrementalCompiler } from "./incremental";
+import { createDependencyGraphCache, createIncrementalCompiler, ModuleDependencyGraph } from "./incremental";
 import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
 import { writeFixtureProject } from "./fixtures/helpers";
+import type { ModuleNode } from "./types";
 
 describe("createIncrementalCompiler", () => {
   test("相同输入命中缓存，单文件修改计算受影响模块", async () => {
@@ -62,5 +63,62 @@ describe("createIncrementalCompiler", () => {
     expect(second.stats.reusedModules).toContain("case");
     // audit 模块对象从缓存原样复用，未重新扫描
     expect(cache.modules.get("audit")?.module).toBe(auditEntryBefore?.module);
+  });
+
+  test("ModuleDependencyGraph tracks forward imports, reverse dependents, and computes affected closures", () => {
+    const modules: ModuleNode[] = [
+      {
+        name: "core",
+        className: "CoreModule",
+        file: "src/core/core.module.ts",
+        line: 1,
+        imports: [],
+        providers: [{ token: "CoreService", tokenKind: "class", kind: "class", scope: "application", deps: [], file: "src/core/core.service.ts", line: 1, exported: true }],
+        controllers: [],
+        commands: [],
+        queries: [],
+        exports: ["CoreService"],
+      },
+      {
+        name: "auth",
+        className: "AuthModule",
+        file: "src/auth/auth.module.ts",
+        line: 1,
+        imports: ["core"],
+        providers: [{ token: "AuthService", tokenKind: "class", kind: "class", scope: "application", deps: ["CoreService"], file: "src/auth/auth.service.ts", line: 1, exported: true }],
+        controllers: [],
+        commands: [],
+        queries: [],
+        exports: ["AuthService"],
+      },
+      {
+        name: "dashboard",
+        className: "DashboardModule",
+        file: "src/dashboard/dashboard.module.ts",
+        line: 1,
+        imports: ["auth"],
+        providers: [],
+        controllers: [],
+        commands: [],
+        queries: [],
+        exports: [],
+      },
+    ];
+
+    const graph = new ModuleDependencyGraph(modules);
+    expect(graph.getDirectImports("auth")).toEqual(["core"]);
+    expect(graph.getDirectImports("dashboard")).toEqual(["auth"]);
+    expect(graph.getDirectDependents("core")).toEqual(["auth"]);
+    expect(graph.getDirectDependents("auth")).toEqual(["dashboard"]);
+
+    // Modifying core file affects core, auth (depends on core), and dashboard (depends on auth)
+    const affectedByCore = graph.getAffectedModules(["src/core/core.service.ts"]);
+    expect(affectedByCore).toContain("core");
+    expect(affectedByCore).toContain("auth");
+    expect(affectedByCore).toContain("dashboard");
+
+    // Modifying dashboard only affects dashboard
+    const affectedByDashboard = graph.getAffectedModules(["src/dashboard/dashboard.module.ts"]);
+    expect(affectedByDashboard).toEqual(["dashboard"]);
   });
 });

--- a/packages/compiler/src/incremental.ts
+++ b/packages/compiler/src/incremental.ts
@@ -79,6 +79,9 @@ export function createIncrementalCompiler(): IncrementalCompiler {
         : result.graph.modules.map((module) => module.name);
       const reusedModules = result.graph.cacheStats?.reusedModules ?? [];
       const reanalyzedModules = result.graph.cacheStats?.reanalyzedModules ?? affectedModules;
+      if (cache) {
+        cache.dependencyGraph = new ModuleDependencyGraph(result.graph.modules);
+      }
       const stats: CompileStats = {
         cacheHit: false,
         changedFiles,
@@ -95,6 +98,7 @@ export function createIncrementalCompiler(): IncrementalCompiler {
       previousResult = undefined;
       cache.modules.clear();
       cache.fileHashes.clear();
+      cache.dependencyGraph = undefined;
     },
     getCache(): DependencyGraphCache {
       return cache;
@@ -184,36 +188,107 @@ function diffFiles(previous: Record<string, string> | undefined, current: Record
   return [...names].filter((name) => previous[name] !== current[name]).sort();
 }
 
-function findAffectedModules(previous: ModuleNode[], current: ModuleNode[], changedFiles: string[]): string[] {
-  if (changedFiles.length === 0) return [];
-  const changedSet = new Set(changedFiles);
-  const matchesChanged = (path: string | undefined): boolean => {
-    if (!path) return false;
-    const normalized = path.replace(/\.(tsx?|mts|cts)$/, "");
-    return [...changedSet].some((file) => file.replace(/\.(tsx?|mts|cts)$/, "") === normalized);
-  };
-  const affected = new Set<string>();
-  const markIfOwned = (module: ModuleNode): void => {
-    const ownsChangedFile = [
-      module.file,
-      ...module.providers.map((provider) => provider.importPath),
-      ...module.controllers.map((controller) => controller.importPath),
-    ].some((path) => matchesChanged(path));
-    if (ownsChangedFile) affected.add(module.name);
-  };
-  for (const module of current) markIfOwned(module);
-  if (affected.size === 0) return current.map((module) => module.name);
+/**
+ * Angular Ivy-inspired module dependency graph.
+ * Tracks forward module imports, reverse dependent relationships, and file ownership
+ * to compute precise affected module subgraphs during incremental compilation.
+ */
+export class ModuleDependencyGraph {
+  private readonly imports = new Map<string, Set<string>>();
+  private readonly dependents = new Map<string, Set<string>>();
+  private readonly fileOwners = new Map<string, Set<string>>();
+  private readonly moduleMap = new Map<string, ModuleNode>();
 
-  const modules = new Map(current.map((module) => [module.name, module]));
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const module of modules.values()) {
-      if (module.imports.some((dependency) => affected.has(dependency)) && !affected.has(module.name)) {
-        affected.add(module.name);
-        changed = true;
+  constructor(modules: ModuleNode[] = []) {
+    this.rebuild(modules);
+  }
+
+  rebuild(modules: ModuleNode[]): void {
+    this.imports.clear();
+    this.dependents.clear();
+    this.fileOwners.clear();
+    this.moduleMap.clear();
+
+    for (const mod of modules) {
+      this.moduleMap.set(mod.name, mod);
+      this.imports.set(mod.name, new Set(mod.imports));
+      if (!this.dependents.has(mod.name)) {
+        this.dependents.set(mod.name, new Set());
+      }
+      this.indexFile(mod.file, mod.name);
+      for (const p of mod.providers) {
+        if (p.importPath) this.indexFile(p.importPath, mod.name);
+        if (p.file) this.indexFile(p.file, mod.name);
+      }
+      for (const c of mod.controllers) {
+        if (c.importPath) this.indexFile(c.importPath, mod.name);
+        if (c.file) this.indexFile(c.file, mod.name);
+      }
+    }
+
+    for (const [modName, imps] of this.imports.entries()) {
+      for (const imp of imps) {
+        if (!this.dependents.has(imp)) {
+          this.dependents.set(imp, new Set());
+        }
+        this.dependents.get(imp)!.add(modName);
       }
     }
   }
-  return current.filter((module) => affected.has(module.name)).map((module) => module.name);
+
+  private indexFile(path: string | undefined, moduleName: string): void {
+    if (!path) return;
+    const normalized = path.replace(/\.(tsx?|mts|cts)$/, "");
+    if (!this.fileOwners.has(normalized)) {
+      this.fileOwners.set(normalized, new Set());
+    }
+    this.fileOwners.get(normalized)!.add(moduleName);
+  }
+
+  getModulesOwningFile(filePath: string): string[] {
+    const normalized = filePath.replace(/\.(tsx?|mts|cts)$/, "");
+    return Array.from(this.fileOwners.get(normalized) ?? []);
+  }
+
+  getAffectedModules(changedFiles: string[]): string[] {
+    if (changedFiles.length === 0) return [];
+    const directlyAffected = new Set<string>();
+    for (const file of changedFiles) {
+      for (const modName of this.getModulesOwningFile(file)) {
+        directlyAffected.add(modName);
+      }
+    }
+    if (directlyAffected.size === 0) {
+      return Array.from(this.moduleMap.keys());
+    }
+
+    const affected = new Set(directlyAffected);
+    const queue = Array.from(directlyAffected);
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const dependents = this.dependents.get(current);
+      if (dependents) {
+        for (const dep of dependents) {
+          if (!affected.has(dep)) {
+            affected.add(dep);
+            queue.push(dep);
+          }
+        }
+      }
+    }
+    return Array.from(this.moduleMap.keys()).filter((name) => affected.has(name));
+  }
+
+  getDirectImports(moduleName: string): string[] {
+    return Array.from(this.imports.get(moduleName) ?? []);
+  }
+
+  getDirectDependents(moduleName: string): string[] {
+    return Array.from(this.dependents.get(moduleName) ?? []);
+  }
+}
+
+function findAffectedModules(previous: ModuleNode[], current: ModuleNode[], changedFiles: string[]): string[] {
+  const depGraph = new ModuleDependencyGraph(current);
+  return depGraph.getAffectedModules(changedFiles);
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -4,6 +4,7 @@ export { watchProject } from "./watch";
 export { doctorProject, explainGraph, formatGraph } from "./inspect";
 export { createIncrementalCompiler } from "./incremental";
 export { createDependencyGraphCache } from "./incremental";
+export { ModuleDependencyGraph } from "./incremental";
 export { generateApplication, renderApplication } from "./generate";
 export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -325,6 +325,8 @@ export interface DependencyGraphCache {
   fileHashes: Map<string, string>;
   /** Retained AST project for true incremental graph re-analysis. */
   project?: any;
+  /** Retained module dependency graph tracking imports and reverse dependents. */
+  dependencyGraph?: any;
   lastStats?: {
     reusedModules: string[];
     reanalyzedModules: string[];

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -1666,4 +1666,89 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(wildcardDiag?.docsUrl).toBe("https://supacloud.dev/errors/SC3012");
     expect(wildcardDiag?.message).toContain("trailing segment");
   });
+
+  test("detects self-referencing provider useExisting alias (SC2008)", () => {
+    const graphWithSelfAlias: ApplicationGraph = {
+      modules: [
+        {
+          name: "AuthModule",
+          className: "AuthModule",
+          file: "src/auth.module.ts",
+          line: 1,
+          imports: [],
+          providers: [
+            {
+              token: "AuthService",
+              tokenKind: "class",
+              kind: "existing",
+              useExisting: "AuthService",
+              scope: "application",
+              deps: [],
+              file: "src/auth.service.ts",
+              line: 10,
+              exported: false,
+            },
+          ],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(graphWithSelfAlias);
+    const selfAliasDiag = diags.find((d) => d.code === "self-referencing-alias");
+    expect(selfAliasDiag).toBeDefined();
+    expect(selfAliasDiag?.errorCode).toBe("SC2008");
+    expect(selfAliasDiag?.docsUrl).toBe("https://supacloud.dev/errors/SC2008");
+    expect(selfAliasDiag?.message).toContain("referencing itself");
+    expect(selfAliasDiag?.suggestion).toContain("different provider token");
+  });
+
+  test("detects invalid route query parameter names (SC3013)", () => {
+    const graphWithInvalidQuery: ApplicationGraph = {
+      modules: [
+        {
+          name: "SearchModule",
+          className: "SearchModule",
+          file: "src/search.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [
+            {
+              className: "SearchController",
+              path: "/search",
+              scope: "request",
+              deps: [],
+              routes: [
+                {
+                  method: "GET",
+                  path: "/query",
+                  handler: "search",
+                  queryBindings: ["validQuery", "invalid#param", " "],
+                },
+              ],
+              file: "src/search.controller.ts",
+              importPath: "./search.controller",
+            },
+          ],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(graphWithInvalidQuery);
+    const invalidQueryDiags = diags.filter((d) => d.code === "invalid-query-param-name");
+    expect(invalidQueryDiags.length).toBe(2);
+    expect(invalidQueryDiags[0].errorCode).toBe("SC3013");
+    expect(invalidQueryDiags[0].docsUrl).toBe("https://supacloud.dev/errors/SC3013");
+    expect(invalidQueryDiags.some((d) => d.message.includes("illegal character"))).toBe(true);
+    expect(invalidQueryDiags.some((d) => d.message.includes("empty @Query()"))).toBe(true);
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -35,6 +35,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "skip-self-dependency-violation": { code: "SC2005", docsUrl: "https://supacloud.dev/errors/SC2005" },
   "export-unprovided-token": { code: "SC2006", docsUrl: "https://supacloud.dev/errors/SC2006" },
   "unresolved-alias-target": { code: "SC2007", docsUrl: "https://supacloud.dev/errors/SC2007" },
+  "self-referencing-alias": { code: "SC2008", docsUrl: "https://supacloud.dev/errors/SC2008" },
   "shadowed-route": { code: "SC3001", docsUrl: "https://supacloud.dev/errors/SC3001" },
   "unresolved-route-redirect": { code: "SC3002", docsUrl: "https://supacloud.dev/errors/SC3002" },
   "circular-route-redirect": { code: "SC3003", docsUrl: "https://supacloud.dev/errors/SC3003" },
@@ -47,6 +48,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "malformed-route-path": { code: "SC3010", docsUrl: "https://supacloud.dev/errors/SC3010" },
   "duplicate-path-param": { code: "SC3011", docsUrl: "https://supacloud.dev/errors/SC3011" },
   "wildcard-not-trailing": { code: "SC3012", docsUrl: "https://supacloud.dev/errors/SC3012" },
+  "invalid-query-param-name": { code: "SC3013", docsUrl: "https://supacloud.dev/errors/SC3013" },
   "command-missing-permission": { code: "SC4001", docsUrl: "https://supacloud.dev/errors/SC4001" },
   "duplicate-command": { code: "SC4002", docsUrl: "https://supacloud.dev/errors/SC4002" },
   "route-command-unresolved": { code: "SC4003", docsUrl: "https://supacloud.dev/errors/SC4003" },
@@ -335,6 +337,28 @@ export function validateGraph(
                 `Add @Param('${param}') to ${route.handler} arguments.`,
               );
             }
+          }
+        }
+
+        // Angular Ivy-style query parameter static validation (SC3013)
+        const queryBindings = route.queryBindings ?? [];
+        for (const q of queryBindings) {
+          if (!q || q.trim().length === 0) {
+            error(
+              "invalid-query-param-name",
+              `Controller ${controller.className} handler ${route.handler} specifies an empty @Query() parameter binding.`,
+              controller.file,
+              undefined,
+              `Specify a non-empty parameter name in @Query('paramName').`,
+            );
+          } else if (/[#?&=/\s]/.test(q)) {
+            error(
+              "invalid-query-param-name",
+              `Controller ${controller.className} handler ${route.handler} specifies invalid @Query('${q}') with illegal character. Query parameter names cannot contain '#', '?', '&', '=', '/', or whitespace.`,
+              controller.file,
+              undefined,
+              `Rename query parameter '${q}' to a valid identifier name without reserved characters.`,
+            );
           }
         }
 
@@ -729,15 +753,25 @@ export function validateGraph(
     for (const provider of module.providers) {
       if (provider.useExisting) {
         const target = provider.useExisting;
-        const resolved = resolveDep(module, target);
-        if (!resolved && !graph.externalTokens.includes(target)) {
+        if (target === provider.token) {
           error(
-            "unresolved-alias-target",
-            `Module '${module.name}' defines provider '${provider.token}' with useExisting: '${target}', but '${target}' is neither provided in '${module.name}' nor imported from an imported module.`,
+            "self-referencing-alias",
+            `Module '${module.name}' defines provider '${provider.token}' with useExisting referencing itself.`,
             provider.file ?? module.file,
             provider.line ?? module.line,
-            `Add a provider for '${target}' to '${module.name}.providers' or an imported module, or update useExisting to reference an available token.`,
+            `Change useExisting to reference a different provider token, or remove the self-referencing alias.`,
           );
+        } else {
+          const resolved = resolveDep(module, target);
+          if (!resolved && !graph.externalTokens.includes(target)) {
+            error(
+              "unresolved-alias-target",
+              `Module '${module.name}' defines provider '${provider.token}' with useExisting: '${target}', but '${target}' is neither provided in '${module.name}' nor imported from an imported module.`,
+              provider.file ?? module.file,
+              provider.line ?? module.line,
+              `Add a provider for '${target}' to '${module.name}.providers' or an imported module, or update useExisting to reference an available token.`,
+            );
+          }
         }
       }
     }

--- a/packages/compiler/src/watch.test.ts
+++ b/packages/compiler/src/watch.test.ts
@@ -29,6 +29,7 @@ describe("watchProject", () => {
 
     const initial = await handle.ready;
     expect(initial.type).toBe("compiled");
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await appendFile(join(rootDir, "src/features/health/health.module.ts"), "\n", "utf8");
 
     await new Promise<void>((resolvePromise, rejectPromise) => {


### PR DESCRIPTION
### Summary of Changes

1. **Angular-inspired Functional HTTP Client & Context (`@supacloud/app`)**:
   - `HttpParams`: Immutable query parameter collection with `get`, `getAll`, `has`, `set`, `append`, `delete`, and URI encoding.
   - `HttpHeaders`: Case-insensitive immutable header collection with `get`, `getAll`, `has`, `set`, `append`, `delete`, and `toObject`.
   - `HttpContext` & `HttpContextToken`: Strongly-typed request metadata passing through functional interceptors.
   - `HttpClient` & `provideHttpClient`: Angular 15+ standalone HTTP Client supporting functional interceptor pipelines, `withFetch`, `withInterceptors`, typed verbs (`get`, `post`, `put`, `delete`, `patch`, `request`), and `HttpErrorResponse`.

2. **Angular Router UrlTree & UrlSerializer (`@supacloud/app`)**:
   - `UrlTree`, `UrlSegmentGroup`, and `UrlSegment` structured URL representation.
   - `UrlSerializer` and `DefaultUrlSerializer` supporting path segments, matrix parameters, query parameters, and fragments.

3. **Heavy-Compilation Static Analysis & Ivy Diagnostics (`@supacloud/compiler`)**:
   - `SC2008` (`self-referencing-alias`): Static detection of `useExisting` provider referencing itself, preventing runtime infinite recursion loops.
   - `SC3013` (`invalid-query-param-name`): Static validation of `@Query()` parameter bindings preventing empty names or illegal query delimiter characters (`#`, `?`, `&`, `=`, `/`, whitespace).

4. **Module Dependency Graph & Incremental Compilation (`@supacloud/compiler`)**:
   - Implemented `ModuleDependencyGraph` tracking forward module imports, reverse dependent relationships, and file-to-module mappings to compute precise affected module subgraphs.