### PR TITLE
fix(diagnostics): respect embedded edge runtime mode

### DIFF
--- a/packages/management-api/src/diagnostics/checks/platform-service.ts
+++ b/packages/management-api/src/diagnostics/checks/platform-service.ts
@@ -42,14 +42,20 @@ registerCheck({
   severity: "critical",
   repairable: false,
   async run(): Promise<DiagnosticCheckResult | null> {
+    const { config } = await import("../../config");
     const gateway = { unit: "supacloud-caddy", label: "Caddy Gateway" };
     const services = [
       { unit: "supacloud", label: "Management API" },
       gateway,
-      { unit: "supacloud-edge-runtime", label: "Edge Runtime" },
       { unit: "supacloud-pgredis-runtime", label: "pgredis Runtime" },
     ];
     const optionalSkipped: string[] = [];
+
+    if (config.edgeRuntimeMode === "external") {
+      services.push({ unit: "supacloud-edge-runtime", label: "Edge Runtime" });
+    } else {
+      optionalSkipped.push("Edge Runtime standalone unit (embedded in supacloud.service)");
+    }
 
     if (await isSystemdUnitInstalled("patroni")) {
       services.push({ unit: "patroni", label: "Patroni (PostgreSQL HA)" });

--- a/packages/management-api/tests/unit/infra-health.test.ts
+++ b/packages/management-api/tests/unit/infra-health.test.ts
@@ -50,6 +50,21 @@ describe("platform infrastructure health checks", () => {
     expect(body).not.toContain('{ unit: "patroni", label: "Patroni (PostgreSQL HA)" },');
   });
 
+  test("diagnostics check the standalone Edge Runtime unit only in external mode", () => {
+    const source = readRepoFile("src/diagnostics/checks/platform-service.ts");
+    const start = source.indexOf('id: "platform-service-status"');
+    const end = source.indexOf("// --- Port listener check ---", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const body = source.slice(start, end);
+    expect(body).toContain('const { config } = await import("../../config");');
+    expect(body).toContain('if (config.edgeRuntimeMode === "external")');
+    expect(body).toContain('{ unit: "supacloud-edge-runtime", label: "Edge Runtime" }');
+    expect(body).toContain("Edge Runtime standalone unit (embedded in supacloud.service)");
+  });
+
   test("diagnostics only check PostgreSQL listener when configured DB is local", () => {
     const source = readRepoFile("src/diagnostics/checks/platform-service.ts");
     const start = source.indexOf('id: "platform-port-listeners"');


### PR DESCRIPTION
Fix platform diagnostics to check the standalone Edge Runtime systemd unit only in external mode. Embedded mode is managed by supacloud.service; the standalone unit being inactive is expected. Adds regression coverage.