### PR TITLE
docs(cli): document Bun execution path

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -138,6 +138,14 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` es por defecto específico del proyecto y se vincula automáticamente desde el `.env` del espacio de trabajo actual cuando está disponible.
 No existe un alias de compatibilidad de CLI de proyecto llamado `supacloud`: ese nombre está reservado para el binario del servidor compilado en `/usr/local/bin/supacloud`. Usa `supacloudctl` solo para el despachador local unificado opcional.
 
+La entrada al estilo npm usa Node.js de forma predeterminada. Los usuarios de
+Bun pueden ejecutar el paquete explícitamente con Bun, también desde terminales
+de Windows, sin instalar Node.js ni un wrapper independiente:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` o `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` o `SUPACLOUD_API_TOKEN`
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ supacloud-cli frontend list_releases --ref <project-ref> --id <deployment-id>
 `supacloud-cli` defaults to project context and auto-links from the current workspace `.env` when available.
 There is no project-CLI compatibility alias named `supacloud`: that name is reserved for the compiled server binary at `/usr/local/bin/supacloud`. Use `supacloudctl` only for the optional local unified dispatcher.
 
+The npm-style entry uses Node.js by default. Bun users can run the package
+explicitly with Bun, including from Windows terminals, without installing
+Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` or `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` or `SUPACLOUD_API_TOKEN`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,13 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` 默认是项目级 CLI，会优先从当前目录 `.env` 自动绑定项目。
 项目 CLI 不再提供名为 `supacloud` 的兼容别名：该名称只保留给 `/usr/local/bin/supacloud` 服务端二进制。本地统一分发入口必须明确使用 `supacloudctl`。
 
+npm 风格入口默认使用 Node.js。Bun 用户可以显式指定 Bun 运行同一个包，
+包括在 Windows 终端中使用；不需要安装 Node.js，也不需要额外的包装器：
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` 或 `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` 或 `SUPACLOUD_API_TOKEN`
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -200,6 +200,12 @@ One-off execution without global install:
 npm exec --package @supacloud/cli -- supacloud-cli status
 ```
 
+Bun users can force the same package to run with Bun, including on Windows:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 ### Application framework commands
 
 Local commands for the application framework (`@supacloud/app` +

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,13 @@ npm install -g @supacloud/cli
 supacloud-cli status
 ```
 
+Bun users can run the same package explicitly with Bun, including on Windows,
+without installing Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 One-off execution:
 
 ```bash

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -162,6 +162,24 @@ describe("supacloud-cli process contract", () => {
         expect(build.exitCode).toBe(0);
         const builtEntry = join(buildDirectory, "index.js");
         expect(readFileSync(builtEntry, "utf8").split("\n", 1)[0]).toBe("#!/usr/bin/env node");
+
+        const bunPath = join(sandbox, "bun-bin");
+        mkdirSync(bunPath);
+        const bunProcess = Bun.spawn([process.execPath, builtEntry, "--version"], {
+            cwd: PACKAGE_ROOT,
+            env: cleanEnvironment({ PATH: bunPath }),
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const [bunExitCode, bunStdout, bunStderr] = await Promise.all([
+            bunProcess.exited,
+            new Response(bunProcess.stdout).text(),
+            new Response(bunProcess.stderr).text(),
+        ]);
+        expect(bunExitCode).toBe(0);
+        expect(bunStdout.trim()).toBe(packageMetadata.version);
+        expect(bunStderr).toBe("");
+
         const binDirectory = join(sandbox, "node_modules/.bin");
         mkdirSync(binDirectory, { recursive: true });
         const linkedEntry = join(binDirectory, "supacloud-cli");


### PR DESCRIPTION
## Summary
- document the explicit Bun execution path for @supacloud/cli on Unix and Windows
- keep the Node shebang as the default npm-compatible entry
- test Bun execution of the Node-target bundle without node on PATH

## Validation
- bun test src (991 pass, 0 fail)
- bun run typecheck
- bun run build
- dependency audit
- git diff --check