### PR TITLE
feat(compiler): enforce generated type safety

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -138,6 +138,14 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` es por defecto específico del proyecto y se vincula automáticamente desde el `.env` del espacio de trabajo actual cuando está disponible.
 No existe un alias de compatibilidad de CLI de proyecto llamado `supacloud`: ese nombre está reservado para el binario del servidor compilado en `/usr/local/bin/supacloud`. Usa `supacloudctl` solo para el despachador local unificado opcional.
 
+La entrada al estilo npm usa Node.js de forma predeterminada. Los usuarios de
+Bun pueden ejecutar el paquete explícitamente con Bun, también desde terminales
+de Windows, sin instalar Node.js ni un wrapper independiente:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` o `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` o `SUPACLOUD_API_TOKEN`
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ supacloud-cli frontend list_releases --ref <project-ref> --id <deployment-id>
 `supacloud-cli` defaults to project context and auto-links from the current workspace `.env` when available.
 There is no project-CLI compatibility alias named `supacloud`: that name is reserved for the compiled server binary at `/usr/local/bin/supacloud`. Use `supacloudctl` only for the optional local unified dispatcher.
 
+The npm-style entry uses Node.js by default. Bun users can run the package
+explicitly with Bun, including from Windows terminals, without installing
+Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` or `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` or `SUPACLOUD_API_TOKEN`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,13 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` 默认是项目级 CLI，会优先从当前目录 `.env` 自动绑定项目。
 项目 CLI 不再提供名为 `supacloud` 的兼容别名：该名称只保留给 `/usr/local/bin/supacloud` 服务端二进制。本地统一分发入口必须明确使用 `supacloudctl`。
 
+npm 风格入口默认使用 Node.js。Bun 用户可以显式指定 Bun 运行同一个包，
+包括在 Windows 终端中使用；不需要安装 Node.js，也不需要额外的包装器：
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` 或 `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` 或 `SUPACLOUD_API_TOKEN`
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -200,6 +200,12 @@ One-off execution without global install:
 npm exec --package @supacloud/cli -- supacloud-cli status
 ```
 
+Bun users can force the same package to run with Bun, including on Windows:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 ### Application framework commands
 
 Local commands for the application framework (`@supacloud/app` +

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,13 @@ npm install -g @supacloud/cli
 supacloud-cli status
 ```
 
+Bun users can run the same package explicitly with Bun, including on Windows,
+without installing Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 One-off execution:
 
 ```bash

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -162,6 +162,24 @@ describe("supacloud-cli process contract", () => {
         expect(build.exitCode).toBe(0);
         const builtEntry = join(buildDirectory, "index.js");
         expect(readFileSync(builtEntry, "utf8").split("\n", 1)[0]).toBe("#!/usr/bin/env node");
+
+        const bunPath = join(sandbox, "bun-bin");
+        mkdirSync(bunPath);
+        const bunProcess = Bun.spawn([process.execPath, builtEntry, "--version"], {
+            cwd: PACKAGE_ROOT,
+            env: cleanEnvironment({ PATH: bunPath }),
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const [bunExitCode, bunStdout, bunStderr] = await Promise.all([
+            bunProcess.exited,
+            new Response(bunProcess.stdout).text(),
+            new Response(bunProcess.stderr).text(),
+        ]);
+        expect(bunExitCode).toBe(0);
+        expect(bunStdout.trim()).toBe(packageMetadata.version);
+        expect(bunStderr).toBe("");
+
         const binDirectory = join(sandbox, "node_modules/.bin");
         mkdirSync(binDirectory, { recursive: true });
         const linkedEntry = join(binDirectory, "supacloud-cli");

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -20,7 +20,12 @@ const result = await compileProject({
   rootDir: "/path/to/app",            // 项目根（含 tsconfig）
   include: ["**/*.ts"],               // 可选，默认 ['**/*.module.ts', '**/*.ts']
   outDir: "/path/to/app/generated",   // 生成目录
-  strict: false,                      // true 时 warn 级诊断升级为 error
+  strict: true,                       // 同时启用类型安全门，并将 warn 升级为 error
+  typeSafety: {
+    noAnyInGenerated: true,           // 生成的 TS 产物禁止 any
+    scanProductionSource: true,       // 扫描生产源码的 any/断言/隐式宽化
+    exclude: ["src/legacy/**"],       // 额外排除的相对 glob
+  },
 });
 result.diagnostics; // Diagnostic[]
 result.graph;       // ApplicationGraph
@@ -62,6 +67,7 @@ interface ApplicationGraph {
 - 含 request 级 provider/controller 的模块额外生成 `create<Name>RequestScope(services, ctx)`：依赖 `REQUEST_CONTEXT`（或 token name `supacloud.request-context`）的参数传 `ctx`，其余经 `services` 解析（运行期负责把 imports 模块导出的 application 服务合并进 `services`）；job 级同理生成 `create<Name>JobScope`。
 - services 对象的 key 为 token 名的 camelCase：`CaseService → caseService`、`CASE_REPOSITORY → caseRepository`、`LOGGER → logger`。
 - controller 描述静态给出：`{ path, serviceKey, scope, routes: [{ method, path, handler, body?, params?, query?, response? }] }`，schema 直接引用 import 进来的对象。
+- 严格生成模式会对 `application.ts`、可选的 `client.ts` 和 `permissions.ts` 做 AST 扫描，禁止生成 `any`。
 
 `<outDir>/app.manifest.json`：`{ version: 1, modules, externalTokens }`，供 CLI graph/explain 使用。
 
@@ -80,8 +86,23 @@ interface ApplicationGraph {
 | `route-command-unresolved` | error | 路由绑定了本模块未声明的 command 类 |
 | `command-missing-permission` | error | `@Command` 未声明 permission |
 | `missing-deps` | warn（strict 时 error） | 构造/工厂依赖无法静态解析 |
+| `generated-any` | warn（strict 时 error） | 生成的 TypeScript 产物包含 `any` |
+| `source-any` | warn（strict 时 error） | 未被排除的生产源码包含显式 `any` |
+| `source-type-assertion` | warn（strict 时 error） | 生产源码使用 `as T` 或 `<T>value` 类型断言 |
+| `source-non-null-assertion` | warn（strict 时 error） | 生产源码使用非空断言 `value!` |
+| `source-implicit-widening` | warn（strict 时 error） | 可静态判定的字面量类型隐式宽化 |
 
 依赖的 token 全图都无 provider 时不报错，记入 `externalTokens`（平台注入）。
+
+## 类型安全扫描
+
+`strict: true` 默认开启两道类型安全门；也可以单独配置 `typeSafety`。生产源码扫描默认排除测试、fixture、声明文件、`generated` 和 `dist`，并支持 `typeSafety.exclude` 增加项目自定义排除规则。
+
+```bash
+supacloud-compiler check --root ./app --out ./app/generated --strict
+```
+
+程序化调用可直接使用 `scanGeneratedArtifacts()` 和 `scanProductionSource()` 获取结构化诊断。
 
 ## 开发模式
 

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -262,7 +262,7 @@ describe("analyzeProject：command 与 externalTokens", () => {
 
         @Injectable()
         export class FirstService {
-          constructor(@Inject(forwardRef(() => SecondService)) private second: any) {}
+          constructor(@Inject(forwardRef(() => SecondService)) private second: unknown) {}
         }
 
         @Injectable()
@@ -410,8 +410,8 @@ describe("analyzeProject：command 与 externalTokens", () => {
       "src/resolver.controller.ts": `
         import { Controller, Get, Resolve } from "@supacloud/app";
 
-        const UserResolver = (ctx: any) => ({ id: ctx.userId });
-        const OrgResolver = (ctx: any) => ({ id: ctx.orgId });
+        const UserResolver = (ctx: { userId: string }) => ({ id: ctx.userId });
+        const OrgResolver = (ctx: { orgId: string }) => ({ id: ctx.orgId });
 
         @Controller({ path: "/accounts", standalone: true })
         export class AccountsController {

--- a/packages/compiler/src/cli.ts
+++ b/packages/compiler/src/cli.ts
@@ -29,7 +29,7 @@ Commands:
 Options:
   --root, -r <dir>    Application source root (default: current directory or first positional argument)
   --out, -o <dir>     Artifact output directory (default: <rootDir>/generated)
-  --strict            Treat all warnings as errors
+  --strict            Enable type-safety gates and treat all warnings as errors
   --client            Generate typed API client in client.ts
   --permissions       Generate typed permissions registry in permissions.ts
   --debounce <ms>     Debounce source changes in dev mode (default: 100)

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -4,6 +4,7 @@ import type { CheckProjectResult, CompileOptions, CompileResult, Diagnostic } fr
 import { validateGraph } from "./validate";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
 
 /**
  * Complete compilation pipeline: AST analysis -> validation -> generate static factory code and manifest.
@@ -27,6 +28,30 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
     for (const diagnostic of diagnostics) {
       if (diagnostic.severity === "warn") diagnostic.severity = "error";
     }
+  }
+  const typeSafety = resolveTypeSafety(options);
+  const rendered = renderApplication(graph, {
+    rootDir: options.rootDir,
+    outDir: options.outDir,
+    generateClient: options.generateClient,
+    generatePermissions: options.generatePermissions,
+    treeShakeUnusedProviders: options.treeShakeUnusedProviders,
+  });
+  if (typeSafety.scanProductionSource) {
+    diagnostics.push(...scanProductionSource({
+      rootDir: options.rootDir,
+      include: options.include,
+      outDir: options.outDir,
+      strict: options.strict,
+      ...typeSafety,
+    }));
+  }
+  if (typeSafety.noAnyInGenerated) {
+    diagnostics.push(...scanGeneratedArtifacts({
+      "application.ts": rendered.applicationCode,
+      "client.ts": rendered.clientCode,
+      "permissions.ts": rendered.permissionsCode,
+    }, options.strict ?? false));
   }
   const hasErrors = diagnostics.some((diagnostic) => diagnostic.severity === "error");
   const written = !hasErrors || options.writeOnError !== false
@@ -74,6 +99,7 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     }
   }
 
+  const typeSafety = resolveTypeSafety(options);
   const rendered = renderApplication(graph, {
     rootDir: options.rootDir,
     outDir: options.outDir,
@@ -81,6 +107,22 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     generatePermissions: options.generatePermissions,
     treeShakeUnusedProviders: options.treeShakeUnusedProviders,
   });
+  if (typeSafety.scanProductionSource) {
+    diagnostics.push(...scanProductionSource({
+      rootDir: options.rootDir,
+      include: options.include,
+      outDir: options.outDir,
+      strict: options.strict,
+      ...typeSafety,
+    }));
+  }
+  if (typeSafety.noAnyInGenerated) {
+    diagnostics.push(...scanGeneratedArtifacts({
+      "application.ts": rendered.applicationCode,
+      "client.ts": rendered.clientCode,
+      "permissions.ts": rendered.permissionsCode,
+    }, options.strict ?? false));
+  }
 
   const expectedFiles: Record<string, string> = {
     "application.ts": rendered.applicationCode,
@@ -111,5 +153,13 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     mismatches,
     diagnostics,
     graph,
+  };
+}
+
+function resolveTypeSafety(options: CompileOptions): NonNullable<CompileOptions["typeSafety"]> {
+  return {
+    noAnyInGenerated: options.typeSafety?.noAnyInGenerated ?? options.strict ?? false,
+    scanProductionSource: options.typeSafety?.scanProductionSource ?? options.strict ?? false,
+    exclude: options.typeSafety?.exclude,
   };
 }

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -8,6 +8,7 @@ import { renderApplication } from "./generate";
 import { BAD_PROJECT_FILES } from "./fixtures/bad-project";
 import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
 import { writeFixtureProject } from "./fixtures/helpers";
+import { scanGeneratedArtifacts } from "./type-safety";
 import type { ApplicationGraph, CompileResult } from "./types";
 
 let rootDir: string;
@@ -30,6 +31,10 @@ describe("compileProject：总体结果", () => {
       join(outDir, "application.ts"),
       join(outDir, "app.manifest.json"),
     ]);
+  });
+
+  test("严格生成产物不包含 any", () => {
+    expect(scanGeneratedArtifacts({ "application.ts": applicationCode })).toEqual([]);
   });
 
   test("app.manifest.json 是 graph 的 JSON 序列化", async () => {
@@ -111,14 +116,41 @@ describe("generate：application.ts 关键内容", () => {
     expect(applicationCode).toContain('serviceKey: "caseController"');
     expect(applicationCode).toContain('path: "/cases"');
     expect(applicationCode).toContain(
-      '{ method: "POST", path: "/:caseId/accept", handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult, command: "AcceptCaseCommand", invoker: async (ctrl: any, req: any) => await (ctrl as any).accept(req) }',
+      'handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult, command: "AcceptCaseCommand", invoker: async (ctrl: unknown',
     );
   });
 });
 
 describe("generate：application.ts 可被 bun 直接执行", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let compiled: any;
+  type RuntimeServices = {
+    auditConfig: { level: string };
+    logger: { level: string };
+    auditService: { config: unknown; logger: unknown };
+    caseRepository: { db: unknown };
+    caseService: { repository: unknown; audit: unknown };
+    acceptCaseCommand: { caseService: unknown };
+    healthService: { status: () => string };
+    caseController: { ctx: unknown; repository: unknown; audit: unknown };
+  };
+  type RuntimeModule = {
+    name: string;
+    commands: Array<{ className: string; name: string; permission: string }>;
+    controllers: Array<{
+      path: string;
+      serviceKey: string;
+      scope: string;
+      routes: Array<{ body?: unknown; params?: unknown; response?: unknown }>;
+    }>;
+    createServices: (deps: Record<string, unknown>, imported: Record<string, Partial<RuntimeServices>>) => RuntimeServices;
+    createRequestScope?: (
+      services: RuntimeServices,
+      ctx: unknown,
+      imported?: Record<string, Partial<RuntimeServices>>,
+    ) => RuntimeServices;
+  };
+  let compiled: {
+    createCompiledModules: () => RuntimeModule[];
+  };
 
   beforeAll(async () => {
     const url = pathToFileURL(join(outDir, "application.ts")).href;
@@ -173,8 +205,10 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
     const ctx1 = { requestId: "r1" };
     const ctx2 = { requestId: "r2" };
     const imported = { audit: modules[0].createServices(deps, {}) };
-    const scope1 = caseModule.createRequestScope(services, ctx1, imported);
-    const scope2 = caseModule.createRequestScope(services, ctx2, imported);
+    const createRequestScope = caseModule.createRequestScope;
+    if (!createRequestScope) throw new Error("request scope factory is missing");
+    const scope1 = createRequestScope(services, ctx1, imported);
+    const scope2 = createRequestScope(services, ctx2, imported);
 
     expect(scope1.caseController.ctx).toBe(ctx1);
     expect(scope1.caseController.repository).toBe(services.caseRepository);
@@ -587,7 +621,7 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
     );
 
     expect(rendered.applicationCode).toContain('canDeactivate: ["UnsavedGuard"]');
-    expect(rendered.applicationCode).toContain('const apiUrl = typeof API_URL === "object" && API_URL && "factory" in API_URL');
+    expect(rendered.applicationCode).toContain("const apiUrl = resolveFactoryValue(API_URL);");
     expect(rendered.clientCode).toContain('"canDeactivate": [\n      "UnsavedGuard"\n    ]');
   });
 
@@ -762,7 +796,9 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
       rootDir: "/app",
       outDir: "/app/gen",
     });
-    expect(rendered.applicationCode).toContain("invoker: async (ctrl: any, req: any) => await (ctrl as any).getUser(");
+    expect(rendered.applicationCode).toContain("invoker: async (ctrl: unknown, req:");
+    expect(rendered.applicationCode).toContain('const handler = ctrl["getUser"];');
+    expect(rendered.applicationCode).toContain("Reflect.apply(handler, ctrl");
     expect(rendered.applicationCode).toContain('Number(req.params?.["id"])');
     expect(rendered.applicationCode).toContain('Number(req.query?.["limit"])');
     expect(rendered.applicationCode).toContain(": 20");

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -87,6 +87,19 @@ export interface CompiledModule {
   commands: CompiledCommand[];
 }`;
 
+const TYPE_GUARDS = `function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+  return typeof value === "function";
+}
+
+function resolveFactoryValue(value: unknown): unknown {
+  if (!isRecord(value) || !isFunction(value.factory)) return undefined;
+  return value.factory();
+}`;
+
 export interface GenerateOptions {
   rootDir: string;
   outDir: string;
@@ -149,6 +162,8 @@ export function renderApplication(
     ...(imports.size > 0 ? [""] : []),
     INTERFACES,
     "",
+    TYPE_GUARDS,
+    "",
     "export function createCompiledModules(): CompiledModule[] {",
     "  return [",
     ...descriptorEntries.map((entry) => indent(entry, 4) + ","),
@@ -156,29 +171,29 @@ export function renderApplication(
     "}",
     "",
     "export async function initializeApplication(services: Record<string, unknown>): Promise<void> {",
-    '  const initializers = (services.appInitializer ?? (services as any)["supacloud.app-initializer"]) as unknown;',
+    '  const initializers = services.appInitializer ?? services["supacloud.app-initializer"];',
     "  if (Array.isArray(initializers)) {",
     "    for (const init of initializers) {",
     '      if (typeof init === "function") await init();',
     "    }",
-    '  } else if (typeof initializers === "function") {',
-    "    await (initializers as () => unknown)();",
+    '  } else if (isFunction(initializers)) {',
+    "    await initializers();",
     "  }",
     "}",
     "",
     "export async function destroyApplication(services: Record<string, unknown>): Promise<void> {",
-    '  const destroyRef = (services.destroyRef ?? (services as any)["supacloud.destroy-ref"]) as { destroy?: () => Promise<void>; _teardowns?: Array<() => void | Promise<void>> } | undefined;',
-    '  if (destroyRef && typeof destroyRef.destroy === "function") {',
+    '  const destroyRef = services.destroyRef ?? services["supacloud.destroy-ref"];',
+    '  if (isRecord(destroyRef) && isFunction(destroyRef.destroy)) {',
     "    await destroyRef.destroy();",
-    "  } else if (destroyRef && Array.isArray(destroyRef._teardowns)) {",
+    "  } else if (isRecord(destroyRef) && Array.isArray(destroyRef._teardowns)) {",
     "    for (const teardown of [...destroyRef._teardowns].reverse()) {",
-    '      if (typeof teardown === "function") await teardown();',
+    "      if (isFunction(teardown)) await teardown();",
     "    }",
     "  }",
     "  const instances = Object.values(services);",
     "  for (const inst of instances.reverse()) {",
-    '    if (inst && typeof (inst as any).onDestroy === "function") {',
-    "      await (inst as any).onDestroy();",
+    '    if (isRecord(inst) && isFunction(inst.onDestroy)) {',
+    "      await inst.onDestroy();",
     "    }",
     "  }",
     "}",
@@ -472,7 +487,13 @@ class ModuleGenerator {
           return "undefined";
         });
         const callArgs = invokerArgs.length > 0 ? invokerArgs.join(", ") : "req";
-        fields.push(`invoker: async (ctrl: any, req: any) => await (ctrl as any).${route.handler}(${callArgs})`);
+        fields.push(
+          `invoker: async (ctrl: unknown, req: { params?: Record<string, unknown>; query?: Record<string, unknown>; body?: unknown; headers?: Record<string, unknown>; context?: unknown }) => { ` +
+          `if (!isRecord(ctrl)) throw new TypeError("Route controller is not an object"); ` +
+          `const handler = ctrl[${JSON.stringify(route.handler)}]; ` +
+          `if (typeof handler !== "function") throw new TypeError("Route handler ${route.handler} is not callable"); ` +
+          `return await Reflect.apply(handler, ctrl, [${callArgs}]); }`,
+        );
         return `{ ${fields.join(", ")} }`;
       });
       return [
@@ -578,7 +599,7 @@ class ModuleGenerator {
         if (provider.tokenKind === "injection-token" && !provider.useFactoryName) {
           const tokenIdent = this.imports.add(provider.token, provider.importPath);
           const local = this.localVar(isMulti ? `${provider.token}Item` : provider.token, kind);
-          const constLine = `const ${local} = typeof ${tokenIdent} === "object" && ${tokenIdent} && "factory" in ${tokenIdent} && typeof (${tokenIdent} as any).factory === "function" ? (${tokenIdent} as any).factory() : undefined;`;
+          const constLine = `const ${local} = resolveFactoryValue(${tokenIdent});`;
           return { constLine, key, expr: local };
         }
         const factory = this.imports.add(provider.useFactoryName ?? "", provider.importPath);

--- a/packages/compiler/src/incremental.ts
+++ b/packages/compiler/src/incremental.ts
@@ -153,6 +153,7 @@ function optionsKeyOf(options: CompileOptions): string {
     detectOrphanModules: options.detectOrphanModules,
     generateClient: options.generateClient,
     generatePermissions: options.generatePermissions,
+    typeSafety: options.typeSafety,
   });
 }
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -10,6 +10,7 @@ export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";
 export { validateGraph, COMPILER_DIAGNOSTIC_CODES } from "./validate";
 export { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
+export type { TypeSafetyScanOptions } from "./type-safety";
 export { camelName } from "./util";
 export {
   ANGULAR_ENTERPRISE_RULES,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -9,6 +9,7 @@ export { generateApplication, renderApplication } from "./generate";
 export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";
 export { validateGraph, COMPILER_DIAGNOSTIC_CODES } from "./validate";
+export { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
 export { camelName } from "./util";
 export {
   ANGULAR_ENTERPRISE_RULES,
@@ -30,6 +31,7 @@ export type {
   CompileStats,
   ControllerNode,
   DependencyGraphCache,
+  DependencyGraphIndex,
   Diagnostic,
   ModuleBoundaryPresetName,
   ModuleBoundaryProfile,
@@ -41,6 +43,7 @@ export type {
   RouteNode,
   Scope,
   TokenKind,
+  TypeSafetyOptions,
   ValidateOptions,
   WatchEvent,
   WatchHandle,

--- a/packages/compiler/src/profiles.test.ts
+++ b/packages/compiler/src/profiles.test.ts
@@ -42,7 +42,7 @@ describe("Architecture governance presets (profiles.ts)", () => {
   });
 
   test("getModuleBoundaryProfile rejects unknown presets with a useful error", () => {
-    expect(() => getModuleBoundaryProfile("unknown-preset" as any)).toThrow(
+    expect(() => getModuleBoundaryProfile("unknown-preset" as never)).toThrow(
       "Unknown module boundary preset: 'unknown-preset'",
     );
   });

--- a/packages/compiler/src/type-safety.test.ts
+++ b/packages/compiler/src/type-safety.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
+import { writeFixtureProject } from "./fixtures/helpers";
+
+describe("compiler type-safety gates", () => {
+  test("strict generated-artifact scan rejects any", () => {
+    const diagnostics = scanGeneratedArtifacts({
+      "application.ts": "export function create(value: any): unknown { return value; }\n",
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      severity: "error",
+      code: "generated-any",
+      errorCode: "SC6001",
+      file: "application.ts",
+      line: 1,
+    });
+  });
+
+  test("production scan reports any, assertions, non-null assertions and widening", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+      "src/production.ts": [
+        "export const unsafe: any = 1;",
+        "export const asserted = unsafe as number;",
+        "export const required = unsafe!;",
+        "export let widened = 'mutable';",
+      ].join("\n"),
+      "src/ignored.test.ts": "export const ignored: any = 1;",
+      "src/ignored.ts": "export const ignored: any = 1;",
+    });
+
+    const diagnostics = scanProductionSource({
+      rootDir,
+      exclude: ["src/ignored.ts"],
+      strict: true,
+    });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "source-any",
+      "source-type-assertion",
+      "source-non-null-assertion",
+      "source-implicit-widening",
+    ]);
+    expect(diagnostics.every((diagnostic) => diagnostic.severity === "error")).toBe(true);
+    expect(diagnostics.every((diagnostic) => diagnostic.file === "src/production.ts")).toBe(true);
+  });
+
+  test("as const and excluded test files are accepted", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+      "src/production.ts": [
+        'export const stable = { mode: "strict" } as const;',
+        "export const typed: { mode: string } = { mode: 'strict' };",
+      ].join("\n"),
+      "src/production.test.ts": "export const ignored: any = 1;",
+    });
+
+    expect(scanProductionSource({ rootDir, strict: true })).toEqual([]);
+  });
+});

--- a/packages/compiler/src/type-safety.test.ts
+++ b/packages/compiler/src/type-safety.test.ts
@@ -44,6 +44,7 @@ describe("compiler type-safety gates", () => {
       "source-any",
       "source-type-assertion",
       "source-non-null-assertion",
+      "source-any",
       "source-implicit-widening",
     ]);
     expect(diagnostics.every((diagnostic) => diagnostic.severity === "error")).toBe(true);

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -135,6 +135,17 @@ function scanSourceFile(
     if (!initializer || declaration.getTypeNode()) continue;
     const declarationType = declaration.getType();
     const initializerType = initializer.getType();
+    if (declarationType.isAny()) {
+      diagnostics.push(makeDiagnostic(
+        "source-any",
+        "生产源码中的变量被推断为 any；请为边界数据提供解析类型或显式 unknown。",
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+      continue;
+    }
     if (declaration.getVariableStatement()?.getDeclarationKind() === "let"
       && isLiteralSyntax(initializer)
       && !declarationType.isLiteral()) {
@@ -160,6 +171,19 @@ function scanSourceFile(
         `常量对象 ${declaration.getName()} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
         sourceFile,
         declaration,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+
+  for (const parameter of sourceFile.getDescendantsOfKind(SyntaxKind.Parameter)) {
+    if (!parameter.getTypeNode() && parameter.getType().isAny()) {
+      diagnostics.push(makeDiagnostic(
+        "source-any",
+        "生产源码中的参数被推断为 any；请补充参数类型。",
+        sourceFile,
+        parameter,
         strict,
         rootDir,
       ));

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -97,6 +97,7 @@ function scanSourceFile(
 
   for (const node of sourceFile.getDescendants()) {
     if (Node.isAsExpression(node)) {
+      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
       const assertedType = node.getTypeNode()?.getText();
       if (assertedType === "const") continue;
       diagnostics.push(makeDiagnostic(
@@ -108,6 +109,7 @@ function scanSourceFile(
         rootDir,
       ));
     } else if (Node.isTypeAssertion(node)) {
+      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
       diagnostics.push(makeDiagnostic(
         "source-type-assertion",
         `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
@@ -163,6 +165,7 @@ function scanSourceFile(
       ));
     }
   }
+
 }
 
 function isProductionSource(

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -1,0 +1,236 @@
+import { Node, Project, SyntaxKind, type SourceFile } from "ts-morph";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { relative, sep } from "node:path";
+import type { Diagnostic, TypeSafetyOptions } from "./types";
+
+const DEFAULT_EXCLUDES = [
+  "**/*.test.ts",
+  "**/*.spec.ts",
+  "**/__tests__/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/dist/**",
+  "**/*.d.ts",
+];
+
+const DIAGNOSTIC_META = {
+  "generated-any": { errorCode: "SC6001", docsUrl: "https://supacloud.dev/errors/SC6001" },
+  "source-any": { errorCode: "SC6002", docsUrl: "https://supacloud.dev/errors/SC6002" },
+  "source-type-assertion": { errorCode: "SC6003", docsUrl: "https://supacloud.dev/errors/SC6003" },
+  "source-non-null-assertion": { errorCode: "SC6004", docsUrl: "https://supacloud.dev/errors/SC6004" },
+  "source-implicit-widening": { errorCode: "SC6005", docsUrl: "https://supacloud.dev/errors/SC6005" },
+} as const;
+
+export interface TypeSafetyScanOptions extends TypeSafetyOptions {
+  rootDir: string;
+  include?: string[];
+  outDir?: string;
+  strict?: boolean;
+}
+
+export function scanGeneratedArtifacts(
+  artifacts: Record<string, string | undefined>,
+  strict = true,
+): Diagnostic[] {
+  const project = new Project({ useInMemoryFileSystem: true });
+  const diagnostics: Diagnostic[] = [];
+  for (const [file, content] of Object.entries(artifacts)) {
+    if (content === undefined) continue;
+    const sourceFile = project.createSourceFile(file, content, { overwrite: true });
+    for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+      diagnostics.push(makeDiagnostic(
+        "generated-any",
+        `生成产物 ${file} 包含 any；严格生成模式要求使用 unknown、具体接口或泛型约束。`,
+        file,
+        node,
+        strict,
+      ));
+    }
+  }
+  return diagnostics;
+}
+
+export function scanProductionSource(options: TypeSafetyScanOptions): Diagnostic[] {
+  const project = new Project({
+    ...(existsSync(join(options.rootDir, "tsconfig.json"))
+      ? { tsConfigFilePath: join(options.rootDir, "tsconfig.json") }
+      : {
+          compilerOptions: {
+            strict: true,
+            skipLibCheck: true,
+          },
+        }),
+    skipAddingFilesFromTsConfig: true,
+  });
+  const include = options.include ?? ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
+  project.addSourceFilesAtPaths(include.map((pattern) => `${options.rootDir}/${pattern}`));
+  const outDir = options.outDir ? normalizeRelative(options.rootDir, options.outDir) : undefined;
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.exclude ?? [])];
+  const sourceFiles = project
+    .getSourceFiles()
+    .filter((sourceFile) => isProductionSource(options.rootDir, sourceFile, excludes, outDir));
+
+  const diagnostics: Diagnostic[] = [];
+  for (const sourceFile of sourceFiles) {
+    scanSourceFile(sourceFile, options.rootDir, diagnostics, options.strict ?? false);
+  }
+  return diagnostics;
+}
+
+function scanSourceFile(
+  sourceFile: SourceFile,
+  rootDir: string,
+  diagnostics: Diagnostic[],
+  strict: boolean,
+): void {
+  for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+    diagnostics.push(makeDiagnostic(
+      "source-any",
+      "生产源码使用了显式 any；请改用 unknown、具体接口或泛型约束。",
+      sourceFile,
+      node,
+      strict,
+      rootDir,
+    ));
+  }
+
+  for (const node of sourceFile.getDescendants()) {
+    if (Node.isAsExpression(node)) {
+      const assertedType = node.getTypeNode()?.getText();
+      if (assertedType === "const") continue;
+      diagnostics.push(makeDiagnostic(
+        "source-type-assertion",
+        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    } else if (Node.isTypeAssertion(node)) {
+      diagnostics.push(makeDiagnostic(
+        "source-type-assertion",
+        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    } else if (Node.isNonNullExpression(node)) {
+      diagnostics.push(makeDiagnostic(
+        "source-non-null-assertion",
+        `生产源码包含非空断言 ${node.getText()}；请显式处理 null/undefined。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+
+  for (const declaration of sourceFile.getVariableDeclarations()) {
+    const initializer = declaration.getInitializer();
+    if (!initializer || declaration.getTypeNode()) continue;
+    const declarationType = declaration.getType();
+    const initializerType = initializer.getType();
+    if (declaration.getVariableStatement()?.getDeclarationKind() === "let"
+      && isLiteralSyntax(initializer)
+      && !declarationType.isLiteral()) {
+      diagnostics.push(makeDiagnostic(
+        "source-implicit-widening",
+        `变量 ${declaration.getName()} 的字面量类型从 ${initializerType.getText()} 隐式宽化为 ${declarationType.getText()}；请补充类型或使用 const。`,
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+    }
+    if (Node.isObjectLiteralExpression(initializer)
+      && declaration.getVariableStatement()?.getDeclarationKind() === "const"
+      && initializer.getText().length > 0
+      && initializer.getProperties().some((property) => {
+        return Node.isPropertyAssignment(property)
+          && property.getInitializer()?.getKind() !== SyntaxKind.AsExpression
+          && isLiteralExpression(property.getInitializer());
+      })) {
+      diagnostics.push(makeDiagnostic(
+        "source-implicit-widening",
+        `常量对象 ${declaration.getName()} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+}
+
+function isProductionSource(
+  rootDir: string,
+  sourceFile: SourceFile,
+  excludes: string[],
+  outDir?: string,
+): boolean {
+  const relativePath = normalizeRelative(rootDir, sourceFile.getFilePath());
+  if (relativePath.startsWith("../") || relativePath.includes("node_modules/")) return false;
+  if (outDir && (relativePath === outDir || relativePath.startsWith(`${outDir}/`))) return false;
+  return !excludes.some((pattern) => globMatches(relativePath, pattern));
+}
+
+function globMatches(value: string, pattern: string): boolean {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "§§")
+    .replace(/\*/g, "[^/]*")
+    .replace(/§§/g, ".*")
+    .replace(/\?/g, "[^/]");
+  const optionalRoot = escaped.startsWith(".*\\/") ? "(?:.*\\/)?"
+    : escaped;
+  return new RegExp(`^${optionalRoot === escaped ? escaped : optionalRoot + escaped.slice(3)}$`).test(value);
+}
+
+function isLiteralExpression(node: Node | undefined): boolean {
+  if (!node) return false;
+  return [
+    SyntaxKind.StringLiteral,
+    SyntaxKind.NumericLiteral,
+    SyntaxKind.TrueKeyword,
+    SyntaxKind.FalseKeyword,
+  ].includes(node.getKind());
+}
+
+function isLiteralSyntax(node: Node): boolean {
+  return Node.isStringLiteral(node)
+    || Node.isNumericLiteral(node)
+    || node.getKind() === SyntaxKind.TrueKeyword
+    || node.getKind() === SyntaxKind.FalseKeyword;
+}
+
+function makeDiagnostic(
+  code: keyof typeof DIAGNOSTIC_META,
+  message: string,
+  fileOrSourceFile: string | SourceFile,
+  node: Node,
+  strict: boolean,
+  rootDir?: string,
+): Diagnostic {
+  const file = typeof fileOrSourceFile === "string"
+    ? fileOrSourceFile
+    : rootDir
+      ? normalizeRelative(rootDir, fileOrSourceFile.getFilePath())
+      : fileOrSourceFile.getFilePath();
+  const meta = DIAGNOSTIC_META[code];
+  return {
+    severity: strict ? "error" : "warn",
+    code,
+    message,
+    file,
+    line: node.getStartLineNumber(),
+    errorCode: meta.errorCode,
+    docsUrl: meta.docsUrl,
+  };
+}
+
+function normalizeRelative(rootDir: string, filePath: string): string {
+  return relative(rootDir, filePath).split(sep).join("/").replace(/^\.\//, "");
+}

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -3,6 +3,8 @@
  * No runtime reflection or container; all metadata is explicitly represented here and in generated code.
  */
 
+import type { Project } from "ts-morph";
+
 export type Scope = "application" | "request" | "job";
 
 export type ProviderKind = "class" | "value" | "factory" | "existing";
@@ -215,6 +217,17 @@ export interface CompileOptions {
   treeShakeUnusedProviders?: boolean;
   /** Incremental dependency graph cache. */
   cache?: DependencyGraphCache;
+  /** Type-safety gates for generated artifacts and production source. */
+  typeSafety?: TypeSafetyOptions;
+}
+
+export interface TypeSafetyOptions {
+  /** Reject the `any` keyword in generated TypeScript artifacts. */
+  noAnyInGenerated?: boolean;
+  /** Scan non-test production source for unsafe type escapes and widening. */
+  scanProductionSource?: boolean;
+  /** Additional relative glob patterns excluded from the production-source scan. */
+  exclude?: string[];
 }
 
 export interface ModuleBoundaryRule {
@@ -334,11 +347,15 @@ export interface DependencyGraphCache {
   /** Global file hashes by relative file path. */
   fileHashes: Map<string, string>;
   /** Retained AST project for true incremental graph re-analysis. */
-  project?: any;
+  project?: Project;
   /** Retained module dependency graph tracking imports and reverse dependents. */
-  dependencyGraph?: any;
+  dependencyGraph?: DependencyGraphIndex;
   lastStats?: {
     reusedModules: string[];
     reanalyzedModules: string[];
   };
+}
+
+export interface DependencyGraphIndex {
+  getAffectedModules(changedFiles: string[]): string[];
 }

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -381,7 +381,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
     };
 
     const diags = validateGraph(sampleGraph, {
-      moduleBoundaryPreset: "non-existent-preset" as any,
+      moduleBoundaryPreset: "non-existent-preset" as never,
     });
 
     const errors = diags.filter((d) => d.code === "invalid-boundary-preset");


### PR DESCRIPTION
## Summary
- remove `any` from compiler-generated application artifacts
- add type-safety diagnostics for explicit and inferred `any` in production source
- expose typed scan options and preserve compiler cache type contracts
- document strict type-safety gates

## Validation
- `bun run typecheck`
- `bun run typecheck:test`
- `bun test` (120 passed)
- `bun run build`
- `git diff --check`