### PR TITLE
feat: migrate compiler and strengthen type safety

### DIFF
--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -158,6 +158,8 @@ describe('trusted review workflow', () => {
       }
       if (contents === releaseWorkflow) {
         assert.deepEqual(lockfileGenerationLines, [
+          '            bun install --lockfile-only --registry https://registry.npmjs.org',
+          '          bun install --lockfile-only --registry https://registry.npmjs.org',
           '          bun install --lockfile-only --registry https://registry.npmjs.org',
         ]);
       } else {

--- a/.github/scripts/sync-compiler-dependency.mjs
+++ b/.github/scripts/sync-compiler-dependency.mjs
@@ -1,0 +1,99 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const SEMVER_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function packageVersion(candidatePackage, packageName) {
+  const version = candidatePackage?.version;
+  if (typeof version !== 'string' || !SEMVER_PATTERN.test(version)) {
+    throw new Error(`${packageName} has an invalid version`);
+  }
+  return version;
+}
+
+function stableVersionPrecedence(version, packageName) {
+  const precedence = version.split('+', 1)[0];
+  if (precedence.includes('-')) {
+    throw new Error(`${packageName} prerelease versions are not supported for automatic synchronization`);
+  }
+  return precedence.split('.').map((identifier) => BigInt(identifier));
+}
+
+function comparePrecedence(leftVersion, rightVersion) {
+  for (let index = 0; index < leftVersion.length; index += 1) {
+    if (leftVersion[index] < rightVersion[index]) return -1;
+    if (leftVersion[index] > rightVersion[index]) return 1;
+  }
+  return 0;
+}
+
+function caretLowerBound(range, dependencyName) {
+  if (typeof range !== 'string' || !range.startsWith('^')) {
+    throw new Error(`${dependencyName} has an unsupported dependency range`);
+  }
+  const lowerVersion = range.slice(1);
+  if (!SEMVER_PATTERN.test(lowerVersion)) {
+    throw new Error(`${dependencyName} has an unsupported dependency range`);
+  }
+  return stableVersionPrecedence(lowerVersion, `${dependencyName} dependency range`);
+}
+
+export function syncCompilerDependency({ cliPackage, compilerPackage }) {
+  if (!cliPackage?.dependencies || typeof cliPackage.dependencies !== 'object') {
+    throw new Error('CLI package has no dependencies object');
+  }
+
+  const compilerVersion = packageVersion(compilerPackage, '@supacloud/compiler');
+  const compilerPrecedence = stableVersionPrecedence(compilerVersion, '@supacloud/compiler');
+  const currentRange = cliPackage.dependencies['@supacloud/compiler'];
+  const currentPrecedence = caretLowerBound(currentRange, '@supacloud/compiler');
+  const nextPackage = structuredClone(cliPackage);
+  const comparison = comparePrecedence(compilerPrecedence, currentPrecedence);
+
+  if (comparison < 0) {
+    throw new Error(
+      `@supacloud/compiler candidate ${compilerVersion} is below current lower bound ${currentRange}`,
+    );
+  }
+  if (comparison === 0) {
+    return { changed: false, package: nextPackage };
+  }
+
+  nextPackage.dependencies['@supacloud/compiler'] = `^${compilerVersion}`;
+  return { changed: true, package: nextPackage };
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function repositoryPackages(repoRoot = DEFAULT_REPO_ROOT) {
+  const cliPath = resolve(repoRoot, 'packages/cli/package.json');
+  const compilerPath = resolve(repoRoot, 'packages/compiler/package.json');
+  return {
+    cliPath,
+    cliPackage: await readJson(cliPath),
+    compilerPackage: await readJson(compilerPath),
+  };
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return entrypoint && pathToFileURL(resolve(entrypoint)).href === import.meta.url;
+}
+
+if (isMainModule()) {
+  try {
+    const repository = await repositoryPackages();
+    const synchronization = syncCompilerDependency(repository);
+    if (synchronization.changed) {
+      await writeFile(repository.cliPath, `${JSON.stringify(synchronization.package, null, 2)}\n`);
+    }
+    console.log(`changed=${synchronization.changed}`);
+  } catch (error) {
+    console.error(`Failed to sync compiler dependency: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/sync-compiler-dependency.test.mjs
+++ b/.github/scripts/sync-compiler-dependency.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { syncCompilerDependency } from './sync-compiler-dependency.mjs';
+
+function packagesWithRange(range, compilerVersion) {
+  return {
+    cliPackage: {
+      name: '@supacloud/cli',
+      dependencies: {
+        '@supacloud/compiler': range,
+        preserved: '^1.2.3',
+      },
+    },
+    compilerPackage: {
+      name: '@supacloud/compiler',
+      version: compilerVersion,
+    },
+  };
+}
+
+describe('CLI compiler dependency sync', () => {
+  test('updates the CLI range to the newly released compiler', () => {
+    const packages = packagesWithRange('^0.2.0', '0.6.0');
+    const synchronization = syncCompilerDependency(packages);
+
+    assert.equal(synchronization.changed, true);
+    assert.equal(synchronization.package.dependencies['@supacloud/compiler'], '^0.6.0');
+    assert.equal(packages.cliPackage.dependencies['@supacloud/compiler'], '^0.2.0');
+    assert.equal(synchronization.package.dependencies.preserved, '^1.2.3');
+  });
+
+  test('is idempotent for the current compiler version', () => {
+    assert.equal(
+      syncCompilerDependency(packagesWithRange('^0.6.0', '0.6.0')).changed,
+      false,
+    );
+  });
+
+  test('fails closed for a compiler version regression', () => {
+    assert.throws(
+      () => syncCompilerDependency(packagesWithRange('^0.6.0', '0.5.0')),
+      /candidate 0\.5\.0 is below current lower bound \^0\.6\.0/,
+    );
+  });
+
+  test('rejects unsupported ranges and prereleases', () => {
+    assert.throws(
+      () => syncCompilerDependency(packagesWithRange('~0.2.0', '0.6.0')),
+      /unsupported dependency range/,
+    );
+    assert.throws(
+      () => syncCompilerDependency(packagesWithRange('^0.2.0-beta.1', '0.6.0')),
+      /prerelease versions are not supported/,
+    );
+    assert.throws(
+      () => syncCompilerDependency(packagesWithRange('^0.2.0', '0.6.0-beta.1')),
+      /prerelease versions are not supported/,
+    );
+  });
+});

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -151,8 +151,8 @@ jobs:
           - name: Project CLI
             working-directory: packages/cli
             script: |
-              bun --cwd ../compiler install --frozen-lockfile
-              bun --cwd ../compiler run build
+              bun install --cwd ../compiler --frozen-lockfile
+              bun run --cwd ../compiler build
               bun install --frozen-lockfile
               bun run typecheck
               bun test src

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -151,6 +151,8 @@ jobs:
           - name: Project CLI
             working-directory: packages/cli
             script: |
+              bun --cwd ../compiler install --frozen-lockfile
+              bun --cwd ../compiler run build
               bun install --frozen-lockfile
               bun run typecheck
               bun test src

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -151,9 +151,9 @@ jobs:
           - name: Project CLI
             working-directory: packages/cli
             script: |
+              bun install --frozen-lockfile
               bun install --cwd ../compiler --frozen-lockfile
               bun run --cwd ../compiler build
-              bun install --frozen-lockfile
               bun run typecheck
               bun test src
               bun run build

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -152,8 +152,6 @@ jobs:
             working-directory: packages/cli
             script: |
               bun install --frozen-lockfile
-              bun install --cwd ../compiler --frozen-lockfile
-              bun run --cwd ../compiler build
               bun run typecheck
               bun test src
               bun run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -421,14 +421,6 @@ jobs:
           bun run check
           node "$GITHUB_WORKSPACE/.github/scripts/publish-npm-package.mjs"
 
-      - name: Publish cli to NPM
-        if: ${{ needs.release-please.outputs.cli_released == 'true' }}
-        working-directory: packages/cli
-        run: |
-          bun install --frozen-lockfile
-          bun run build
-          node "$GITHUB_WORKSPACE/.github/scripts/publish-npm-package.mjs"
-
       - name: Publish admin to NPM
         if: ${{ needs.release-please.outputs.admin_released == 'true' }}
         working-directory: packages/admin
@@ -472,6 +464,33 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
         run: |
           bun install --frozen-lockfile
+          bun run build
+          node "$GITHUB_WORKSPACE/.github/scripts/publish-npm-package.mjs"
+
+      - name: Publish cli to NPM
+        if: ${{ needs.release-please.outputs.cli_released == 'true' }}
+        working-directory: packages/cli
+        run: |
+          if [[ "${{ needs.release-please.outputs.compiler_released }}" == "true" ]]; then
+            compiler_version="$(node -p "require('../compiler/package.json').version")"
+            published=""
+            for attempt in $(seq 1 12); do
+              published="$(npm view "@supacloud/compiler@$compiler_version" version 2>/dev/null || true)"
+              if [[ "$published" == "$compiler_version" ]]; then
+                break
+              fi
+              if [[ "$attempt" -lt 12 ]]; then
+                sleep 5
+              fi
+            done
+            if [[ "$published" != "$compiler_version" ]]; then
+              echo "Published compiler is not visible: @supacloud/compiler@$compiler_version" >&2
+              exit 1
+            fi
+            node "$GITHUB_WORKSPACE/.github/scripts/sync-compiler-dependency.mjs"
+            bun install --lockfile-only --registry https://registry.npmjs.org
+          fi
+          bun install --frozen-lockfile --registry https://registry.npmjs.org
           bun run build
           node "$GITHUB_WORKSPACE/.github/scripts/publish-npm-package.mjs"
 
@@ -610,6 +629,106 @@ jobs:
               --head "$branch" \
               --title "fix(supacloud): sync published CLI dependencies" \
               --body "Synchronize the umbrella package with the CLI and Admin versions that have completed trusted npm publication, including the reproducible Bun lockfile."
+          else
+            echo "Updated dependency synchronization PR #$existing_pr."
+          fi
+
+  sync-cli-compiler-dependency:
+    needs: [release-please, publish-npm]
+    if: ${{ always() && needs.publish-npm.result == 'success' && needs.release-please.outputs.compiler_released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Synchronize CLI compiler dependency
+        id: synchronize
+        run: |
+          if ! sync_output="$(node .github/scripts/sync-compiler-dependency.mjs)"; then
+            echo "Compiler dependency synchronization failed." >&2
+            exit 1
+          fi
+          case "$sync_output" in
+            changed=true|changed=false) ;;
+            *)
+              echo "Unexpected compiler dependency synchronization output: $sync_output" >&2
+              exit 1
+              ;;
+          esac
+          printf '%s\n' "$sync_output" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for published compiler
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
+        run: |
+          compiler_version="$(node -p "require('./packages/compiler/package.json').version")"
+          published=""
+          for attempt in $(seq 1 12); do
+            published="$(npm view "@supacloud/compiler@$compiler_version" version 2>/dev/null || true)"
+            if [[ "$published" == "$compiler_version" ]]; then
+              break
+            fi
+            if [[ "$attempt" -lt 12 ]]; then
+              sleep 5
+            fi
+          done
+          if [[ "$published" != "$compiler_version" ]]; then
+            echo "Published compiler is not visible: @supacloud/compiler@$compiler_version" >&2
+            exit 1
+          fi
+
+      - name: Regenerate and verify CLI lockfile
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
+        working-directory: packages/cli
+        run: |
+          bun install --lockfile-only --registry https://registry.npmjs.org
+          bun install --frozen-lockfile --registry https://registry.npmjs.org
+          bun run typecheck
+          bun run build
+          git diff --check -- package.json bun.lock
+
+      - name: Open CLI dependency synchronization PR
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+        run: |
+          if git diff --quiet -- packages/cli/package.json packages/cli/bun.lock; then
+            echo "Dependency synchronization reported a change but produced no diff." >&2
+            exit 1
+          fi
+
+          branch="automation/sync-cli-compiler-dependency"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add packages/cli/package.json packages/cli/bun.lock
+          git commit -m "fix(cli): sync published compiler dependency"
+          git push --force-with-lease origin "HEAD:$branch"
+
+          existing_pr="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [[ -z "$existing_pr" ]]; then
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "fix(cli): sync published compiler dependency" \
+              --body "Synchronize the CLI with the compiler release after trusted npm publication, including the reproducible Bun lockfile."
           else
             echo "Updated dependency synchronization PR #$existing_pr."
           fi

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -138,6 +138,14 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` es por defecto específico del proyecto y se vincula automáticamente desde el `.env` del espacio de trabajo actual cuando está disponible.
 No existe un alias de compatibilidad de CLI de proyecto llamado `supacloud`: ese nombre está reservado para el binario del servidor compilado en `/usr/local/bin/supacloud`. Usa `supacloudctl` solo para el despachador local unificado opcional.
 
+La entrada al estilo npm usa Node.js de forma predeterminada. Los usuarios de
+Bun pueden ejecutar el paquete explícitamente con Bun, también desde terminales
+de Windows, sin instalar Node.js ni un wrapper independiente:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` o `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` o `SUPACLOUD_API_TOKEN`
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ supacloud-cli frontend list_releases --ref <project-ref> --id <deployment-id>
 `supacloud-cli` defaults to project context and auto-links from the current workspace `.env` when available.
 There is no project-CLI compatibility alias named `supacloud`: that name is reserved for the compiled server binary at `/usr/local/bin/supacloud`. Use `supacloudctl` only for the optional local unified dispatcher.
 
+The npm-style entry uses Node.js by default. Bun users can run the package
+explicitly with Bun, including from Windows terminals, without installing
+Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` or `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` or `SUPACLOUD_API_TOKEN`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -138,6 +138,13 @@ supacloud-cli frontend list --ref <project-ref>
 `supacloud-cli` 默认是项目级 CLI，会优先从当前目录 `.env` 自动绑定项目。
 项目 CLI 不再提供名为 `supacloud` 的兼容别名：该名称只保留给 `/usr/local/bin/supacloud` 服务端二进制。本地统一分发入口必须明确使用 `supacloudctl`。
 
+npm 风格入口默认使用 Node.js。Bun 用户可以显式指定 Bun 运行同一个包，
+包括在 Windows 终端中使用；不需要安装 Node.js，也不需要额外的包装器：
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 - `SUPABASE_URL` 或 `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` 或 `SUPACLOUD_API_TOKEN`
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -200,6 +200,12 @@ One-off execution without global install:
 npm exec --package @supacloud/cli -- supacloud-cli status
 ```
 
+Bun users can force the same package to run with Bun, including on Windows:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 ### Application framework commands
 
 Local commands for the application framework (`@supacloud/app` +

--- a/packages/admin/src/shared/cli.ts
+++ b/packages/admin/src/shared/cli.ts
@@ -150,7 +150,7 @@ export async function runCli(
     }
     
     const parsedArgs: Record<string, any> = {};
-    let startIdx = 1;
+    let startIdx: number = 1;
 
     // Check if there is an action argument (assuming index 1 is action if not starting with '--')
     if (args.length > 1 && !args[1].startsWith("--")) {

--- a/packages/admin/src/shared/global-options.ts
+++ b/packages/admin/src/shared/global-options.ts
@@ -78,7 +78,7 @@ export function parseGlobalAdminOptions(args: string[]): GlobalAdminOptions {
     const selectedOptions: Partial<Record<GlobalOptionKey, string>> = {};
     const commandArgs: string[] = [];
 
-    for (let index = 0; index < args.length;) {
+    for (let index: number = 0; index < args.length;) {
         const parsedArgument = parseGlobalArgument(args, index, selectedOptions);
         if (parsedArgument.commandArgument !== undefined) {
             commandArgs.push(parsedArgument.commandArgument);

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.ts
@@ -256,7 +256,7 @@ function assertOfficialDownloadUrl(url: URL): void {
 }
 
 function boundedWriter(maxBytes: number): Transform {
-    let receivedBytes = 0;
+    let receivedBytes: number = 0;
     return new Transform({
         transform(chunk: Buffer, _encoding, callback) {
             receivedBytes += chunk.length;
@@ -328,7 +328,7 @@ async function downloadDirect(url: string, destination: string, maxBytes: number
     assertOfficialDownloadUrl(parsed);
     const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
     const retryFailures: unknown[] = [];
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
+    for (let attempt: number = 1; attempt <= 3; attempt += 1) {
         rmSync(destination, { force: true });
         try {
             await downloadHttpsResponse({ url: parsed, destination, maxBytes, redirects: 0, deadline });
@@ -485,8 +485,8 @@ function spawnGithubCli(arguments_: string[]): GithubCliProcess {
 
 function githubCliExitCode(child: GithubCliProcess, timeoutMs: number): Promise<number> {
     return new Promise<number>((resolve, reject) => {
-        let timedOut = false;
-        let settled = false;
+        let timedOut: boolean = false;
+        let settled: boolean = false;
         let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
         const timeout = setTimeout(() => {
             timedOut = true;
@@ -508,8 +508,8 @@ function githubCliExitCode(child: GithubCliProcess, timeoutMs: number): Promise<
 
 export async function runGithubCli(arguments_: string[], timeoutMs: number): Promise<GithubCliResult> {
     const child = spawnGithubCli(arguments_);
-    let stdout = "";
-    let stderr = "";
+    let stdout: string = "";
+    let stderr: string = "";
     child.stdout.on("data", (chunk: Buffer) => { stdout = `${stdout}${chunk.toString()}`.slice(-8_000); });
     child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
     const exitCode = await githubCliExitCode(child, timeoutMs);
@@ -523,7 +523,7 @@ export async function runGithubCliDownload(
     timeoutMs: number,
 ): Promise<GithubCliResult> {
     const child = spawnGithubCli(arguments_);
-    let stderr = "";
+    let stderr: string = "";
     child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
     const write = pipeline(
         child.stdout,

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -298,7 +298,7 @@ export function assertControlPlaneSafetyVersion(version: string): void {
     if (!requested.every(Number.isSafeInteger)) {
         throw new Error("Management version must be an exact stable version");
     }
-    for (let index = 0; index < requested.length; index += 1) {
+    for (let index: number = 0; index < requested.length; index += 1) {
         if (requested[index]! > MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) return;
         if (requested[index]! < MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) {
             throw new Error("Local artifact upgrades require Management 0.61.7 or newer with control-plane backup preflight safety");
@@ -770,7 +770,7 @@ export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
 
 export async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
     let adoptionFailure: Error;
-    let adoptionOutcomeUncertain = false;
+    let adoptionOutcomeUncertain: boolean = false;
     try {
         const adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
         if (adopted.success) return;
@@ -807,7 +807,7 @@ function startUnitScript(paths: RemoteUpgradePaths): string {
 
 export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
     let startFailure: Error;
-    let startOutcomeUncertain = false;
+    let startOutcomeUncertain: boolean = false;
     try {
         const started = await ssh.exec(rootCommand(startUnitScript(paths)), 30_000);
         if (started.success) return;
@@ -915,7 +915,7 @@ async function observeRemoteState(
     observation: RemoteStateObservation,
 ): Promise<RemoteUpgradeState> {
     const readFailures: unknown[] = [];
-    for (let attempt = 1; attempt <= STATE_READ_ATTEMPTS; attempt += 1) {
+    for (let attempt: number = 1; attempt <= STATE_READ_ATTEMPTS; attempt += 1) {
         const remainingMs = observation.deadline === undefined
             ? REMOTE_STATE_READ_TIMEOUT_MS
             : observation.deadline - Date.now();
@@ -1170,7 +1170,7 @@ function assertObservableUpgradeState(state: RemoteUpgradeState, unitRunning: bo
 
 export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
     const observationDeadline = Date.now() + UPGRADE_OBSERVATION_TIMEOUT_MS;
-    let stoppedObservations = 0;
+    let stoppedObservations: number = 0;
     while (true) {
         const state = await observeRemoteState(ssh, paths, {
             deadline: observationDeadline,
@@ -1208,7 +1208,7 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
     const paths = buildRemoteUpgradePaths(runId);
     const preflight = await remoteUpgradePreflight(ssh);
     const bundle = await prepareLocalUpgradeBundle({ ...preflight, ...request });
-    let adopted = false;
+    let adopted: boolean = false;
     let transferError: unknown;
     try {
         try {

--- a/packages/admin/src/shared/tools/database-tools.ts
+++ b/packages/admin/src/shared/tools/database-tools.ts
@@ -266,7 +266,7 @@ function formatTableList(data: unknown, schemas: string[]): string {
     if (!rows.length) return `No tables in: ${schemas.join(", ")}`;
     const grouped: Record<string, string[]> = {};
     for (const r of rows) { (grouped[r.schema] ??= []).push(r.table); }
-    let out = "📋 Tables:\n\n";
+    let out: string = "📋 Tables:\n\n";
     for (const [s, ts] of Object.entries(grouped)) { out += `Schema: ${s}\n${ts.map(t => `  - ${t}`).join("\n")}\n\n`; }
     return out;
 }
@@ -323,7 +323,7 @@ function formatRlsPolicies(data: unknown, schema: string, table: string): string
 function formatAuthUsers(data: unknown): string {
     const rows = (data as any)?.rows || [];
     if (!rows.length) return "No users.";
-    let out = "👥 Auth Users:\n\n";
+    let out: string = "👥 Auth Users:\n\n";
     for (const u of rows) {
         out += `  ${u.email_confirmed_at ? "✅" : "⏳"} ${u.email} (${u.role})\n      ID: ${u.id}\n      Created: ${u.created_at}\n`;
         if (u.last_sign_in_at) out += `      Last login: ${u.last_sign_in_at}\n`;
@@ -356,7 +356,7 @@ function formatConnections(data: unknown): string {
 function formatDbStats(data: unknown): string {
     const rows = (data as any)?.rows || [];
     if (!rows.length) return "No stats.";
-    let out = "📊 Stats:\n\n  Table                          | Rows      | Total      | Table      | Index\n  -------------------------------|-----------|------------|------------|----------\n";
+    let out: string = "📊 Stats:\n\n  Table                          | Rows      | Total      | Table      | Index\n  -------------------------------|-----------|------------|------------|----------\n";
     for (const t of rows) {
         out += `  ${`${t.schemaname}.${t.table_name}`.padEnd(30)} | ${String(t.row_count || 0).padStart(9)} | ${t.total_size.padStart(10)} | ${t.table_size.padStart(10)} | ${t.index_size.padStart(10)}\n`;
     }

--- a/packages/admin/src/shared/tools/project-create-env.ts
+++ b/packages/admin/src/shared/tools/project-create-env.ts
@@ -346,7 +346,7 @@ function environmentFileContent(
 }
 
 async function sanitizeAndClose(openFile: ProjectEnvFileHandle): Promise<boolean> {
-    let sanitized = true;
+    let sanitized: boolean = true;
     try {
         await openFile.truncate(0);
         await openFile.sync();

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -601,9 +601,9 @@ async function executeOfficialUpgrade(
     timeoutMs: number,
 ): Promise<Awaited<ReturnType<SshTransport["exec"]>>> {
     let execution: OfficialUpgradeExecution | undefined;
-    let executionFailed = false;
+    let executionFailed: boolean = false;
     let executionError: unknown;
-    let upgradeExecutionRequested = false;
+    let upgradeExecutionRequested: boolean = false;
     try {
         await prepareRemoteUpgradeHelperDirectory(ssh, helperPath);
         await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
@@ -619,7 +619,7 @@ async function executeOfficialUpgrade(
         executionError = error;
     }
 
-    let cleanupFailed = false;
+    let cleanupFailed: boolean = false;
     let cleanupError: unknown;
     try {
         await removeRemoteUpgradeHelper(ssh, helperPath);
@@ -691,10 +691,10 @@ function assertSafeExecCommand(command: string): string {
     }
 
     if (commandName === "journalctl") {
-        let unit = "";
-        let tailCount = "";
-        let noPager = false;
-        for (let index = 1; index < tokens.length; index += 1) {
+        let unit: string = "";
+        let tailCount: string = "";
+        let noPager: boolean = false;
+        for (let index: number = 1; index < tokens.length; index += 1) {
             const token = tokens[index];
             if (token === "-u" && !unit) {
                 unit = tokens[++index] || "";
@@ -723,7 +723,7 @@ function assertSafeExecCommand(command: string): string {
             reject();
         }
         if (action === "logs") {
-            let index = 2;
+            let index: number = 2;
             if (tokens[index] !== "--tail") reject();
             const countToken = tokens[index + 1] || "";
             const count = Number(countToken);
@@ -745,7 +745,7 @@ function assertSafeExecCommand(command: string): string {
 
     if (commandName === "pg_isready") {
         const seen = new Set<string>();
-        for (let index = 1; index < tokens.length; index += 2) {
+        for (let index: number = 1; index < tokens.length; index += 2) {
             const option = tokens[index];
             const optionValue = tokens[index + 1];
             if (!optionValue || seen.has(option)) reject();

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -124,7 +124,7 @@ function responseExceedsDeclaredLimit(response: Response, maxBytes: number): boo
 
 function joinedResponseBytes(chunks: Uint8Array[], totalBytes: number): Uint8Array {
     const responseBytes = new Uint8Array(totalBytes);
-    let offset = 0;
+    let offset: number = 0;
     for (const chunk of chunks) {
         responseBytes.set(chunk, offset);
         offset += chunk.byteLength;
@@ -141,7 +141,7 @@ async function responseBytesFromReader(
     maxBytes: number,
 ): Promise<Uint8Array | null> {
     const chunks: Uint8Array[] = [];
-    let totalBytes = 0;
+    let totalBytes: number = 0;
     while (true) {
         const { done, value } = await reader.read();
         if (done) return joinedResponseBytes(chunks, totalBytes);
@@ -239,7 +239,7 @@ async function fetchWithRetry(
     timeoutMs = DEFAULT_TIMEOUT,
 ): Promise<Response> {
     const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    for (let attempt: number = 0; attempt <= retries; attempt++) {
         try {
             const res = await fetchWithTimeout(url, options, timeoutMs);
 

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -156,7 +156,7 @@ const SENSITIVE_STRUCTURED_FIELD = /(?:password|pass|secret|token|key|credential
 
 function decodedStructuredFieldName(encodedName: string): string | null {
     let decodedName = encodedName.replace(/\\'/g, "'");
-    for (let decodingPass = 0; decodingPass < 3; decodingPass += 1) {
+    for (let decodingPass: number = 0; decodingPass < 3; decodingPass += 1) {
         if (decodedName.length > 256) return null;
         try {
             const nextName = JSON.parse(`"${decodedName.replace(/"/g, '\\"')}"`);
@@ -187,7 +187,7 @@ function structuredSensitiveFieldsAreRedacted(message: string): boolean {
     try {
         const parsedDiagnostic = JSON.parse(normalizedQuotes);
         if (!parsedDiagnostic || typeof parsedDiagnostic !== "object") return false;
-        let foundSensitiveField = false;
+        let foundSensitiveField: boolean = false;
         const pending = [parsedDiagnostic];
         while (pending.length > 0) {
             const current = pending.pop();
@@ -360,7 +360,7 @@ export class SshTransport {
         auditCommand(command, this.config.host, false);
 
         const conn = await this.pool.acquire();
-        let connectionReusable = true;
+        let connectionReusable: boolean = true;
         try {
             return await new Promise<SshResult>((resolve, reject) => {
                 const outputLimit = this.config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
@@ -463,7 +463,7 @@ export class SshTransport {
 
     private async runSftpOperation(timeoutMs: number, operation: (sftp: SftpClient) => Promise<void>): Promise<void> {
         const conn = await this.pool.acquire();
-        let connectionReusable = true;
+        let connectionReusable: boolean = true;
         let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         try {
             const operationPromise = openSftp(conn).then(async (sftp) => {

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -8,6 +8,11 @@ SupaCloud compiler (`@supacloud/compiler`) reads that metadata from source,
 validates the dependency graph and generates plain static factories — there is
 no runtime reflection and no `reflect-metadata` dependency.
 
+Runtime DI delegates to Angular's public `@angular/core` APIs through a small
+compatibility adapter. SupaCloud decorators retain module/compiler metadata,
+while production application factories remain compiler-generated and
+reflection-free.
+
 ```ts
 import {
   Command,

--- a/packages/app/bun.lock
+++ b/packages/app/bun.lock
@@ -5,12 +5,15 @@
     "": {
       "name": "@supacloud/app",
       "devDependencies": {
+        "@angular/core": "^22.1.5",
         "@types/bun": "^1.4.0",
         "typescript": "^7.0.2",
       },
     },
   },
   "packages": {
+    "@angular/core": ["@angular/core@22.1.5", "https://registry.npmmirror.com/@angular/core/-/core-22.1.5.tgz", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/compiler": "22.1.5", "rxjs": "^6.5.3 || ^7.4.0", "zone.js": "~0.15.0 || ~0.16.0" }, "optionalPeers": ["@angular/compiler", "zone.js"] }, "sha512-uiL+xVL4264NEuc3E5ILd6meSv9I4Xt82VQHvYlAVYlcjHlWY49yVe0/apzncUOGxUKzvK8/GDbyFEH7WfJYFw=="],
+
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
@@ -56,6 +59,10 @@
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "rxjs": ["rxjs@7.8.2", "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.2.tgz", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "tslib": ["tslib@2.8.1", "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,6 +40,9 @@
     "url": "https://github.com/vibeunion/supacloud.git",
     "directory": "packages/app"
   },
+  "dependencies": {
+    "@angular/core": "^22.1.5"
+  },
   "devDependencies": {
     "@types/bun": "^1.4.0",
     "typescript": "^7.0.2"

--- a/packages/app/src/context.ts
+++ b/packages/app/src/context.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from "./token";
+import { DestroyRef as AngularDestroyRef, inject as angularInject } from "@angular/core";
 
 /**
  * Built-in token resolved from the request-context argument of a compiled
@@ -70,7 +71,16 @@ export interface DestroyRef {
  */
 export const DESTROY_REF = new InjectionToken<DestroyRef>("supacloud.destroy-ref", {
   scope: "application",
-  factory: () => createDestroyRef(),
+  factory: () => {
+    try {
+      const destroyRef = angularInject(AngularDestroyRef);
+      return destroyRef && typeof destroyRef.onDestroy === "function"
+        ? destroyRef
+        : createDestroyRef();
+    } catch {
+      return createDestroyRef();
+    }
+  },
 });
 
 /**

--- a/packages/app/src/decorators.ts
+++ b/packages/app/src/decorators.ts
@@ -1,4 +1,4 @@
-import type { Provider, Token, Type } from "./provider";
+import type { Provider, ProviderDep, Token, Type } from "./provider";
 import type { EnvironmentProviders } from "./provider";
 import { flattenProviders } from "./provider";
 import type { Scope } from "./scope";
@@ -54,13 +54,13 @@ export interface InjectableOptions {
   /** Automatically provide this service in root scope without manual module declaration (Angular-style). */
   providedIn?: "root";
   /** Explicit constructor dependency tokens, in parameter order. */
-  deps?: Token[];
+  deps?: ProviderDep[];
 }
 
 export interface InjectableMeta {
   scope: Scope;
   providedIn?: "root";
-  deps: Token[];
+  deps: ProviderDep[];
 }
 
 export interface ModuleOptions {
@@ -183,7 +183,7 @@ export function Injectable(options: InjectableOptions = {}): ClassDecorator {
     AngularInjectable({
       providedIn: options.providedIn ?? null,
     })(target);
-    const prototype = (target as Type<unknown>).prototype as Record<string, unknown>;
+    const prototype = (target as unknown as Type<unknown>).prototype as Record<string, unknown>;
     if (
       typeof prototype.ngOnDestroy !== "function" &&
       typeof prototype.onDestroy === "function"

--- a/packages/app/src/decorators.ts
+++ b/packages/app/src/decorators.ts
@@ -3,6 +3,14 @@ import type { EnvironmentProviders } from "./provider";
 import { flattenProviders } from "./provider";
 import type { Scope } from "./scope";
 import { DEFAULT_SCOPE } from "./scope";
+import {
+  Host as AngularHost,
+  Inject as AngularInject,
+  Injectable as AngularInjectable,
+  Optional as AngularOptional,
+  Self as AngularSelf,
+  SkipSelf as AngularSkipSelf,
+} from "@angular/core";
 
 /**
  * Decorator metadata keys. Metadata is attached as static properties on the
@@ -172,6 +180,22 @@ function readOwnOrInherited<T>(target: object, key: string): T | undefined {
 
 export function Injectable(options: InjectableOptions = {}): ClassDecorator {
   return (target) => {
+    AngularInjectable({
+      providedIn: options.providedIn ?? null,
+    })(target);
+    const prototype = (target as Type<unknown>).prototype as Record<string, unknown>;
+    if (
+      typeof prototype.ngOnDestroy !== "function" &&
+      typeof prototype.onDestroy === "function"
+    ) {
+      Object.defineProperty(prototype, "ngOnDestroy", {
+        configurable: true,
+        value(this: Record<string, unknown>) {
+          const destroy = this.onDestroy;
+          return typeof destroy === "function" ? destroy.call(this) : undefined;
+        },
+      });
+    }
     const meta: InjectableMeta = {
       scope: options.scope ?? DEFAULT_SCOPE,
       providedIn: options.providedIn,
@@ -196,6 +220,7 @@ export function Inject(token: Token): ParameterDecorator {
       throw new Error("@Inject() is only supported on constructor parameters");
     }
     const cls = target as Type<unknown>;
+    AngularInject(token as never)(target, propertyKey, parameterIndex);
     const meta: Record<number, Token> = {
       ...readOwnOrInherited<Record<number, Token>>(cls, INJECT_PARAMS_METADATA),
     };
@@ -218,6 +243,7 @@ export function Optional(): ParameterDecorator {
       throw new Error("@Optional() is only supported on constructor parameters");
     }
     const cls = target as Type<unknown>;
+    AngularOptional()(target, propertyKey, parameterIndex);
     const list = [...(readOwnOrInherited<number[]>(cls, OPTIONAL_PARAMS_METADATA) ?? [])];
     if (!list.includes(parameterIndex)) list.push(parameterIndex);
     defineMetadata(cls, OPTIONAL_PARAMS_METADATA, list);
@@ -238,6 +264,7 @@ export function Self(): ParameterDecorator {
       throw new Error("@Self() is only supported on constructor parameters");
     }
     const cls = target as Type<unknown>;
+    AngularSelf()(target, propertyKey, parameterIndex);
     const list = [...(readOwnOrInherited<number[]>(cls, SELF_PARAMS_METADATA) ?? [])];
     if (!list.includes(parameterIndex)) list.push(parameterIndex);
     defineMetadata(cls, SELF_PARAMS_METADATA, list);
@@ -258,6 +285,7 @@ export function SkipSelf(): ParameterDecorator {
       throw new Error("@SkipSelf() is only supported on constructor parameters");
     }
     const cls = target as Type<unknown>;
+    AngularSkipSelf()(target, propertyKey, parameterIndex);
     const list = [...(readOwnOrInherited<number[]>(cls, SKIP_SELF_PARAMS_METADATA) ?? [])];
     if (!list.includes(parameterIndex)) list.push(parameterIndex);
     defineMetadata(cls, SKIP_SELF_PARAMS_METADATA, list);
@@ -278,6 +306,7 @@ export function Host(): ParameterDecorator {
       throw new Error("@Host() is only supported on constructor parameters");
     }
     const cls = target as Type<unknown>;
+    AngularHost()(target, propertyKey, parameterIndex);
     const list = [...(readOwnOrInherited<number[]>(cls, HOST_PARAMS_METADATA) ?? [])];
     if (!list.includes(parameterIndex)) list.push(parameterIndex);
     defineMetadata(cls, HOST_PARAMS_METADATA, list);

--- a/packages/app/src/forms.test.ts
+++ b/packages/app/src/forms.test.ts
@@ -129,4 +129,110 @@ describe("Angular-style Reactive Forms & Validation (@angular/forms)", () => {
     expect(username.invalid).toBe(true);
     expect(username.hasError("usernameTaken")).toBe(true);
   });
+
+  test("ignores stale async validator results", async () => {
+    const resolvers = new Map<string, (errors: Record<string, unknown> | null) => void>();
+    const username = new FormControl("first", null, (ctrl) => new Promise((resolve) => {
+      resolvers.set(String(ctrl.value), resolve);
+    }));
+
+    username.setValue("second");
+    resolvers.get("first")?.({ stale: true });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(username.pending).toBe(true);
+
+    resolvers.get("second")?.(null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(username.valid).toBe(true);
+    expect(username.errors).toBeNull();
+  });
+
+  test("recalculates nested parents after async validation completes", async () => {
+    let resolveChild!: (errors: Record<string, unknown> | null) => void;
+    const child = new FormControl("value", null, () => new Promise((resolve) => {
+      resolveChild = resolve;
+    }));
+    const group = new FormGroup({ child });
+    const root = new FormGroup({ group });
+
+    expect(group.pending).toBe(true);
+    expect(root.pending).toBe(true);
+    resolveChild(null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(child.valid).toBe(true);
+    expect(group.valid).toBe(true);
+    expect(root.valid).toBe(true);
+  });
+
+  test("converts rejected async validators into a stable validation error", async () => {
+    const control = new FormControl("value", null, async () => {
+      throw new Error("network unavailable");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(control.pending).toBe(false);
+    expect(control.invalid).toBe(true);
+    expect(control.hasError("asyncValidator")).toBe(true);
+  });
+
+  test("keeps disabled groups and arrays disabled during parent aggregation", () => {
+    const group = new FormGroup({
+      child: new FormControl("value", Validators.required),
+    });
+    const array = new FormArray([
+      new FormControl("value", Validators.required),
+    ]);
+
+    group.disable();
+    array.disable();
+    group.updateValueAndValidity();
+    array.updateValueAndValidity();
+
+    expect(group.disabled).toBe(true);
+    expect(group.valid).toBe(false);
+    expect(group.errors).toBeNull();
+    expect(array.disabled).toBe(true);
+    expect(array.valid).toBe(false);
+    expect(array.errors).toBeNull();
+  });
+
+  test("clears stale child aggregation errors while a child is pending", () => {
+    let resolveChild!: (errors: Record<string, unknown> | null) => void;
+    const child = new FormControl("", Validators.required);
+    const group = new FormGroup({ child });
+
+    expect(group.invalid).toBe(true);
+    const asyncChild = new FormControl("value", null, () => new Promise((resolve) => {
+      resolveChild = resolve;
+    }));
+    group.setControl("child", asyncChild);
+
+    expect(group.pending).toBe(true);
+    expect(group.errors).toBeNull();
+    resolveChild(null);
+  });
+
+  test("ignores container async results after a child becomes invalid", async () => {
+    for (const array of [false, true]) {
+      const child = new FormControl("value", Validators.required);
+      let finish!: (errors: null) => void;
+      const validate = () => new Promise<null>((resolve) => { finish = resolve; });
+      const container = array
+        ? new FormArray([child], null, validate)
+        : new FormGroup({ child }, null, validate);
+      const root = new FormGroup({ container });
+
+      expect(container.pending).toBe(true);
+      child.setValue("");
+      expect(container.invalid).toBe(true);
+      finish(null);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(container.invalid).toBe(true);
+      expect(root.invalid).toBe(true);
+      expect(container.hasError("invalidChildren")).toBe(true);
+    }
+  });
 });

--- a/packages/app/src/forms.ts
+++ b/packages/app/src/forms.ts
@@ -23,11 +23,12 @@ export interface AbstractControlOptions {
  */
 export abstract class AbstractControl<TValue = any> {
   private _value!: TValue;
-  private _status: FormControlStatus = "VALID";
-  private _errors: ValidationErrors | null = null;
+  protected _status: FormControlStatus = "VALID";
+  protected _errors: ValidationErrors | null = null;
   private _pristine = true;
   private _touched = false;
   private _parent: FormGroup | FormArray | null = null;
+  private _validationRun = 0;
   protected _validator: ValidatorFn | null = null;
   protected _asyncValidator: AsyncValidatorFn | null = null;
 
@@ -153,6 +154,7 @@ export abstract class AbstractControl<TValue = any> {
   }
 
   disable(): void {
+    this._validationRun += 1;
     this._status = "DISABLED";
     this._errors = null;
     if (this._parent) this._parent.updateValueAndValidity();
@@ -165,7 +167,11 @@ export abstract class AbstractControl<TValue = any> {
 
   setErrors(errors: ValidationErrors | null): void {
     this._errors = errors;
-    this._status = errors ? "INVALID" : "VALID";
+    this._status = this.disabled ? "DISABLED" : errors ? "INVALID" : "VALID";
+  }
+
+  protected cancelPendingValidation(): void {
+    this._validationRun += 1;
   }
 
   hasError(errorCode: string, path?: string | (string | number)[]): boolean {
@@ -187,6 +193,7 @@ export abstract class AbstractControl<TValue = any> {
   }
 
   updateValueAndValidity(): void {
+    const validationRun = ++this._validationRun;
     if (this.disabled) {
       this._status = "DISABLED";
       this._errors = null;
@@ -203,11 +210,17 @@ export abstract class AbstractControl<TValue = any> {
 
     if (this._status === "VALID" && this._asyncValidator) {
       this._status = "PENDING";
-      this._asyncValidator(this).then((errors) => {
-        if (this._status === "PENDING") {
+      this._asyncValidator(this)
+        .then((errors) => {
+          if (validationRun !== this._validationRun) return;
           this.setErrors(errors);
-        }
-      });
+          this._parent?.updateValueAndValidity();
+        })
+        .catch(() => {
+          if (validationRun !== this._validationRun) return;
+          this.setErrors({ asyncValidator: true });
+          this._parent?.updateValueAndValidity();
+        });
     }
 
     if (this._parent) {
@@ -357,6 +370,7 @@ export class FormGroup<
   override updateValueAndValidity(): void {
     if (this.disabled) {
       this.setErrors(null);
+      this.parent?.updateValueAndValidity();
       return;
     }
     let hasInvalid = false;
@@ -367,12 +381,17 @@ export class FormGroup<
     }
 
     if (hasInvalid) {
+      this.cancelPendingValidation();
       this.setErrors({ invalidChildren: true });
     } else if (hasPending) {
-      (this as any)._status = "PENDING";
+      this.cancelPendingValidation();
+      this._errors = null;
+      this._status = "PENDING";
     } else {
       super.updateValueAndValidity();
+      return;
     }
+    this.parent?.updateValueAndValidity();
   }
 }
 
@@ -457,6 +476,7 @@ export class FormArray<
   override updateValueAndValidity(): void {
     if (this.disabled) {
       this.setErrors(null);
+      this.parent?.updateValueAndValidity();
       return;
     }
     let hasInvalid = false;
@@ -467,12 +487,17 @@ export class FormArray<
     }
 
     if (hasInvalid) {
+      this.cancelPendingValidation();
       this.setErrors({ invalidChildren: true });
     } else if (hasPending) {
-      (this as any)._status = "PENDING";
+      this.cancelPendingValidation();
+      this._errors = null;
+      this._status = "PENDING";
     } else {
       super.updateValueAndValidity();
+      return;
     }
+    this.parent?.updateValueAndValidity();
   }
 }
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -20,6 +20,8 @@ export type {
   ExistingProvider,
   FactoryProvider,
   Provider,
+  ProviderDep,
+  ProviderDependency,
   Token,
   Type,
   ValueProvider,

--- a/packages/app/src/inject.test.ts
+++ b/packages/app/src/inject.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { INJECTOR, createEnvironmentInjector, inject, runInInjectionContext } from "./inject";
+import { INJECTOR, createEnvironmentInjector, inject, injectAll, runInInjectionContext } from "./inject";
 import { InjectionToken } from "./token";
 import { DESTROY_REF, type OnDestroy } from "./context";
-import { provideEnvironmentInitializer, provideToken } from "./provider";
+import {
+  makeEnvironmentProviders,
+  provideEnvironmentInitializer,
+  provideToken,
+} from "./provider";
 
 describe("Angular 14+ EnvironmentInjector and createEnvironmentInjector", () => {
   it("resolves basic providers and executes runInContext", () => {
@@ -108,5 +112,61 @@ describe("Angular 14+ EnvironmentInjector and createEnvironmentInjector", () => 
       return inject(INJECTOR);
     });
     expect(resolvedInjector).toBe(env);
+  });
+
+  it("resolves provider deps, aliases, multi providers, and nested environment providers", () => {
+    const CONFIG = new InjectionToken<{ prefix: string }>("CONFIG");
+    const VALUE = new InjectionToken<string>("VALUE");
+    const HOOKS = new InjectionToken<() => string>("HOOKS");
+    const HOOK_ALIAS = new InjectionToken<() => string>("HOOK_ALIAS");
+    class Service {
+      constructor(
+        readonly config: { prefix: string },
+        readonly value: string,
+      ) {}
+    }
+
+    const env = createEnvironmentInjector([
+      makeEnvironmentProviders([
+        provideToken(CONFIG, { prefix: "supacloud" }),
+        provideToken(VALUE, "di"),
+      ]),
+      {
+        provide: Service,
+        useClass: Service,
+        deps: [CONFIG, VALUE],
+      },
+      {
+        provide: HOOKS,
+        useFactory: (service: Service) => () => `${service.config.prefix}-${service.value}`,
+        deps: [Service],
+        multi: true,
+      },
+      {
+        provide: HOOK_ALIAS,
+        useValue: () => "di",
+      },
+      {
+        provide: HOOKS,
+        useExisting: HOOK_ALIAS,
+        multi: true,
+      },
+    ]);
+
+    expect(env.get(Service).value).toBe("di");
+    expect(env.runInContext(() => injectAll(HOOKS).map((hook) => hook()))).toEqual([
+      "supacloud-di",
+      "di",
+    ]);
+  });
+
+  it("runs token factories inside the active injection context", () => {
+    const CONFIG = new InjectionToken<string>("CONFIG");
+    const DERIVED = new InjectionToken<string>("DERIVED", {
+      factory: () => `${inject(CONFIG)}:derived`,
+    });
+    const env = createEnvironmentInjector([provideToken(CONFIG, "context")]);
+
+    expect(env.get(DERIVED)).toBe("context:derived");
   });
 });

--- a/packages/app/src/inject.test.ts
+++ b/packages/app/src/inject.test.ts
@@ -169,4 +169,26 @@ describe("Angular 14+ EnvironmentInjector and createEnvironmentInjector", () => 
 
     expect(env.get(DERIVED)).toBe("context:derived");
   });
+
+  it("supports Angular provider deps descriptors without a custom lookup container", () => {
+    const VALUE = new InjectionToken<string>("VALUE");
+    const MISSING = new InjectionToken<string>("MISSING");
+    const RESULT = new InjectionToken<string>("RESULT");
+
+    const parent = createEnvironmentInjector([
+      { provide: VALUE, useValue: "parent" },
+    ]);
+    const child = createEnvironmentInjector([
+      {
+        provide: RESULT,
+        useFactory: (value: string, missing: string | undefined) => `${value}:${missing ?? "optional"}`,
+        deps: [
+          { token: VALUE, skipSelf: true },
+          { token: MISSING, optional: true },
+        ],
+      },
+    ], parent);
+
+    expect(child.get(RESULT)).toBe("parent:optional");
+  });
 });

--- a/packages/app/src/inject.ts
+++ b/packages/app/src/inject.ts
@@ -1,169 +1,139 @@
-import type { EnvironmentProviders, Provider, Token, Type } from "./provider";
-import { flattenProviders, isClassProvider, isExistingProvider, isFactoryProvider, isValueProvider } from "./provider";
-import { APP_INITIALIZER, DESTROY_REF, ENVIRONMENT_INITIALIZER, createDestroyRef } from "./context";
-import { resolveForwardRef } from "./forward_ref";
+import {
+  assertInInjectionContext as angularAssertInInjectionContext,
+  createEnvironmentInjector as angularCreateEnvironmentInjector,
+  inject as angularInject,
+  Injector as AngularInjector,
+  runInInjectionContext as angularRunInInjectionContext,
+  DestroyRef as AngularDestroyRef,
+  type EnvironmentInjector as AngularEnvironmentInjector,
+  type InjectOptions,
+  type Provider as AngularProvider,
+} from "@angular/core";
+import type { EnvironmentProviders, Provider, Token } from "./provider";
+import { flattenProviders } from "./provider";
+import { APP_INITIALIZER, DESTROY_REF, ENVIRONMENT_INITIALIZER } from "./context";
 import { InjectionToken } from "./token";
 
-export interface InjectFlags {
-  /** If true, returns undefined instead of throwing when token is not found. */
-  optional?: boolean;
-  /** If true, requires token to be resolved from current local injector. */
-  self?: boolean;
-  /** If true, skips current local injector and resolves from parent. */
-  skipSelf?: boolean;
-  /** If true, resolves from host injector. */
-  host?: boolean;
-}
+export type InjectFlags = InjectOptions;
 
 export interface InjectorLike {
   get<T>(token: Token<T>, options?: InjectFlags): T | undefined;
+  get<T>(token: Token<T>, notFoundValue: T, options?: InjectFlags): T;
   readonly parent?: InjectorLike;
 }
 
 let currentInjector: InjectorLike | null = null;
 
-/**
- * Returns the current active Injector context, or null if not inside an injection context.
- */
 export function getActiveInjector(): InjectorLike | null {
   return currentInjector;
 }
 
 /**
- * Built-in injection token for resolving the active injector instance.
- * Modeled directly after Angular's INJECTOR token.
+ * Compatibility token backed by Angular's public Injector token.
+ * The compiler does not use this token; it is provided for runtime/TestBed APIs.
  */
 export const INJECTOR = new InjectionToken<InjectorLike>("supacloud.injector", {
   scope: "application",
-  factory: () => {
-    const active = getActiveInjector();
-    if (!active) {
-      throw new Error("Cannot resolve INJECTOR outside of an active injection context.");
-    }
-    return active;
-  },
+  factory: () => adaptInjector(angularInject(AngularInjector)),
 });
 
-/**
- * Executes a function within the scope of a specific injector.
- * Modeled directly after Angular's `runInInjectionContext(injector, fn)`.
- */
 export function runInInjectionContext<R>(injector: InjectorLike, fn: () => R): R {
-  const prev = currentInjector;
+  const previous = currentInjector;
   currentInjector = injector;
   try {
-    return fn();
+    return angularRunInInjectionContext(injector as AngularInjector, fn);
   } finally {
-    currentInjector = prev;
+    currentInjector = previous;
   }
 }
 
 /**
- * Resolves a token from the currently active injection context.
- * Modeled directly after Angular's `inject(token)`.
- *
- * Can be used in:
- * 1. Property initializers of classes
- * 2. Constructors
- * 3. Functional route guards (CanActivateFn)
- * 4. Route resolvers (ResolveFn)
- * 5. Factory providers
- * 6. Code executed inside `runInInjectionContext`
+ * Angular is the source of truth for runtime injection semantics. This
+ * wrapper keeps the SupaCloud error contract for calls outside a context.
  */
 export function inject<T>(token: Token<T>, options?: InjectFlags): T {
-  if (!currentInjector) {
-    throw new Error(
-      `inject() can only be used within an active injection context (constructor, factory, guard, or runInInjectionContext). Token: ${tokenToString(token)}`,
-    );
-  }
-
-  const resolved = resolveForwardRef(token);
-  let value: unknown;
-
-  if (options?.skipSelf) {
-    if (!currentInjector.parent) {
-      if (options.optional) return undefined as unknown as T;
-      throw new Error(`NullInjectorError: No parent provider found for skipSelf token ${tokenToString(resolved)}`);
+  try {
+    const value = options === undefined
+      ? angularInject(token as never)
+      : angularInject(token as never, options);
+    if (value !== undefined && value !== null) return value as T;
+    if (
+      token instanceof InjectionToken &&
+      token.factory &&
+      !options?.self &&
+      !options?.skipSelf
+    ) {
+      return token.factory() as T;
     }
-    value = currentInjector.parent.get(resolved, options);
-  } else {
-    value = currentInjector.get(resolved, options);
-  }
-
-  if (value === undefined) {
-    if (options?.optional) {
-      return undefined as unknown as T;
+    return undefined as T;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      /NG0201|No provider found/i.test(error.message) &&
+      token instanceof InjectionToken &&
+      token.factory &&
+      !options?.self &&
+      !options?.skipSelf
+    ) {
+      return token.factory() as T;
     }
-    if (resolved instanceof InjectionToken && resolved.factory && !options?.self && !options?.skipSelf) {
-      return resolved.factory();
+    if (error instanceof Error && /NG0203|injection context/i.test(error.message)) {
+      throw new Error(
+        `inject() can only be used within an active injection context (constructor, factory, guard, or runInInjectionContext). Token: ${tokenToString(token)}`,
+      );
     }
-    throw new Error(`NullInjectorError: No provider for ${tokenToString(resolved)}`);
+    if (error instanceof Error && /NG0201|No provider found/i.test(error.message)) {
+      throw new Error(`NullInjectorError: No provider for ${tokenToString(token)}`);
+    }
+    throw error;
   }
-  return value as T;
 }
 
-/**
- * Injects all instances registered for a multi-provider token.
- * Modeled after Angular's multi-provider injection.
- */
 export function injectAll<T>(token: Token<T>): T[] {
   const value = inject<T | T[]>(token, { optional: true });
   if (value === undefined) return [];
   return Array.isArray(value) ? value : [value];
 }
 
-/**
- * Creates a hierarchical child injector that inherits providers from a parent injector.
- * Modeled directly after Angular's hierarchical injectors.
- */
 export function createChildInjector(
   parent: InjectorLike,
   localProviders: Map<Token<unknown> | string, unknown> | Record<string, unknown> = new Map(),
 ): InjectorLike & { readonly parent: InjectorLike } {
-  const providerMap = localProviders instanceof Map
-    ? (localProviders as Map<Token<unknown> | string, unknown>)
-    : new Map<Token<unknown> | string, unknown>(Object.entries(localProviders));
-
+  const entries = localProviders instanceof Map
+    ? [...localProviders.entries()]
+    : Object.entries(localProviders);
+  const child = AngularInjector.create({
+    parent: parent as AngularInjector,
+    providers: entries.map(([token, value]) => ({ provide: token, useValue: value })),
+  });
   return {
     parent,
-    get<T>(token: Token<T>, options?: InjectFlags): T | undefined {
-      const resolved = resolveForwardRef(token);
-      if (providerMap.has(resolved)) {
-        return providerMap.get(resolved) as T;
+    get<T>(token: Token<T>, notFoundOrOptions?: T | InjectFlags, maybeOptions?: InjectFlags): T | undefined {
+      if (isInjectOptions(notFoundOrOptions)) {
+        const value = child.get(token as never, undefined, notFoundOrOptions);
+        return (value === null ? undefined : value) as T | undefined;
       }
-      if (resolved instanceof InjectionToken && providerMap.has(resolved.name)) {
-        return providerMap.get(resolved.name) as T;
-      }
-      if (options?.self) {
-        return undefined;
-      }
-      return parent.get(resolved);
+      const value = child.get(token as never, notFoundOrOptions, maybeOptions);
+      return (value === null ? undefined : value) as T | undefined;
     },
   };
 }
 
-/**
- * Asserts that execution is currently within an injection context.
- * Modeled after Angular's `assertInInjectionContext`.
- */
 export function assertInInjectionContext(fnName: string): void {
-  if (!currentInjector) {
+  try {
+    angularAssertInInjectionContext(() => undefined);
+  } catch {
     throw new Error(`${fnName} must be called from an active injection context.`);
   }
 }
 
-/**
- * Injects the AbortSignal of the active DestroyRef.
- * Automatically aborted when the active context or service is destroyed.
- * Modeled after Angular's DestroyRef signal pattern.
- */
 export function injectDestroySignal(): AbortSignal {
   const ref = inject(DESTROY_REF);
   if (ref.signal) return ref.signal;
   throw new Error("Active DestroyRef does not provide an AbortSignal");
 }
 
-function tokenToString(token: Token<any>): string {
+function tokenToString(token: Token<unknown>): string {
   if (typeof token === "string") return token;
   if (token instanceof InjectionToken) return token.toString();
   if (typeof token === "function") return token.name || "AnonymousClass";
@@ -180,202 +150,102 @@ export interface EnvironmentInjector extends InjectorLike {
 }
 
 /**
- * Creates an EnvironmentInjector with an isolated dependency scope and lifecycle.
- * Modeled directly after Angular 14+ createEnvironmentInjector.
- * Automatically executes all ENVIRONMENT_INITIALIZER / APP_INITIALIZER hooks upon creation,
- * and executes DestroyRef teardowns and OnDestroy hooks upon destroy().
+ * Runtime compatibility adapter over Angular's public EnvironmentInjector.
+ * SupaCloud EnvironmentProviders are flattened before crossing the boundary;
+ * no Angular private ɵ API is referenced.
  */
 export function createEnvironmentInjector(
   providers: Array<Provider | EnvironmentProviders>,
   parent?: InjectorLike,
 ): EnvironmentInjector {
-  let isDestroyed = false;
-  const flatProviders = flattenProviders(providers);
-  const effectiveProviders = new Map<Token<unknown>, Provider>();
-  const multiProviders = new Map<Token<unknown>, Provider[]>();
-  const instances = new Map<Token<unknown> | string, unknown>();
-
-  // Create isolated destroyRef for this environment injector
-  const localDestroyRef = createDestroyRef();
-  instances.set(DESTROY_REF, localDestroyRef);
-
-  for (const p of flatProviders) {
-    const token = typeof p === "function" ? resolveForwardRef(p) : resolveForwardRef(p.provide);
-    if (typeof p !== "function" && p.multi) {
-      const list = multiProviders.get(token) ?? [];
-      list.push(p);
-      multiProviders.set(token, list);
-    } else {
-      effectiveProviders.set(token, p);
-    }
-  }
-
-  const injector: EnvironmentInjector = {
+  let adapter: EnvironmentInjector;
+  const runtime = angularCreateEnvironmentInjector(
+    [
+      {
+        provide: DESTROY_REF,
+        useFactory: () => angularInject(AngularDestroyRef),
+      },
+      {
+        provide: INJECTOR,
+        useFactory: () => adapter,
+      },
+      ...flattenProviders(providers),
+    ] as AngularProvider[],
+    parent as AngularEnvironmentInjector,
+    "supacloud",
+  );
+  adapter = {
     parent,
     get destroyed() {
-      return isDestroyed;
-    },
-    runInContext<R>(fn: () => R): R {
-      if (isDestroyed) {
-        throw new Error("EnvironmentInjector has already been destroyed.");
-      }
-      return runInInjectionContext(injector, fn);
-    },
-    destroy(): void {
-      if (isDestroyed) return;
-      isDestroyed = true;
-      void localDestroyRef.destroy();
-      for (const inst of instances.values()) {
-        if (inst && typeof inst === "object" && inst !== localDestroyRef) {
-          if ("onDestroy" in inst && typeof (inst as any).onDestroy === "function") {
-            try {
-              (inst as any).onDestroy();
-            } catch (err) {
-              console.error("Error in onDestroy hook:", err);
-            }
-          }
-          if ("ngOnDestroy" in inst && typeof (inst as any).ngOnDestroy === "function") {
-            try {
-              (inst as any).ngOnDestroy();
-            } catch (err) {
-              console.error("Error in ngOnDestroy hook:", err);
-            }
-          }
-        }
-      }
-      instances.clear();
+      return runtime.destroyed;
     },
     get<T>(token: Token<T>, notFoundOrOptions?: T | InjectFlags, maybeOptions?: InjectFlags): T {
-      if (isDestroyed) {
-        throw new Error("EnvironmentInjector has already been destroyed.");
-      }
-      let notFoundValue: T | undefined = undefined;
-      let flags: InjectFlags | undefined = undefined;
-
-      if (
-        notFoundOrOptions !== undefined &&
-        (typeof notFoundOrOptions !== "object" ||
-          notFoundOrOptions === null ||
-          (!("optional" in notFoundOrOptions) &&
-            !("skipSelf" in notFoundOrOptions) &&
-            !("self" in notFoundOrOptions) &&
-            !("host" in notFoundOrOptions)))
-      ) {
-        notFoundValue = notFoundOrOptions as T;
-        flags = maybeOptions;
-      } else if (notFoundOrOptions && typeof notFoundOrOptions === "object") {
-        flags = notFoundOrOptions as InjectFlags;
-      }
-
-      const resolved = resolveForwardRef(token);
-
-      if (flags?.skipSelf) {
-        if (!parent) {
-          if (flags.optional) return undefined as unknown as T;
-          if (notFoundValue !== undefined) return notFoundValue;
-          throw new Error(`NullInjectorError: No parent provider found for skipSelf token ${tokenToString(resolved)}`);
+      try {
+        if (isInjectOptions(notFoundOrOptions)) {
+          const value = runtime.get(token as never, undefined, notFoundOrOptions);
+          return (value === null ? undefined : value) as T;
         }
-        const val = parent.get(resolved, flags);
-        if (val === undefined && notFoundValue !== undefined) return notFoundValue;
-        return val as T;
-      }
-
-      if (instances.has(resolved)) {
-        return instances.get(resolved) as T;
-      }
-      if (resolved instanceof InjectionToken && instances.has(resolved.name)) {
-        return instances.get(resolved.name) as T;
-      }
-
-      if (multiProviders.has(resolved)) {
-        const provs = multiProviders.get(resolved)!;
-        const results = provs.map((prov) => {
-          if (isValueProvider(prov)) return prov.useValue;
-          if (isFactoryProvider(prov)) return runInInjectionContext(injector, () => prov.useFactory());
-          if (isClassProvider(prov)) return runInInjectionContext(injector, () => new (prov.useClass as Type<any>)());
-          if (isExistingProvider(prov)) return injector.get(prov.useExisting);
-          return undefined;
-        });
-        instances.set(resolved, results);
-        if (resolved instanceof InjectionToken) {
-          instances.set(resolved.name, results);
-        }
-        return results as unknown as T;
-      }
-
-      const provider = effectiveProviders.get(resolved);
-      if (!provider) {
-        if (flags?.self) {
-          if (flags.optional) return undefined as unknown as T;
-          if (notFoundValue !== undefined) return notFoundValue;
-          throw new Error(`NullInjectorError: No local provider for ${tokenToString(resolved)}`);
-        }
-        if (parent) {
-          const fromParent = parent.get(resolved, flags);
-          if (fromParent !== undefined) return fromParent as T;
-        }
-        if (flags?.optional) return undefined as unknown as T;
-        if (notFoundValue !== undefined) return notFoundValue;
-        if (resolved instanceof InjectionToken && resolved.factory && !flags?.self && !flags?.skipSelf) {
-          const inst = resolved.factory();
-          instances.set(resolved, inst);
-          return inst;
-        }
-        if (typeof resolved === "function") {
-          try {
-            const inst = new (resolved as Type<T>)();
-            instances.set(resolved, inst);
-            return inst;
-          } catch {
-            // not a zero-arg constructor
+        const value = runtime.get(token as never, notFoundOrOptions, maybeOptions);
+        return (value === null ? undefined : value) as T;
+      } catch (error) {
+        if (error instanceof Error && /NG0201|No provider found/i.test(error.message)) {
+          if (
+            token instanceof InjectionToken &&
+            token.factory &&
+            !maybeOptions?.self &&
+            !maybeOptions?.skipSelf
+          ) {
+            return runInInjectionContext(adapter, token.factory) as T;
           }
+          throw new Error(`NullInjectorError: No provider for ${tokenToString(token)}`);
         }
-        throw new Error(`NullInjectorError: No provider for ${tokenToString(resolved)}`);
+        throw error;
       }
-
-      let created: unknown;
-      if (typeof provider === "function") {
-        created = runInInjectionContext(injector, () => new (provider as Type<any>)());
-      } else if (isValueProvider(provider)) {
-        created = provider.useValue;
-      } else if (isFactoryProvider(provider)) {
-        created = runInInjectionContext(injector, () => provider.useFactory());
-      } else if (isClassProvider(provider)) {
-        created = runInInjectionContext(injector, () => new (provider.useClass as Type<any>)());
-      } else if (isExistingProvider(provider)) {
-        created = injector.get(provider.useExisting);
-      }
-
-      instances.set(resolved, created);
-      return created as T;
+    },
+    runInContext<R>(fn: () => R): R {
+      return runInInjectionContext(adapter, fn);
+    },
+    destroy(): void {
+      runtime.destroy();
     },
   };
-  instances.set(INJECTOR, injector);
 
-  // Run all ENVIRONMENT_INITIALIZER / APP_INITIALIZER tokens automatically upon creation
-  const envInitializers = injector.get(ENVIRONMENT_INITIALIZER, { optional: true });
-  const seenInits = new Set<unknown>();
-  if (Array.isArray(envInitializers)) {
-    for (const init of envInitializers) {
-      if (typeof init === "function") {
-        seenInits.add(init);
-        runInInjectionContext(injector, () => {
-          void init();
-        });
-      }
+  runInitializers(adapter, ENVIRONMENT_INITIALIZER);
+  runInitializers(adapter, APP_INITIALIZER);
+  return adapter;
+}
+
+function runInitializers(
+  injector: EnvironmentInjector,
+  token: Token<() => void | Promise<void>>,
+): void {
+  const initializers = injector.get(token, { optional: true }) as unknown;
+  if (!Array.isArray(initializers)) return;
+  for (const initializer of initializers) {
+    if (typeof initializer === "function") {
+      void injector.runInContext(() => initializer());
     }
   }
-  const appInitializers = injector.get(APP_INITIALIZER, { optional: true });
-  if (Array.isArray(appInitializers)) {
-    for (const init of appInitializers) {
-      if (typeof init === "function" && !seenInits.has(init)) {
-        seenInits.add(init);
-        runInInjectionContext(injector, () => {
-          void init();
-        });
-      }
-    }
-  }
+}
 
-  return injector;
+function isInjectOptions(value: unknown): value is InjectFlags {
+  return typeof value === "object" && value !== null && (
+    "optional" in value ||
+    "self" in value ||
+    "skipSelf" in value ||
+    "host" in value
+  );
+}
+
+function adaptInjector(injector: AngularInjector): InjectorLike {
+  return {
+    get<T>(token: Token<T>, notFoundOrOptions?: T | InjectFlags, maybeOptions?: InjectFlags): T | undefined {
+      if (isInjectOptions(notFoundOrOptions)) {
+        const value = injector.get(token as never, undefined, notFoundOrOptions);
+        return (value === null ? undefined : value) as T | undefined;
+      }
+      const value = injector.get(token as never, notFoundOrOptions, maybeOptions);
+      return (value === null ? undefined : value) as T | undefined;
+    },
+  };
 }

--- a/packages/app/src/inject.ts
+++ b/packages/app/src/inject.ts
@@ -9,9 +9,18 @@ import {
   type InjectOptions,
   type Provider as AngularProvider,
 } from "@angular/core";
-import type { EnvironmentProviders, Provider, Token } from "./provider";
-import { flattenProviders } from "./provider";
+import type { EnvironmentProviders, Provider, ProviderDep, ProviderDependency, Token, Type } from "./provider";
+import { flattenProviders, isClassProvider, isFactoryProvider } from "./provider";
 import { APP_INITIALIZER, DESTROY_REF, ENVIRONMENT_INITIALIZER } from "./context";
+import {
+  getInjectableMeta,
+  getInjectParams,
+  getOptionalParams,
+  getSelfParams,
+  getSkipSelfParams,
+  getHostParams,
+} from "./decorators";
+import { resolveForwardRef } from "./forward_ref";
 import { InjectionToken } from "./token";
 
 export type InjectFlags = InjectOptions;
@@ -65,7 +74,8 @@ export function inject<T>(token: Token<T>, options?: InjectFlags): T {
     ) {
       return token.factory() as T;
     }
-    return undefined as T;
+    if (options?.optional) return undefined as T;
+    throw new Error(`NullInjectorError: No provider for ${tokenToString(token)}`);
   } catch (error) {
     if (
       error instanceof Error &&
@@ -159,6 +169,60 @@ export function createEnvironmentInjector(
   parent?: InjectorLike,
 ): EnvironmentInjector {
   let adapter: EnvironmentInjector;
+  const trackedInstances: unknown[] = [];
+  const track = (value: unknown): unknown => {
+    if (value && typeof value === "object" && !trackedInstances.includes(value)) {
+      trackedInstances.push(value);
+    }
+    return value;
+  };
+  const instantiate = (type: Type<unknown>, explicitDeps?: unknown[]): unknown => {
+    const dependencies = explicitDeps ?? resolveClassDependencies(type);
+    return track(new type(...dependencies));
+  };
+  const normalizedProviders: AngularProvider[] = flattenProviders(providers).map((provider) => {
+    if (typeof provider === "function") {
+      const type = resolveForwardRef(provider);
+      return {
+        provide: type,
+        useFactory: () => instantiate(type as Type<unknown>),
+      };
+    }
+    if (isClassProvider(provider)) {
+      const type = resolveForwardRef(provider.useClass) as Type<unknown>;
+      const dependencies = provider.deps ?? [];
+      const hasDescriptors = dependencies.some((dependency) => isProviderDependency(dependency));
+      return {
+        provide: provider.provide,
+        useFactory: (...deps: unknown[]) => instantiate(
+          type,
+          hasDescriptors
+            ? dependencies.map((dependency) => resolveProviderDependency(dependency))
+            : deps,
+        ),
+        deps: hasDescriptors
+          ? undefined
+          : dependencies as unknown as never[],
+      };
+    }
+    if (isFactoryProvider(provider)) {
+      const dependencies = provider.deps ?? [];
+      const hasDescriptors = dependencies.some((dependency) => isProviderDependency(dependency));
+      if (hasDescriptors) {
+        return {
+          provide: provider.provide,
+          useFactory: () => track(provider.useFactory(
+            ...dependencies.map((dependency) => resolveProviderDependency(dependency)),
+          )),
+        };
+      }
+      return {
+        ...provider,
+        useFactory: (...deps: unknown[]) => track(provider.useFactory(...deps)),
+      } as AngularProvider;
+    }
+    return provider as AngularProvider;
+  });
   const runtime = angularCreateEnvironmentInjector(
     [
       {
@@ -169,7 +233,7 @@ export function createEnvironmentInjector(
         provide: INJECTOR,
         useFactory: () => adapter,
       },
-      ...flattenProviders(providers),
+      ...normalizedProviders,
     ] as AngularProvider[],
     parent as AngularEnvironmentInjector,
     "supacloud",
@@ -203,10 +267,22 @@ export function createEnvironmentInjector(
       }
     },
     runInContext<R>(fn: () => R): R {
+      if (runtime.destroyed) {
+        throw new Error("EnvironmentInjector has already been destroyed.");
+      }
       return runInInjectionContext(adapter, fn);
     },
     destroy(): void {
       runtime.destroy();
+      for (const instance of [...trackedInstances].reverse()) {
+        if (!instance || typeof instance !== "object") continue;
+        const candidate = instance as {
+          onDestroy?: () => void | Promise<void>;
+          ngOnDestroy?: () => void | Promise<void>;
+        };
+        const hook = candidate.onDestroy ?? candidate.ngOnDestroy;
+        if (hook) void hook.call(instance);
+      }
     },
   };
 
@@ -226,6 +302,57 @@ function runInitializers(
       void injector.runInContext(() => initializer());
     }
   }
+}
+
+function resolveClassDependencies(type: Type<unknown>): unknown[] {
+  const metadata = getInjectableMeta(type);
+  const indexed = new Map<number, ProviderDep>();
+  if (metadata?.deps) {
+    metadata.deps.forEach((dependency, index) => {
+      indexed.set(index, dependency);
+    });
+  }
+  for (const [index, token] of Object.entries(getInjectParams(type))) {
+    indexed.set(Number(index), token);
+  }
+  if (indexed.size === 0) return [];
+  const optional = new Set(getOptionalParams(type));
+  const self = new Set(getSelfParams(type));
+  const skipSelf = new Set(getSkipSelfParams(type));
+  const host = new Set(getHostParams(type));
+  const maxIndex = Math.max(...indexed.keys());
+  return Array.from({ length: maxIndex + 1 }, (_, index) => {
+    const dependency = indexed.get(index);
+    if (!dependency) return undefined;
+    const token = isProviderDependency(dependency) ? dependency.token : dependency;
+    const descriptor = isProviderDependency(dependency) ? dependency : undefined;
+    const options: InjectFlags = {
+      optional: descriptor?.optional ?? optional.has(index),
+      self: descriptor?.self ?? self.has(index),
+      skipSelf: descriptor?.skipSelf ?? skipSelf.has(index),
+      host: descriptor?.host ?? host.has(index),
+    };
+    const resolved = resolveForwardRef(token);
+    return options.optional || options.self || options.skipSelf || options.host
+      ? angularInject(resolved as never, options)
+      : angularInject(resolved as never);
+  });
+}
+
+function resolveProviderDependency(dependency: ProviderDep): unknown {
+  const descriptor: ProviderDependency = isProviderDependency(dependency)
+    ? dependency
+    : { token: dependency };
+  const { token, optional, self, skipSelf, host } = descriptor;
+  const options: InjectFlags = { optional, self, skipSelf, host };
+  const resolved = resolveForwardRef(token);
+  return optional || self || skipSelf || host
+    ? angularInject(resolved as never, options)
+    : angularInject(resolved as never);
+}
+
+function isProviderDependency(value: unknown): value is ProviderDependency {
+  return typeof value === "object" && value !== null && "token" in value;
 }
 
 function isInjectOptions(value: unknown): value is InjectFlags {

--- a/packages/app/src/provider.ts
+++ b/packages/app/src/provider.ts
@@ -11,6 +11,16 @@ export interface Type<T> {
 /** Anything that can identify a provider: an InjectionToken or a class. */
 export type Token<T = any> = InjectionToken<T> | Type<T> | ForwardRefFn<InjectionToken<T> | Type<T>>;
 
+export interface ProviderDependency {
+  token: Token;
+  optional?: boolean;
+  self?: boolean;
+  skipSelf?: boolean;
+  host?: boolean;
+}
+
+export type ProviderDep = Token | ProviderDependency;
+
 interface BaseProvider {
   /** Overrides the scope derived from @Injectable / token defaults. */
   scope?: Scope;
@@ -24,7 +34,7 @@ export interface ClassProvider<T = any> extends BaseProvider {
   provide: Token<T>;
   useClass: Type<T> | ForwardRefFn<Type<T>>;
   /** Explicit dependency tokens, positional (constructor order). */
-  deps?: Token[];
+  deps?: ProviderDep[];
 }
 
 export interface ValueProvider<T = any> extends BaseProvider {
@@ -35,7 +45,7 @@ export interface ValueProvider<T = any> extends BaseProvider {
 export interface FactoryProvider<T = any> extends BaseProvider {
   provide: Token<T>;
   useFactory: (...deps: any[]) => T;
-  deps?: Token[];
+  deps?: ProviderDep[];
 }
 
 export interface ExistingProvider<T = any> extends BaseProvider {
@@ -72,10 +82,12 @@ export function isExistingProvider<T>(provider: Provider<T>): provider is Existi
  * Modeled directly after Angular's EnvironmentProviders.
  */
 export interface EnvironmentProviders {
-  ɵproviders: Provider[];
+  ɵproviders: Array<Provider | EnvironmentProviders>;
 }
 
-export function makeEnvironmentProviders(providers: Provider[]): EnvironmentProviders {
+export function makeEnvironmentProviders(
+  providers: Array<Provider | EnvironmentProviders>,
+): EnvironmentProviders {
   return { ɵproviders: providers };
 }
 
@@ -87,7 +99,7 @@ export function flattenProviders(providers: Array<Provider | EnvironmentProvider
   const result: Provider[] = [];
   for (const p of providers) {
     if (isEnvironmentProviders(p)) {
-      result.push(...p.ɵproviders);
+      result.push(...flattenProviders(p.ɵproviders));
     } else {
       result.push(p);
     }

--- a/packages/app/src/testing.ts
+++ b/packages/app/src/testing.ts
@@ -1,8 +1,14 @@
-import type { EnvironmentProviders, Provider, Token, Type } from "./provider";
-import { flattenProviders, isClassProvider, isExistingProvider, isFactoryProvider, isValueProvider } from "./provider";
-import { INJECTOR, injectAll, runInInjectionContext, type InjectFlags, type InjectorLike } from "./inject";
+import type { EnvironmentProviders, Provider, Token } from "./provider";
+import { flattenProviders } from "./provider";
+import {
+  createEnvironmentInjector,
+  injectAll,
+  runInInjectionContext,
+  type EnvironmentInjector,
+  type InjectFlags,
+  type InjectorLike,
+} from "./inject";
 import { resolveForwardRef } from "./forward_ref";
-import { InjectionToken } from "./token";
 
 export interface TestModuleMetadata {
   providers?: Array<Provider | EnvironmentProviders>;
@@ -16,8 +22,7 @@ export interface TestModuleMetadata {
 export class TestBed {
   private static declaredProviders: Provider[] = [];
   private static overriddenProviders = new Map<Token<unknown>, Provider>();
-  private static activeInjector: InjectorLike | null = null;
-  private static instances = new Map<Token<unknown> | string, unknown>();
+  private static activeInjector: EnvironmentInjector | null = null;
 
   /**
    * Configures the testing module with providers and imports.
@@ -41,6 +46,7 @@ export class TestBed {
    */
   static overrideProvider(token: Token<unknown>, provider: Provider): typeof TestBed {
     TestBed.overriddenProviders.set(resolveForwardRef(token), provider);
+    TestBed.activeInjector?.destroy();
     TestBed.activeInjector = null;
     return TestBed;
   }
@@ -52,7 +58,17 @@ export class TestBed {
     const injector = TestBed.getOrCreateInjector();
     return runInInjectionContext(injector, () => {
       const resolved = resolveForwardRef(token);
-      const val = injector.get(resolved, flags);
+      let val: T | undefined;
+      try {
+        val = injector.get(resolved, flags);
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.startsWith("NullInjectorError:")) {
+          throw error;
+        }
+        if (notFoundValue !== undefined) return notFoundValue;
+        if (flags?.optional) return undefined as unknown as T;
+        throw new Error(`TestBed: No provider found for token ${String(resolved)}`);
+      }
       if (val === undefined) {
         if (notFoundValue !== undefined) return notFoundValue;
         if (flags?.optional) return undefined as unknown as T;
@@ -84,108 +100,28 @@ export class TestBed {
    * Resets the testing environment, clearing providers, mocks, and instantiated singletons.
    */
   static resetTestingModule(): typeof TestBed {
+    TestBed.activeInjector?.destroy();
     TestBed.declaredProviders = [];
     TestBed.overriddenProviders.clear();
     TestBed.activeInjector = null;
-    TestBed.instances.clear();
     return TestBed;
   }
 
-  private static getOrCreateInjector(): InjectorLike {
+  private static getOrCreateInjector(): EnvironmentInjector {
     if (TestBed.activeInjector) return TestBed.activeInjector;
 
-    const effectiveProviders = new Map<Token<unknown>, Provider>();
-    const multiProviders = new Map<Token<unknown>, Provider[]>();
-
-    for (const p of TestBed.declaredProviders) {
-      const token = typeof p === "function" ? resolveForwardRef(p) : resolveForwardRef(p.provide);
-      if (typeof p !== "function" && p.multi) {
-        const list = multiProviders.get(token) ?? [];
-        list.push(p);
-        multiProviders.set(token, list);
-      } else {
-        effectiveProviders.set(token, p);
+    const effectiveProviders = [...TestBed.declaredProviders];
+    for (const [token, provider] of TestBed.overriddenProviders) {
+      for (let index = effectiveProviders.length - 1; index >= 0; index -= 1) {
+        const existing = effectiveProviders[index];
+        const existingToken = typeof existing === "function"
+          ? resolveForwardRef(existing)
+          : resolveForwardRef(existing.provide);
+        if (existingToken === token) effectiveProviders.splice(index, 1);
       }
+      effectiveProviders.push(provider);
     }
-    for (const [token, p] of TestBed.overriddenProviders) {
-      if (typeof p !== "function" && p.multi) {
-        const list = multiProviders.get(token) ?? [];
-        list.push(p);
-        multiProviders.set(token, list);
-      } else {
-        effectiveProviders.set(token, p);
-        multiProviders.delete(token);
-      }
-    }
-
-    const instances = TestBed.instances;
-
-    const rootInjector: InjectorLike = {
-      get<T>(token: Token<T>, flags?: InjectFlags): T | undefined {
-        const resolved = resolveForwardRef(token);
-        if (instances.has(resolved)) {
-          return instances.get(resolved) as T;
-        }
-        if (resolved instanceof InjectionToken && instances.has(resolved.name)) {
-          return instances.get(resolved.name) as T;
-        }
-
-        if (multiProviders.has(resolved)) {
-          const providers = multiProviders.get(resolved)!;
-          const results = providers.map((prov) => {
-            if (isValueProvider(prov)) return prov.useValue;
-            if (isFactoryProvider(prov)) return runInInjectionContext(rootInjector, () => prov.useFactory());
-            if (isClassProvider(prov)) return runInInjectionContext(rootInjector, () => new (prov.useClass as Type<any>)());
-            if (isExistingProvider(prov)) return rootInjector.get(prov.useExisting);
-            return undefined;
-          });
-          instances.set(resolved, results);
-          if (resolved instanceof InjectionToken) {
-            instances.set(resolved.name, results);
-          }
-          return results as unknown as T;
-        }
-
-        const provider = effectiveProviders.get(resolved);
-        if (!provider) {
-          if (flags?.optional) return undefined;
-          if (resolved instanceof InjectionToken && resolved.factory) {
-            const inst = resolved.factory();
-            instances.set(resolved, inst);
-            return inst;
-          }
-          if (typeof resolved === "function") {
-            try {
-              const inst = new (resolved as Type<T>)();
-              instances.set(resolved, inst);
-              return inst;
-            } catch {
-              return undefined;
-            }
-          }
-          return undefined;
-        }
-
-        let created: unknown;
-        if (typeof provider === "function") {
-          created = runInInjectionContext(rootInjector, () => new (provider as Type<any>)());
-        } else if (isValueProvider(provider)) {
-          created = provider.useValue;
-        } else if (isFactoryProvider(provider)) {
-          created = runInInjectionContext(rootInjector, () => provider.useFactory());
-        } else if (isClassProvider(provider)) {
-          created = runInInjectionContext(rootInjector, () => new (provider.useClass as Type<any>)());
-        } else if (isExistingProvider(provider)) {
-          created = rootInjector.get(provider.useExisting);
-        }
-
-        instances.set(resolved, created);
-        return created as T;
-      },
-    };
-
-    TestBed.activeInjector = rootInjector;
-    instances.set(INJECTOR, rootInjector);
-    return rootInjector;
+    TestBed.activeInjector = createEnvironmentInjector(effectiveProviders);
+    return TestBed.activeInjector;
   }
 }

--- a/packages/app/src/token.ts
+++ b/packages/app/src/token.ts
@@ -1,4 +1,5 @@
 import type { Scope } from "./scope";
+import { InjectionToken as AngularInjectionToken } from "@angular/core";
 
 export interface InjectionTokenOptions<T> {
   /** Optional default factory used when no explicit provider is registered. */
@@ -13,13 +14,21 @@ export interface InjectionTokenOptions<T> {
  * Lightweight injection token, modeled after Angular's tree-shakable tokens.
  * Used as a DI key for interfaces and values that are not classes.
  */
-export class InjectionToken<T> {
+export class InjectionToken<T> extends AngularInjectionToken<T> {
   readonly name: string;
   readonly factory?: () => T;
   readonly providedIn?: "root";
   readonly scope?: Scope;
 
   constructor(name: string, options: InjectionTokenOptions<T> = {}) {
+    if (options.factory) {
+      super(name, {
+        providedIn: options.providedIn ?? null,
+        factory: options.factory,
+      });
+    } else {
+      super(name);
+    }
     this.name = name;
     this.factory = options.factory;
     this.providedIn = options.providedIn;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,6 +12,13 @@ npm install -g @supacloud/cli
 supacloud-cli status
 ```
 
+Bun users can run the same package explicitly with Bun, including on Windows,
+without installing Node.js or a separate wrapper:
+
+```bash
+bunx --bun --package @supacloud/cli supacloud-cli status
+```
+
 One-off execution:
 
 ```bash

--- a/packages/cli/bun.lock
+++ b/packages/cli/bun.lock
@@ -6,7 +6,7 @@
       "name": "@supacloud/cli",
       "dependencies": {
         "@sinclair/typebox": "^0.34.52",
-        "@supacloud/compiler": "^0.2.0",
+        "@supacloud/compiler": "file:../../packages/compiler",
         "@supacloud/db": "^0.2.0",
         "fflate": "^0.8.3",
       },
@@ -17,23 +17,17 @@
     },
   },
   "packages": {
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/compiler": ["@supacloud/compiler@0.2.0", "https://registry.npmmirror.com/@supacloud/compiler/-/compiler-0.2.0.tgz", { "dependencies": { "ts-morph": "^26.0.0" } }, "sha512-LJzWsSkNKmrd/mgXp7N83LEkagWDjbIS6R3i4uwszQ/Ouf1pPi22u9Db/5Qg0ET/n/0fV/FP8UxFvZ/zY4JxGQ=="],
+    "@supacloud/compiler": ["@supacloud/compiler@file:../compiler", { "dependencies": { "@typescript/typescript6": "^6.0.2" }, "devDependencies": { "@types/bun": "^1.4.0", "typescript": "^7.0.2" }, "bin": { "supacloud-compiler": "./dist/cli.js" } }],
 
     "@supacloud/db": ["@supacloud/db@0.2.0", "https://registry.npmmirror.com/@supacloud/db/-/db-0.2.0.tgz", {}, "sha512-rJKMCJqMZf4oQ+x9bOnCoYO6REQqwIcSEwugPjvMfoiCbBo7vhkpytKWfj60UJJl0IJIUjmIZMu4xI2U2Okigg=="],
-
-    "@ts-morph/common": ["@ts-morph/common@0.27.0", "https://registry.npmmirror.com/@ts-morph/common/-/common-0.27.0.tgz", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/old": ["typescript@6.0.3", "https://registry.npmmirror.com/typescript/-/typescript-6.0.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -75,51 +69,11 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "brace-expansion": ["brace-expansion@5.0.9", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
-
-    "braces": ["braces@3.0.3", "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+    "@typescript/typescript6": ["@typescript/typescript6@6.0.2", "https://registry.npmmirror.com/@typescript/typescript6/-/typescript6-6.0.2.tgz", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
-    "code-block-writer": ["code-block-writer@13.0.3", "https://registry.npmmirror.com/code-block-writer/-/code-block-writer-13.0.3.tgz", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
-
-    "fast-glob": ["fast-glob@3.3.3", "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fastq": ["fastq@1.20.3", "https://registry.npmmirror.com/fastq/-/fastq-1.20.3.tgz", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw=="],
-
     "fflate": ["fflate@0.8.3", "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
-
-    "fill-range": ["fill-range@7.1.1", "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "glob-parent": ["glob-parent@5.1.2", "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "is-extglob": ["is-extglob@2.1.1", "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-glob": ["is-glob@4.0.3", "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
-    "is-number": ["is-number@7.0.0", "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "merge2": ["merge2@1.4.1", "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromatch": ["micromatch@4.0.8", "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "minimatch": ["minimatch@10.2.6", "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.6.tgz", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
-
-    "path-browserify": ["path-browserify@1.0.1", "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
-    "picomatch": ["picomatch@2.3.2", "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.2.tgz", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "reusify": ["reusify@1.1.0", "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "ts-morph": ["ts-morph@26.0.0", "https://registry.npmmirror.com/ts-morph/-/ts-morph-26.0.0.tgz", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.52",
-    "@supacloud/compiler": "^0.2.0",
+    "@supacloud/compiler": "file:../../packages/compiler",
     "@supacloud/db": "^0.2.0",
     "fflate": "^0.8.3"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target node",
+    "pretypecheck": "bun install --cwd ../compiler --frozen-lockfile && bun run --cwd ../compiler build && bun install --frozen-lockfile",
     "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -162,6 +162,24 @@ describe("supacloud-cli process contract", () => {
         expect(build.exitCode).toBe(0);
         const builtEntry = join(buildDirectory, "index.js");
         expect(readFileSync(builtEntry, "utf8").split("\n", 1)[0]).toBe("#!/usr/bin/env node");
+
+        const bunPath = join(sandbox, "bun-bin");
+        mkdirSync(bunPath);
+        const bunProcess = Bun.spawn([process.execPath, builtEntry, "--version"], {
+            cwd: PACKAGE_ROOT,
+            env: cleanEnvironment({ PATH: bunPath }),
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const [bunExitCode, bunStdout, bunStderr] = await Promise.all([
+            bunProcess.exited,
+            new Response(bunProcess.stdout).text(),
+            new Response(bunProcess.stderr).text(),
+        ]);
+        expect(bunExitCode).toBe(0);
+        expect(bunStdout.trim()).toBe(packageMetadata.version);
+        expect(bunStderr).toBe("");
+
         const binDirectory = join(sandbox, "node_modules/.bin");
         mkdirSync(binDirectory, { recursive: true });
         const linkedEntry = join(binDirectory, "supacloud-cli");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -208,7 +208,7 @@ async function createProjectStatusResult(context: ResolvedContext) {
             ? Boolean(context.inferredServiceRoleKey)
             : Boolean(context.apiToken),
         checks,
-    };
+    } as const;
     return {
         isError: !projectStatusIsHealthy(checks),
         content: [{ type: "text" as const, text: JSON.stringify(statusPayload, null, 2) }],

--- a/packages/cli/src/shared/cli.ts
+++ b/packages/cli/src/shared/cli.ts
@@ -171,7 +171,7 @@ export async function runCli(
         return;
     }
     
-    let startIdx = 1;
+    let startIdx: number = 1;
 
     // Check if there is an action argument (assuming index 1 is action if not starting with '--')
     if (args.length > 1 && !args[1].startsWith("--")) {

--- a/packages/cli/src/shared/global-options.ts
+++ b/packages/cli/src/shared/global-options.ts
@@ -43,7 +43,7 @@ export function parseGlobalOptions(args: string[]): GlobalCliOptions {
     const values: Partial<Record<GlobalOptionKey, string>> = {};
     const remainingArgs: string[] = [];
 
-    for (let index = 0; index < args.length;) {
+    for (let index: number = 0; index < args.length;) {
         const flag = globalFlag(args[index]);
         if (!flag) {
             remainingArgs.push(args[index]);

--- a/packages/cli/src/shared/tools/ai-tools.ts
+++ b/packages/cli/src/shared/tools/ai-tools.ts
@@ -85,7 +85,7 @@ function backupTimestamp(now: Date): string {
 function availableBackupDirectory(destinationDirectory: string, now: Date): string {
     const baseDirectory = `${destinationDirectory}.backup-${backupTimestamp(now)}`;
     let candidate = baseDirectory;
-    let suffix = 2;
+    let suffix: number = 2;
     while (existsSync(candidate)) {
         candidate = `${baseDirectory}-${suffix}`;
         suffix += 1;

--- a/packages/cli/src/shared/tools/app-tool-export.ts
+++ b/packages/cli/src/shared/tools/app-tool-export.ts
@@ -69,7 +69,7 @@ function uniqueToolName(name: string, moduleName: string, used: Set<string>): st
     const prefix = sanitizeToolName(moduleName).slice(0, 32);
     const candidateBase = `${prefix}_${base}`.slice(0, 64);
     let candidate = candidateBase;
-    let suffix = 2;
+    let suffix: number = 2;
     while (used.has(candidate)) {
         candidate = `${candidateBase.slice(0, 64 - String(suffix).length - 1)}_${suffix}`;
         suffix += 1;

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -191,7 +191,7 @@ function sortMigrationFiles(migrations: MigrationFile[]): MigrationFile[] {
         if (versionA > versionB) return 1;
         return a.file.localeCompare(b.file);
     });
-    for (let i = 1; i < sorted.length; i += 1) {
+    for (let i: number = 1; i < sorted.length; i += 1) {
         const previous = sorted[i - 1];
         const current = sorted[i];
         if (previous.version === current.version && (previous.file !== current.file || previous.name !== current.name)) {
@@ -1209,7 +1209,7 @@ function formatTableList(data: unknown, schemas: string[]): string {
     if (!rows.length) return `No tables in: ${schemas.join(", ")}`;
     const grouped: Record<string, string[]> = {};
     for (const r of rows) { (grouped[r.schema] ??= []).push(r.table); }
-    let out = "📋 Tables:\n\n";
+    let out: string = "📋 Tables:\n\n";
     for (const [s, ts] of Object.entries(grouped)) { out += `Schema: ${s}\n${ts.map(t => `  - ${t}`).join("\n")}\n\n`; }
     return out;
 }
@@ -1266,7 +1266,7 @@ function formatRlsPolicies(data: unknown, schema: string, table: string): string
 function formatAuthUsers(data: unknown): string {
     const rows = (data as any)?.rows || [];
     if (!rows.length) return "No users.";
-    let out = "👥 Auth Users:\n\n";
+    let out: string = "👥 Auth Users:\n\n";
     for (const u of rows) {
         out += `  ${u.email_confirmed_at ? "✅" : "⏳"} ${u.email} (${u.role})\n      ID: ${u.id}\n      Created: ${u.created_at}\n`;
         if (u.last_sign_in_at) out += `      Last login: ${u.last_sign_in_at}\n`;
@@ -1299,7 +1299,7 @@ function formatConnections(data: unknown): string {
 function formatDbStats(data: unknown): string {
     const rows = (data as any)?.rows || [];
     if (!rows.length) return "No stats.";
-    let out = "📊 Stats:\n\n  Table                          | Rows      | Total      | Table      | Index\n  -------------------------------|-----------|------------|------------|----------\n";
+    let out: string = "📊 Stats:\n\n  Table                          | Rows      | Total      | Table      | Index\n  -------------------------------|-----------|------------|------------|----------\n";
     for (const t of rows) {
         out += `  ${`${t.schemaname}.${t.table_name}`.padEnd(30)} | ${String(t.row_count || 0).padStart(9)} | ${t.total_size.padStart(10)} | ${t.table_size.padStart(10)} | ${t.index_size.padStart(10)}\n`;
     }

--- a/packages/cli/src/shared/tools/deploy-tools.ts
+++ b/packages/cli/src/shared/tools/deploy-tools.ts
@@ -357,7 +357,7 @@ async function collectArchiveFiles(root: string): Promise<{ files: Zippable; byt
     await visit(root);
     if (paths.length === 0) throw new Error(`Frontend output directory is empty: ${root}`);
 
-    let bytes = 0;
+    let bytes: number = 0;
     const files: Zippable = {};
     for (const path of paths) {
         const data = new Uint8Array(await readFile(path));

--- a/packages/cli/src/shared/tools/frontend-release-control.ts
+++ b/packages/cli/src/shared/tools/frontend-release-control.ts
@@ -203,7 +203,7 @@ function sameArchiveIdentity(left: BigIntStats, right: BigIntStats): boolean {
 async function archiveSha256(handle: FileHandle, sizeBytes: number): Promise<string> {
     const hash = createHash("sha256");
     const chunk = new Uint8Array(Math.min(sizeBytes, ARCHIVE_CHUNK_BYTES));
-    for (let offset = 0; offset < sizeBytes;) {
+    for (let offset: number = 0; offset < sizeBytes;) {
         const requested = Math.min(chunk.byteLength, sizeBytes - offset);
         const { bytesRead } = await handle.read(chunk, 0, requested, offset);
         if (bytesRead < 1) throw new Error("Frontend release archive changed while it was hashed");
@@ -235,7 +235,7 @@ async function verifiedArchive(path: string): Promise<LocalArchive> {
 }
 
 function archiveStream(archive: LocalArchive): ReadableStream<Uint8Array> {
-    let offset = 0;
+    let offset: number = 0;
     return new ReadableStream<Uint8Array>({
         async pull(controller) {
             if (offset === archive.sizeBytes) {

--- a/packages/cli/src/shared/tools/lite-cli-tools.ts
+++ b/packages/cli/src/shared/tools/lite-cli-tools.ts
@@ -176,8 +176,8 @@ function spawnLiteCommand(
             rejectExecution(new Error("Lite CLI child process did not expose piped output"));
             return;
         }
-        let standardOutput = "";
-        let standardError = "";
+        let standardOutput: string = "";
+        let standardError: string = "";
         child.stdout.setEncoding("utf8");
         child.stderr.setEncoding("utf8");
         child.stdout.on("data", (chunk: string) => { standardOutput += chunk; });

--- a/packages/cli/src/shared/tools/migration-risk.ts
+++ b/packages/cli/src/shared/tools/migration-risk.ts
@@ -88,7 +88,7 @@ function lineCommentEnd(sql: string, start: number): number {
 }
 
 function blockCommentEnd(sql: string, start: number): number {
-    let depth = 1;
+    let depth: number = 1;
     let cursor = start + 2;
     while (cursor < sql.length && depth > 0) {
         if (sql.startsWith("/*", cursor)) {
@@ -137,8 +137,8 @@ function maskSql(
     sql: string,
     quotedIdentifier: typeof maskDoubleQuotedIdentifier,
 ): string {
-    let masked = "";
-    let cursor = 0;
+    let masked: string = "";
+    let cursor: number = 0;
     while (cursor < sql.length) {
         const protectedSpan = maskSqlSpan(sql, cursor, quotedIdentifier);
         if (protectedSpan) {
@@ -163,8 +163,8 @@ function maskSqlPolicyNoise(sql: string): string {
 export function splitSqlStatements(sql: string): string[] {
     const masked = maskSqlNoise(sql);
     const statements: string[] = [];
-    let lastIndex = 0;
-    let cursor = 0;
+    let lastIndex: number = 0;
+    let cursor: number = 0;
 
     while (cursor < masked.length) {
         if (masked[cursor] === ";") {
@@ -258,10 +258,10 @@ function topLevelDoBodies(sql: string): string[] {
 function splitTopLevelClauses(sql: string): string[] {
     const masked = maskSqlNoise(sql);
     const clauses: string[] = [];
-    let parenthesisDepth = 0;
-    let bracketDepth = 0;
-    let clauseStart = 0;
-    for (let cursor = 0; cursor < masked.length; cursor += 1) {
+    let parenthesisDepth: number = 0;
+    let bracketDepth: number = 0;
+    let clauseStart: number = 0;
+    for (let cursor: number = 0; cursor < masked.length; cursor += 1) {
         const character = masked[cursor];
         if (character === "(") parenthesisDepth += 1;
         else if (character === ")") parenthesisDepth -= 1;
@@ -719,10 +719,10 @@ export function analyzeMigrationFiles(
     files: Array<{ file: string; sql: string }>,
 ): MigrationRiskAnalysis {
     const fileRisks: MigrationFileRisk[] = [];
-    let highCount = 0;
-    let mediumCount = 0;
-    let lowCount = 0;
-    let transactionalPushBlockerCount = 0;
+    let highCount: number = 0;
+    let mediumCount: number = 0;
+    let lowCount: number = 0;
+    let transactionalPushBlockerCount: number = 0;
 
     for (const { file, sql } of files) {
         const risks = analyzeMigrationSql(sql);

--- a/packages/cli/src/shared/tools/project-read-projection.ts
+++ b/packages/cli/src/shared/tools/project-read-projection.ts
@@ -63,7 +63,7 @@ function hasOnlyKeys(record: Record<string, unknown>, allowedKeys: ReadonlySet<s
 }
 
 function hasWellFormedUnicode(text: string): boolean {
-    for (let index = 0; index < text.length; index++) {
+    for (let index: number = 0; index < text.length; index++) {
         const codeUnit = text.charCodeAt(index);
         if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
             if (index + 1 >= text.length) return false;

--- a/packages/cli/src/shared/tools/remote-dev-tools.ts
+++ b/packages/cli/src/shared/tools/remote-dev-tools.ts
@@ -78,8 +78,8 @@ export const remoteDevToolSchema = {
 function runProcess(executable: string, args: string[], cwd: string): Promise<CommandResult> {
     return new Promise((resolveResult, reject) => {
         const child = spawn(executable, args, { cwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
-        let stdout = "";
-        let stderr = "";
+        let stdout: string = "";
+        let stderr: string = "";
         child.stdout?.setEncoding("utf8");
         child.stderr?.setEncoding("utf8");
         child.stdout?.on("data", (chunk) => { stdout += String(chunk); });
@@ -234,7 +234,7 @@ async function syncOnce(args: Record<string, unknown>, options: RemoteDevToolOpt
     const target = String(args.target || "project");
     const source = targetDirectory(root, target, typeof args.function === "string" ? args.function : undefined, projectConfig as Record<string, unknown>);
     if (!existsSync(source)) throw new Error(`Dev source directory not found: ${source}`);
-    let compiled = false;
+    let compiled: boolean = false;
     if (config.compile === true && target !== "db") {
         const compileRoot = resolve(root, config.compileRoot || ".");
         const compileOutDir = resolve(root, config.compileOutDir || "generated");
@@ -288,7 +288,7 @@ export function registerRemoteDevTools(server: ToolServer, options: RemoteDevToo
         if (args.action === "watch") {
             const root = resolve(String(args.project_dir || options.cwd || process.cwd()));
             const interval = Math.max(100, Math.min(10_000, Number(args.interval_ms || 300)));
-            let fingerprint = "";
+            let fingerprint: string = "";
             let lastSync: Record<string, unknown> | null = null;
             for (;;) {
                 const nextFingerprint = await sourceFingerprint(root);

--- a/packages/cli/src/shared/tools/supabase-cli-tools.ts
+++ b/packages/cli/src/shared/tools/supabase-cli-tools.ts
@@ -271,8 +271,8 @@ function spawnOfficialSupabaseCommand(
             stdio: ["ignore", "pipe", "pipe"],
             windowsHide: true,
         });
-        let standardOutput = "";
-        let standardError = "";
+        let standardOutput: string = "";
+        let standardError: string = "";
         child.stdout.setEncoding("utf8");
         child.stderr.setEncoding("utf8");
         child.stdout.on("data", (chunk: string) => { standardOutput += chunk; });

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -156,7 +156,7 @@ async function fetchWithRetry(
     timeoutMs = DEFAULT_TIMEOUT,
 ): Promise<Response> {
     const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    for (let attempt: number = 0; attempt <= retries; attempt++) {
         try {
             const res = await fetchWithTimeout(url, options, timeoutMs);
 
@@ -186,7 +186,7 @@ function declaredResponseTooLarge(response: Response, maxBytes: number): boolean
 
 function joinedResponseBytes(chunks: Uint8Array[], totalBytes: number): Uint8Array {
     const responseBytes = new Uint8Array(totalBytes);
-    let offset = 0;
+    let offset: number = 0;
     for (const chunk of chunks) {
         responseBytes.set(chunk, offset);
         offset += chunk.byteLength;
@@ -208,7 +208,7 @@ async function responseBytesFromReader(
     declaredBytes: number | null,
 ): Promise<ResponseBytesRead> {
     const chunks: Uint8Array[] = [];
-    let totalBytes = 0;
+    let totalBytes: number = 0;
     while (true) {
         const { done, value } = await reader.read();
         if (done) {

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -20,7 +20,12 @@ const result = await compileProject({
   rootDir: "/path/to/app",            // 项目根（含 tsconfig）
   include: ["**/*.ts"],               // 可选，默认 ['**/*.module.ts', '**/*.ts']
   outDir: "/path/to/app/generated",   // 生成目录
-  strict: false,                      // true 时 warn 级诊断升级为 error
+  strict: true,                       // 同时启用类型安全门，并将 warn 升级为 error
+  typeSafety: {
+    noAnyInGenerated: true,           // 生成的 TS 产物禁止 any
+    scanProductionSource: true,       // 扫描生产源码的 any/断言/隐式宽化
+    exclude: ["src/legacy/**"],       // 额外排除的相对 glob
+  },
 });
 result.diagnostics; // Diagnostic[]
 result.graph;       // ApplicationGraph
@@ -62,6 +67,7 @@ interface ApplicationGraph {
 - 含 request 级 provider/controller 的模块额外生成 `create<Name>RequestScope(services, ctx)`：依赖 `REQUEST_CONTEXT`（或 token name `supacloud.request-context`）的参数传 `ctx`，其余经 `services` 解析（运行期负责把 imports 模块导出的 application 服务合并进 `services`）；job 级同理生成 `create<Name>JobScope`。
 - services 对象的 key 为 token 名的 camelCase：`CaseService → caseService`、`CASE_REPOSITORY → caseRepository`、`LOGGER → logger`。
 - controller 描述静态给出：`{ path, serviceKey, scope, routes: [{ method, path, handler, body?, params?, query?, response? }] }`，schema 直接引用 import 进来的对象。
+- 严格生成模式会对 `application.ts`、可选的 `client.ts` 和 `permissions.ts` 做 AST 扫描，禁止生成 `any`。
 
 `<outDir>/app.manifest.json`：`{ version: 1, modules, externalTokens }`，供 CLI graph/explain 使用。
 
@@ -80,8 +86,23 @@ interface ApplicationGraph {
 | `route-command-unresolved` | error | 路由绑定了本模块未声明的 command 类 |
 | `command-missing-permission` | error | `@Command` 未声明 permission |
 | `missing-deps` | warn（strict 时 error） | 构造/工厂依赖无法静态解析 |
+| `generated-any` | warn（strict 时 error） | 生成的 TypeScript 产物包含 `any` |
+| `source-any` | warn（strict 时 error） | 未被排除的生产源码包含显式 `any` |
+| `source-type-assertion` | warn（strict 时 error） | 生产源码使用 `as T` 或 `<T>value` 类型断言 |
+| `source-non-null-assertion` | warn（strict 时 error） | 生产源码使用非空断言 `value!` |
+| `source-implicit-widening` | warn（strict 时 error） | 可静态判定的字面量类型隐式宽化 |
 
 依赖的 token 全图都无 provider 时不报错，记入 `externalTokens`（平台注入）。
+
+## 类型安全扫描
+
+`strict: true` 默认开启两道类型安全门；也可以单独配置 `typeSafety`。生产源码扫描默认排除测试、fixture、声明文件、`generated` 和 `dist`，并支持 `typeSafety.exclude` 增加项目自定义排除规则。
+
+```bash
+supacloud-compiler check --root ./app --out ./app/generated --strict
+```
+
+程序化调用可直接使用 `scanGeneratedArtifacts()` 和 `scanProductionSource()` 获取结构化诊断。
 
 ## 开发模式
 

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -63,9 +63,11 @@ interface ApplicationGraph {
 
 - 文件顶部本地声明 `CompiledRoute` / `CompiledController` / `CompiledModule` 接口，不 import 任何外部包。
 - `createCompiledModules()` 按 imports 拓扑序返回模块描述：`{ name, createServices, createRequestScope?, createJobScope?, controllers, commands }`。平台依赖统一由 `createApplication({ deps })` 传入生成工厂。
+- `makeEnvironmentProviders`、`provideToken`、`provideAppInitializer`、`provideEnvironmentInitializer`、`provideRouter` 和 `provideHttpClient` 的可静态展开部分会在 AST 分析阶段展开为普通 provider；不支持静态安全展开的动态参数会产生诊断，不会被静默丢弃。
 - 每个模块一个 `create<Name>Services(deps, imported)`：实例化 application 级 provider；dep 解析顺序为本模块 services > imports 模块导出的 services（`imported.<module>.<key>`）> 平台注入（`deps.<camelName>`）。
 - 含 request 级 provider/controller 的模块额外生成 `create<Name>RequestScope(services, ctx)`：依赖 `REQUEST_CONTEXT`（或 token name `supacloud.request-context`）的参数传 `ctx`，其余经 `services` 解析（运行期负责把 imports 模块导出的 application 服务合并进 `services`）；job 级同理生成 `create<Name>JobScope`。
 - 含 request/job 级 provider 或 controller 的模块同时生成静态 `destroy<Name>RequestScope(scope)` / `destroy<Name>JobScope(scope)`，按编译期确定的逆创建顺序调用已知 `onDestroy` 方法；不会运行时扫描或解析 Token。
+- `@Host()` 在 EnvironmentInjector 作用域中保留元数据但不改变解析，因为 SupaCloud 没有 Angular 元素注入器树；`@Self()` / `@SkipSelf()` 由静态 factory 按当前 scope 与模块可见性执行。
 - services 对象的 key 为 token 名的 camelCase：`CaseService → caseService`、`CASE_REPOSITORY → caseRepository`、`LOGGER → logger`。
 - controller 描述静态给出：`{ path, serviceKey, scope, routes: [{ method, path, handler, body?, params?, query?, response? }] }`，schema 直接引用 import 进来的对象。
 - 严格生成模式会对 `application.ts`、可选的 `client.ts` 和 `permissions.ts` 做 AST 扫描，禁止生成 `any`。
@@ -87,6 +89,7 @@ interface ApplicationGraph {
 | `route-command-unresolved` | error | 路由绑定了本模块未声明的 command 类 |
 | `command-missing-permission` | error | `@Command` 未声明 permission |
 | `provider-type-mismatch` | error | Provider 的 useClass/useValue/useFactory/useExisting 不满足 InjectionToken 的静态类型契约 |
+| `unsupported-provider-helper` | warn（strict 时 error） | functional provider 的动态参数无法安全展开为静态 factory |
 | `missing-deps` | warn（strict 时 error） | 构造/工厂依赖无法静态解析 |
 | `generated-any` | warn（strict 时 error） | 生成的 TypeScript 产物包含 `any` |
 | `source-any` | warn（strict 时 error） | 未被排除的生产源码包含显式 `any` |

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,6 +1,6 @@
 # @supacloud/compiler
 
-SupaCloud 应用静态编译器：读取 `@supacloud/app` 装饰器元数据的源码 AST（ts-morph），构建 ApplicationGraph，做静态校验，并生成**无反射、无容器**的工厂代码与 manifest。
+SupaCloud 应用静态编译器：读取 `@supacloud/app` 装饰器元数据的原生 TypeScript AST，构建 ApplicationGraph，做静态校验，并生成**无反射、无容器**的工厂代码与 manifest。
 
 本包不依赖 `@supacloud/app`：AST 只按装饰器名匹配（`Module`/`Injectable`/`Inject`/`Command`/`Query`/`Controller`/`Get`/`Post`/`Put`/`Patch`/`Delete`/`defineModule`/`InjectionToken`），不校验 import 来源。
 
@@ -65,6 +65,7 @@ interface ApplicationGraph {
 - `createCompiledModules()` 按 imports 拓扑序返回模块描述：`{ name, createServices, createRequestScope?, createJobScope?, controllers, commands }`。平台依赖统一由 `createApplication({ deps })` 传入生成工厂。
 - 每个模块一个 `create<Name>Services(deps, imported)`：实例化 application 级 provider；dep 解析顺序为本模块 services > imports 模块导出的 services（`imported.<module>.<key>`）> 平台注入（`deps.<camelName>`）。
 - 含 request 级 provider/controller 的模块额外生成 `create<Name>RequestScope(services, ctx)`：依赖 `REQUEST_CONTEXT`（或 token name `supacloud.request-context`）的参数传 `ctx`，其余经 `services` 解析（运行期负责把 imports 模块导出的 application 服务合并进 `services`）；job 级同理生成 `create<Name>JobScope`。
+- 含 request/job 级 provider 或 controller 的模块同时生成静态 `destroy<Name>RequestScope(scope)` / `destroy<Name>JobScope(scope)`，按编译期确定的逆创建顺序调用已知 `onDestroy` 方法；不会运行时扫描或解析 Token。
 - services 对象的 key 为 token 名的 camelCase：`CaseService → caseService`、`CASE_REPOSITORY → caseRepository`、`LOGGER → logger`。
 - controller 描述静态给出：`{ path, serviceKey, scope, routes: [{ method, path, handler, body?, params?, query?, response? }] }`，schema 直接引用 import 进来的对象。
 - 严格生成模式会对 `application.ts`、可选的 `client.ts` 和 `permissions.ts` 做 AST 扫描，禁止生成 `any`。
@@ -85,6 +86,7 @@ interface ApplicationGraph {
 | `duplicate-route` | error | 规范化后 HTTP method + path 冲突 |
 | `route-command-unresolved` | error | 路由绑定了本模块未声明的 command 类 |
 | `command-missing-permission` | error | `@Command` 未声明 permission |
+| `provider-type-mismatch` | error | Provider 的 useClass/useValue/useFactory/useExisting 不满足 InjectionToken 的静态类型契约 |
 | `missing-deps` | warn（strict 时 error） | 构造/工厂依赖无法静态解析 |
 | `generated-any` | warn（strict 时 error） | 生成的 TypeScript 产物包含 `any` |
 | `source-any` | warn（strict 时 error） | 未被排除的生产源码包含显式 `any` |

--- a/packages/compiler/bun.lock
+++ b/packages/compiler/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@supacloud/compiler",
       "dependencies": {
-        "ts-morph": "^28.0.0",
+        "@typescript/typescript6": "^6.0.2",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -14,11 +14,11 @@
     },
   },
   "packages": {
-    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
-
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/old": ["typescript@6.0.3", "https://registry.npmmirror.com/typescript/-/typescript-6.0.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -60,25 +60,9 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
-    "brace-expansion": ["brace-expansion@5.0.9", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+    "@typescript/typescript6": ["@typescript/typescript6@6.0.2", "https://registry.npmmirror.com/@typescript/typescript6/-/typescript6-6.0.2.tgz", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
-
-    "code-block-writer": ["code-block-writer@13.0.3", "https://registry.npmmirror.com/code-block-writer/-/code-block-writer-13.0.3.tgz", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
-
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "minimatch": ["minimatch@10.2.6", "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.6.tgz", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
-
-    "path-browserify": ["path-browserify@1.0.1", "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
-    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
-
-    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
-
-    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "build": "bun run clean && bun run build:js && bun run build:types",
-    "build:js": "bun build src/index.ts src/cli.ts --outdir dist --target node --external ts-morph",
+    "build:js": "bun build src/index.ts src/cli.ts --outdir dist --target node --external @typescript/typescript6",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build",
@@ -44,7 +44,7 @@
     "directory": "packages/compiler"
   },
   "dependencies": {
-    "ts-morph": "^28.0.0"
+    "@typescript/typescript6": "^6.0.2"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -209,6 +209,28 @@ describe("analyzeProject：command 与 externalTokens", () => {
     expect(prov?.deps).toContain("CONFIG");
     expect(prov?.deps).toContain("CACHE");
     expect(prov?.optionalDeps).toContain("CACHE");
+    expect(prov?.functionalInjects).toEqual([
+      {
+        token: "CONFIG",
+        expression: "CONFIG",
+        importPath: "src/test.service",
+        importModule: undefined,
+        optional: false,
+        self: false,
+        skipSelf: false,
+        host: false,
+      },
+      {
+        token: "CACHE",
+        expression: "CACHE",
+        importPath: "src/test.service",
+        importModule: undefined,
+        optional: true,
+        self: false,
+        skipSelf: false,
+        host: false,
+      },
+    ]);
   });
 
   test("analyzes canMatch guards, param transforms/defaults, and onDestroy hooks", async () => {
@@ -401,6 +423,46 @@ describe("analyzeProject：command 与 externalTokens", () => {
     expect(prov?.tokenKind).toBe("injection-token");
     expect(prov?.kind).toBe("factory");
     expect(prov?.importPath).toBe("src/tokens");
+  });
+
+  test("expands nested EnvironmentProviders and standalone provider helpers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-environment-providers-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"],
+      "src/runtime.ts": `${RUNTIME_SOURCE}
+export function makeEnvironmentProviders(providers: unknown[]) { return { ɵproviders: providers }; }
+export function provideToken(token: unknown, value: unknown) { return { token, value }; }
+export function provideEnvironmentInitializer(initializer: unknown) { return initializer; }
+`,
+      "src/config.ts": `
+        import { InjectionToken } from "./runtime";
+        export const CONFIG = new InjectionToken<{ mode: string }>("config");
+      `,
+      "src/app.module.ts": `
+        import { Module, makeEnvironmentProviders, provideEnvironmentInitializer, provideToken } from "./runtime";
+        import { CONFIG } from "./config";
+        const SHARED = makeEnvironmentProviders([
+          makeEnvironmentProviders([provideToken(CONFIG, { mode: "strict" })]),
+        ]);
+        @Module({
+          name: "app",
+          providers: [SHARED, provideEnvironmentInitializer(() => {})],
+          exports: [CONFIG],
+        })
+        export class AppModule {}
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const app = analyzed.modules.find((module) => module.name === "app");
+    expect(app?.providers.map((provider) => provider.token)).toEqual([
+      "CONFIG",
+      "ENVIRONMENT_INITIALIZER",
+    ]);
+    expect(app?.providers.find((provider) => provider.token === "CONFIG")?.useValueExpr)
+      .toContain('{ mode: "strict" }');
+    expect(app?.providers.find((provider) => provider.token === "ENVIRONMENT_INITIALIZER")?.multi)
+      .toBe(true);
   });
 
   test("analyzes @Resolve decorator on controller methods", async () => {

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -262,7 +262,7 @@ describe("analyzeProject：command 与 externalTokens", () => {
 
         @Injectable()
         export class FirstService {
-          constructor(@Inject(forwardRef(() => SecondService)) private second: any) {}
+          constructor(@Inject(forwardRef(() => SecondService)) private second: unknown) {}
         }
 
         @Injectable()
@@ -410,8 +410,8 @@ describe("analyzeProject：command 与 externalTokens", () => {
       "src/resolver.controller.ts": `
         import { Controller, Get, Resolve } from "@supacloud/app";
 
-        const UserResolver = (ctx: any) => ({ id: ctx.userId });
-        const OrgResolver = (ctx: any) => ({ id: ctx.orgId });
+        const UserResolver = (ctx: { userId: string }) => ({ id: ctx.userId });
+        const OrgResolver = (ctx: { orgId: string }) => ({ id: ctx.orgId });
 
         @Controller({ path: "/accounts", standalone: true })
         export class AccountsController {

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -458,3 +458,69 @@ describe("analyzeProject：command 与 externalTokens", () => {
     expect(route?.queryBindings).toEqual(["format"]);
   });
 });
+
+describe("analyzeProject：Angular Provider 类型契约", () => {
+  test("useClass 与 InjectionToken<T> 不兼容时生成静态诊断", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-compiler-provider-class-type-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": FIXTURE_TSCONFIG,
+      "src/runtime.ts": RUNTIME_SOURCE,
+      "src/provider.ts": `
+        import { InjectionToken, Module } from "./runtime";
+
+        interface Repository {
+          find(id: string): Promise<string>;
+        }
+
+        const REPOSITORY = new InjectionToken<Repository>("repository");
+
+        class WrongRepository {
+          find(id: string): string {
+            return id;
+          }
+        }
+
+        @Module({
+          name: "provider",
+          providers: [{ provide: REPOSITORY, useClass: WrongRepository }],
+        })
+        export class ProviderModule {}
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const diagnostic = analyzed.diagnostics?.find((item) => item.code === "provider-type-mismatch");
+    expect(diagnostic).toMatchObject({
+      severity: "error",
+      errorCode: "SC2010",
+      docsUrl: "https://supacloud.dev/errors/SC2010",
+    });
+    expect(diagnostic?.message).toContain("REPOSITORY");
+    expect(diagnostic?.message).toContain("useClass");
+  });
+
+  test("useValue 与 InjectionToken<T> 不兼容时生成静态诊断", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-compiler-provider-value-type-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": FIXTURE_TSCONFIG,
+      "src/runtime.ts": RUNTIME_SOURCE,
+      "src/provider.ts": `
+        import { InjectionToken, Module } from "./runtime";
+
+        const CONFIG = new InjectionToken<{ retries: number }>("config");
+
+        @Module({
+          name: "provider",
+          providers: [{ provide: CONFIG, useValue: { retries: "three" } }],
+        })
+        export class ProviderModule {}
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const diagnostic = analyzed.diagnostics?.find((item) => item.code === "provider-type-mismatch");
+    expect(diagnostic?.severity).toBe("error");
+    expect(diagnostic?.message).toContain("CONFIG");
+    expect(diagnostic?.message).toContain("useValue");
+  });
+});

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -10,6 +10,7 @@ import type {
   DependencyGraphCache,
   Diagnostic,
   HandlerParamNode,
+  FunctionalInjectNode,
   ModuleNode,
   ProviderNode,
   QueryNode,
@@ -111,6 +112,10 @@ function hasMethod(cls: ts.ClassDeclaration, name: string): boolean {
     member.name !== undefined &&
     propertyName(member.name) === name,
   );
+}
+
+function hasDestroyHook(cls: ts.ClassDeclaration): boolean {
+  return hasMethod(cls, "onDestroy") || hasMethod(cls, "ngOnDestroy");
 }
 
 function descendantsOfKind<T extends ts.Node>(
@@ -338,7 +343,7 @@ export async function analyzeProject(
     if (!allRegisteredClasses.has(name)) {
       const injectable = parseInjectableOptions(classInfo.decl, ctx);
       if (injectable?.providedIn === "root") {
-        const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing } = classDeps(classInfo.decl, ctx);
+        const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, functionalInjects, missing } = classDeps(classInfo.decl, ctx);
         const file = sourcePath(ctx.rootDir, classInfo.file);
         const line = lineOf(classInfo.decl);
         if (missing) {
@@ -355,8 +360,9 @@ export async function analyzeProject(
           selfDeps: selfDeps.length > 0 ? selfDeps : undefined,
           skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
           hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
+          functionalInjects: functionalInjects.length > 0 ? functionalInjects : undefined,
           providedIn: "root",
-          hasOnDestroy: hasMethod(classInfo.decl, "onDestroy") || undefined,
+          hasOnDestroy: hasDestroyHook(classInfo.decl) || undefined,
           exported: true,
           file,
           line,
@@ -615,7 +621,23 @@ function parseModule(
   const exportsSet = new Set(exports);
 
   const providers: ProviderNode[] = [];
-  for (const el of arrayProp(options, "providers")) {
+  for (const el of expandProviderExpressions(arrayProp(options, "providers"), ctx)) {
+    const parsedProviders = parseFunctionalProvider(el, exportsSet, ctx);
+    if (parsedProviders) {
+      providers.push(...parsedProviders);
+      continue;
+    }
+    if (ts.isCallExpression(el)) {
+      const helper = nodeText(el.expression).split(".").pop() ?? nodeText(el.expression);
+      warn(
+        ctx,
+        "unsupported-provider-helper",
+        `无法静态展开 provider helper '${helper}'；请改用显式 Provider 或实现编译器支持的 helper`,
+        sourcePath(ctx.rootDir, el.getSourceFile().fileName),
+        lineOf(el),
+      );
+      continue;
+    }
     const provider = parseProvider(el, exportsSet, ctx);
     if (provider) providers.push(provider);
   }
@@ -714,9 +736,9 @@ function parseProvider(
     const decl = resolveDeclaration(unwrappedEl, ctx)[0];
     const cls = decl && ts.isClassDeclaration(decl) ? decl : undefined;
     const className = cls?.name?.text ?? unwrappedEl.text;
-    const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing } = cls
+    const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, functionalInjects, missing } = cls
       ? classDeps(cls, ctx)
-      : { deps: [], optionalDeps: [], selfDeps: [], skipSelfDeps: [], hostDeps: [], missing: false };
+      : { deps: [], optionalDeps: [], selfDeps: [], skipSelfDeps: [], hostDeps: [], functionalInjects: [], missing: false };
     const injectable = cls ? parseInjectableOptions(cls, ctx) : undefined;
     if (missing) {
       warn(ctx, "missing-deps", `provider ${className} 的部分构造依赖无法静态解析`, file, line);
@@ -732,8 +754,9 @@ function parseProvider(
       selfDeps: selfDeps.length > 0 ? selfDeps : undefined,
       skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
       hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
+      functionalInjects: functionalInjects.length > 0 ? functionalInjects : undefined,
       providedIn: injectable?.providedIn,
-      hasOnDestroy: cls ? hasMethod(cls, "onDestroy") || undefined : undefined,
+      hasOnDestroy: cls ? hasDestroyHook(cls) || undefined : undefined,
       exported: exportsSet.has(className),
       file,
       line,
@@ -764,13 +787,22 @@ function parseProvider(
     let selfDeps: string[] = [];
     let skipSelfDeps: string[] = [];
     let hostDeps: string[] = [];
-    if (deps.length === 0 && cls) {
+    let functionalInjects: FunctionalInjectNode[] = [];
+    if (cls) {
       const result = classDeps(cls, ctx);
-      deps = result.deps;
-      optionalDeps = result.optionalDeps;
-      selfDeps = result.selfDeps;
-      skipSelfDeps = result.skipSelfDeps;
-      hostDeps = result.hostDeps;
+      if (deps.length === 0) {
+        deps = result.deps;
+        optionalDeps = result.optionalDeps;
+        selfDeps = result.selfDeps;
+        skipSelfDeps = result.skipSelfDeps;
+        hostDeps = result.hostDeps;
+      } else {
+        optionalDeps = result.optionalDeps.filter((dep) => deps.includes(dep));
+        selfDeps = result.selfDeps.filter((dep) => deps.includes(dep));
+        skipSelfDeps = result.skipSelfDeps.filter((dep) => deps.includes(dep));
+        hostDeps = result.hostDeps.filter((dep) => deps.includes(dep));
+      }
+      functionalInjects = result.functionalInjects;
       if (result.missing) {
         warn(ctx, "missing-deps", `provider ${token} (useClass ${useClass}) 的部分构造依赖无法静态解析`, file, line);
       }
@@ -788,6 +820,7 @@ function parseProvider(
       selfDeps: selfDeps.length > 0 ? selfDeps : undefined,
       skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
       hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
+      functionalInjects: functionalInjects.length > 0 ? functionalInjects : undefined,
       multi: multi ?? undefined,
       providedIn: injectable?.providedIn,
       hasOnDestroy: cls ? hasMethod(cls, "onDestroy") || undefined : undefined,
@@ -859,6 +892,212 @@ function parseProvider(
       file,
       line,
     };
+  }
+
+  return undefined;
+}
+
+/**
+ * Expands Angular-style standalone provider helpers into ordinary provider
+ * expressions before graph analysis. The generated application still contains
+ * only direct static providers.
+ */
+function expandProviderExpressions(
+  expressions: readonly Expression[],
+  ctx: AnalysisContext,
+  seen = new Set<string>(),
+): Expression[] {
+  const result: Expression[] = [];
+  for (const expression of expressions) {
+    if (ts.isSpreadElement(expression)) {
+      result.push(...expandProviderExpressions([expression.expression], ctx, seen));
+      continue;
+    }
+    if (ts.isIdentifier(expression)) {
+      const declaration = resolveDeclaration(expression, ctx)[0];
+      if (declaration && ts.isVariableDeclaration(declaration) && declaration.initializer) {
+        const key = `${declaration.getSourceFile().fileName}:${declaration.pos}`;
+        if (seen.has(key)) continue;
+        const initializer = declaration.initializer;
+        if (ts.isCallExpression(initializer) && isProviderHelper(initializer, "makeEnvironmentProviders")) {
+          const nested = initializer.arguments[0];
+          if (nested && ts.isArrayLiteralExpression(nested)) {
+            seen.add(key);
+            result.push(...expandProviderExpressions([...nested.elements], ctx, seen));
+            seen.delete(key);
+            continue;
+          }
+        }
+      }
+    }
+    if (ts.isCallExpression(expression) && isProviderHelper(expression, "makeEnvironmentProviders")) {
+      const nested = expression.arguments[0];
+      if (nested && ts.isArrayLiteralExpression(nested)) {
+        result.push(...expandProviderExpressions([...nested.elements], ctx, seen));
+        continue;
+      }
+    }
+    result.push(expression);
+  }
+  return result;
+}
+
+function isProviderHelper(expression: ts.CallExpression, name: string): boolean {
+  return nodeText(expression.expression).split(".").pop() === name;
+}
+
+function parseFunctionalProvider(
+  expression: Expression,
+  exportsSet: Set<string>,
+  ctx: AnalysisContext,
+): ProviderNode[] | undefined {
+  if (!ts.isCallExpression(expression)) return undefined;
+  const helper = nodeText(expression.expression).split(".").pop();
+  const args = expression.arguments;
+  const file = sourcePath(ctx.rootDir, expression.getSourceFile().fileName);
+  const line = lineOf(expression);
+
+  if (helper === "provideToken") {
+    const tokenExpr = args[0];
+    const valueExpr = args[1];
+    if (!tokenExpr || !valueExpr) return [];
+    const { name: token, kind: tokenKind } = tokenNameOf(tokenExpr, ctx);
+    validateProviderCompatibility(tokenExpr, valueExpr, "value", token, ctx, file, line);
+    return [{
+      token,
+      tokenKind,
+      kind: "value",
+      useValueExpr: nodeText(valueExpr),
+      scope: resolveScope({ tokenName: token }, ctx),
+      deps: [],
+      exported: exportsSet.has(token),
+      file,
+      line,
+      importPath: ts.isIdentifier(valueExpr) ? importPathOf(valueExpr, ctx) : undefined,
+    }];
+  }
+
+  if (helper === "provideAppInitializer" || helper === "provideEnvironmentInitializer") {
+    const initializer = args[0];
+    if (!initializer) return [];
+    const token = helper === "provideAppInitializer" ? "APP_INITIALIZER" : "ENVIRONMENT_INITIALIZER";
+    return [{
+      token,
+      tokenKind: "injection-token",
+      kind: "value",
+      useValueExpr: nodeText(initializer),
+      scope: "application",
+      deps: [],
+      multi: true,
+      exported: false,
+      file,
+      line,
+      importPath: ts.isIdentifier(initializer) ? importPathOf(initializer, ctx) : undefined,
+    }];
+  }
+
+  if (helper === "provideRouter") {
+    const providers: ProviderNode[] = [];
+    const routes = args[0];
+    if (routes) {
+      providers.push({
+        token: "ROUTE_CONFIG",
+        tokenKind: "injection-token",
+        kind: "value",
+        useValueExpr: nodeText(routes),
+        scope: "application",
+        deps: [],
+        exported: false,
+        file,
+        line,
+        importPath: ts.isIdentifier(routes) ? importPathOf(routes, ctx) : undefined,
+      });
+    }
+    for (const feature of args.slice(1)) {
+      if (!ts.isCallExpression(feature)) continue;
+      const featureName = nodeText(feature.expression).split(".").pop();
+      if (featureName === "withRouterConfig" && feature.arguments[0]) {
+        providers.push({
+          token: "ROUTER_CONFIGURATION",
+          tokenKind: "injection-token",
+          kind: "value",
+          useValueExpr: nodeText(feature.arguments[0]),
+          scope: "application",
+          deps: [],
+          exported: false,
+          file,
+          line,
+        });
+      } else if (featureName === "withTitleStrategy" && feature.arguments[0]) {
+        const strategy = feature.arguments[0];
+        const isClass = ts.isIdentifier(strategy) && Boolean(resolveDeclaration(strategy, ctx)
+          .find((declaration) => ts.isClassDeclaration(declaration)));
+        providers.push({
+          token: "TITLE_STRATEGY",
+          tokenKind: "injection-token",
+          kind: isClass ? "class" : "value",
+          ...(isClass ? { useClass: nodeText(strategy) } : { useValueExpr: nodeText(strategy) }),
+          scope: "application",
+          deps: [],
+          exported: false,
+          file,
+          line,
+          importPath: ts.isIdentifier(strategy) ? importPathOf(strategy, ctx) : undefined,
+        });
+      }
+    }
+    return providers;
+  }
+
+  if (helper === "provideHttpClient") {
+    const providers: ProviderNode[] = [{
+      token: "HttpClient",
+      tokenKind: "class",
+      kind: "class",
+      useClass: "HttpClient",
+      scope: "application",
+      deps: ["HTTP_CLIENT_CONFIG", "HTTP_INTERCEPTORS"],
+      optionalDeps: ["HTTP_CLIENT_CONFIG", "HTTP_INTERCEPTORS"],
+      exported: false,
+      file,
+      line,
+      importModule: "@supacloud/app",
+    }];
+    for (const feature of args) {
+      if (!ts.isCallExpression(feature)) continue;
+      const featureName = nodeText(feature.expression).split(".").pop();
+      if (featureName === "withInterceptors") {
+        for (const interceptorArg of feature.arguments) {
+          const values = ts.isArrayLiteralExpression(interceptorArg)
+            ? [...interceptorArg.elements]
+            : [interceptorArg];
+          for (const value of values) {
+            providers.push({
+              token: "HTTP_INTERCEPTORS",
+              tokenKind: "injection-token",
+              kind: "value",
+              useValueExpr: nodeText(value),
+              scope: "application",
+              deps: [],
+              multi: true,
+              exported: false,
+              file,
+              line,
+              importPath: ts.isIdentifier(value) ? importPathOf(value, ctx) : undefined,
+            });
+          }
+        }
+      } else if (featureName === "withFetch" && feature.arguments.length > 0) {
+        warn(
+          ctx,
+          "unsupported-provider-helper",
+          "provideHttpClient(withFetch(customFetch)) 需要显式声明 HTTP_CLIENT_CONFIG provider 才能保持静态生成",
+          file,
+          line,
+        );
+      }
+    }
+    return providers;
   }
 
   return undefined;
@@ -984,7 +1223,7 @@ function parseController(
     }
   }
 
-  const { deps, optionalDeps, selfDeps, skipSelfDeps, missing } = classDeps(decl, ctx);
+  const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, functionalInjects, missing } = classDeps(decl, ctx);
   const file = sourcePath(ctx.rootDir, decl.getSourceFile().fileName);
   if (missing) {
     warn(ctx, "missing-deps", `controller ${decl.name?.text} 的部分构造依赖无法静态解析`, file, lineOf(decl));
@@ -1240,10 +1479,12 @@ function parseController(
     path,
     scope: injectable?.scope ?? "request",
     deps,
-    hasOnDestroy: hasMethod(decl, "onDestroy") || undefined,
+    hasOnDestroy: hasDestroyHook(decl) || undefined,
     optionalDeps: optionalDeps.length > 0 ? optionalDeps : undefined,
     selfDeps: selfDeps.length > 0 ? selfDeps : undefined,
     skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
+    hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
+    functionalInjects: functionalInjects.length > 0 ? functionalInjects : undefined,
     standalone: standalone || undefined,
     routes,
     file,
@@ -1266,29 +1507,20 @@ function classDeps(
   selfDeps: string[];
   skipSelfDeps: string[];
   hostDeps: string[];
+  functionalInjects: FunctionalInjectNode[];
   missing: boolean;
 } {
   const injectable = parseInjectableOptions(cls, ctx);
-  if (injectable?.deps) {
-    return {
-      deps: injectable.deps,
-      optionalDeps: [],
-      selfDeps: [],
-      skipSelfDeps: [],
-      hostDeps: [],
-      missing: false,
-    };
-  }
-
   const ctor = cls.members.find(ts.isConstructorDeclaration);
-  const deps: string[] = [];
+  const deps: string[] = injectable?.deps ? [...injectable.deps] : [];
   const optionalDeps: string[] = [];
   const selfDeps: string[] = [];
   const skipSelfDeps: string[] = [];
   const hostDeps: string[] = [];
+  const functionalInjects: FunctionalInjectNode[] = [];
   let missing: boolean = false;
 
-  if (ctor && ctor.parameters.length > 0) {
+  if (!injectable?.deps && ctor && ctor.parameters.length > 0) {
     const injectParams = parseInjectParams(cls, ctx);
     const optionalIndices = parseOptionalParams(cls);
     const selfIndices = parseModifierParams(cls, "Self");
@@ -1310,7 +1542,7 @@ function classDeps(
     });
   }
 
-  // Property-level inject() calls (Angular functional DI syntax: private foo = inject(TOKEN))
+  // Property-level inject() calls (Angular functional DI syntax: private foo = inject(TOKEN)).
   for (const prop of cls.members.filter(ts.isPropertyDeclaration)) {
     const init = prop.initializer;
     if (init && ts.isCallExpression(init)) {
@@ -1319,33 +1551,56 @@ function classDeps(
         const [tokenArg, optionsArg] = init.arguments;
         if (tokenArg) {
           const tokenName = tokenText(tokenArg, ctx);
-          if (tokenName) {
-            if (!deps.includes(tokenName)) deps.push(tokenName);
-            if (optionsArg && ts.isObjectLiteralExpression(optionsArg)) {
-              const isOptional = booleanProp(optionsArg, "optional");
-              if (isOptional && !optionalDeps.includes(tokenName)) {
-                optionalDeps.push(tokenName);
+          const unwrappedToken = unwrapForwardRef(tokenArg);
+          const known = ts.isStringLiteral(unwrappedToken)
+            || (ts.isIdentifier(unwrappedToken)
+              && (ctx.tokensByName.has(tokenName) || ctx.classesByName.has(tokenName)));
+          if (!known) {
+            missing = true;
+            continue;
+          }
+          if (!deps.includes(tokenName)) deps.push(tokenName);
+          const options = optionsArg && ts.isObjectLiteralExpression(optionsArg)
+            ? {
+                optional: booleanProp(optionsArg, "optional") ?? false,
+                self: booleanProp(optionsArg, "self") ?? false,
+                skipSelf: booleanProp(optionsArg, "skipSelf") ?? false,
+                host: booleanProp(optionsArg, "host") ?? false,
               }
-              const isSelf = booleanProp(optionsArg, "self");
-              if (isSelf && !selfDeps.includes(tokenName)) {
-                selfDeps.push(tokenName);
-              }
-              const isSkipSelf = booleanProp(optionsArg, "skipSelf");
-              if (isSkipSelf && !skipSelfDeps.includes(tokenName)) {
-                skipSelfDeps.push(tokenName);
-              }
-              const isHost = booleanProp(optionsArg, "host");
-              if (isHost && !hostDeps.includes(tokenName)) {
-                hostDeps.push(tokenName);
-              }
-            }
+            : { optional: false, self: false, skipSelf: false, host: false };
+          if (options.optional && !optionalDeps.includes(tokenName)) optionalDeps.push(tokenName);
+          if (options.self && !selfDeps.includes(tokenName)) selfDeps.push(tokenName);
+          if (options.skipSelf && !skipSelfDeps.includes(tokenName)) skipSelfDeps.push(tokenName);
+          if (options.host && !hostDeps.includes(tokenName)) hostDeps.push(tokenName);
+          if (!functionalInjects.some((entry) => entry.token === tokenName)) {
+            functionalInjects.push({
+              token: tokenName,
+              expression: nodeText(unwrappedToken),
+              importPath: ts.isIdentifier(unwrappedToken)
+                ? (() => {
+                    const declaration = resolveDeclaration(unwrappedToken, ctx)[0];
+                    return declaration && isProjectSourcePath(declaration.getSourceFile().fileName, ctx.rootDir)
+                      ? modulePath(ctx.rootDir, declaration.getSourceFile().fileName)
+                      : undefined;
+                  })()
+                : undefined,
+              importModule: ts.isIdentifier(unwrappedToken)
+                ? (() => {
+                    const declaration = resolveDeclaration(unwrappedToken, ctx)[0];
+                    return declaration && !isProjectSourcePath(declaration.getSourceFile().fileName, ctx.rootDir)
+                      ? importModuleOf(unwrappedToken, ctx)
+                      : undefined;
+                  })()
+                : undefined,
+              ...options,
+            });
           }
         }
       }
     }
   }
 
-  return { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing };
+  return { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, functionalInjects, missing };
 }
 
 /** Fallback for constructor parameter type name: only used if type name references a known class or known InjectionToken variable. */
@@ -1506,6 +1761,23 @@ function resolveDeclaration(id: Identifier, ctx: AnalysisContext): ts.Declaratio
 function importPathOf(id: Identifier, ctx: AnalysisContext): string | undefined {
   const decl = resolveDeclaration(id, ctx)[0];
   if (decl) return modulePath(ctx.rootDir, decl.getSourceFile().fileName);
+  return undefined;
+}
+
+/** Package specifier for an imported symbol declared outside the project source tree. */
+function importModuleOf(id: Identifier, ctx: AnalysisContext): string | undefined {
+  const symbol = ctx.checker.getSymbolAtLocation(id);
+  const declarations = symbol?.declarations ?? [];
+  for (const declaration of declarations) {
+    let current: ts.Node | undefined = declaration;
+    while (current) {
+      if (ts.isImportDeclaration(current)) {
+        const moduleSpecifier = current.moduleSpecifier;
+        return ts.isStringLiteral(moduleSpecifier) ? moduleSpecifier.text : undefined;
+      }
+      current = current.parent;
+    }
+  }
   return undefined;
 }
 

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -1,21 +1,7 @@
-import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { join, relative, sep } from "node:path";
-import {
-  Node,
-  Project,
-  SyntaxKind,
-  type CallExpression,
-  type ClassDeclaration,
-  type Decorator,
-  type Expression,
-  type Identifier,
-  type ObjectLiteralExpression,
-  type ParameterDeclaration,
-  type SourceFile,
-  type Symbol as TsSymbol,
-  type VariableDeclaration,
-} from "ts-morph";
+import { relative, resolve as resolvePath, sep } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { createIncrementalProgramSession } from "./program";
 import type {
   ApplicationGraph,
   CachedModuleEntry,
@@ -44,6 +30,10 @@ const ROUTE_DECORATORS: Record<string, RouteNode["method"]> = {
 };
 const SCOPES: Scope[] = ["application", "request", "job"];
 
+function isScope(value: string): value is Scope {
+  return SCOPES.some((scope) => scope === value);
+}
+
 interface TokenInfo {
   /** Variable name, e.g. CASE_REPOSITORY. */
   name: string;
@@ -56,6 +46,18 @@ interface TokenInfo {
   line?: number;
 }
 
+type AstNode = ts.Node;
+type CallExpression = ts.CallExpression;
+type ClassDeclaration = ts.ClassDeclaration;
+type Decorator = ts.Decorator;
+type Expression = ts.Expression;
+type Identifier = ts.Identifier;
+type ObjectLiteralExpression = ts.ObjectLiteralExpression;
+type ParameterDeclaration = ts.ParameterDeclaration;
+type SourceFile = ts.SourceFile;
+type TsSymbol = ts.Symbol;
+type VariableDeclaration = ts.VariableDeclaration;
+
 interface ClassInfo {
   name: string;
   decl: ClassDeclaration;
@@ -65,13 +67,67 @@ interface ClassInfo {
 /** Analysis context: project-wide symbol index + diagnostics collection. */
 interface AnalysisContext {
   rootDir: string;
+  program: ts.Program;
+  checker: ts.TypeChecker;
   tokensByName: Map<string, TokenInfo>;
   classesByName: Map<string, ClassInfo>;
   diagnostics: Diagnostic[];
 }
 
+function nodeText(node: ts.Node): string {
+  return node.getText(node.getSourceFile());
+}
+
+function lineOf(node: ts.Node): number {
+  const sourceFile = node.getSourceFile();
+  return sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+}
+
+function variableName(decl: ts.VariableDeclaration): string {
+  return ts.isIdentifier(decl.name) ? decl.name.text : nodeText(decl.name);
+}
+
+function propertyName(name: ts.PropertyName | ts.BindingName): string {
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) return name.text;
+  if (ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return nodeText(name);
+}
+
+function parameterName(param: ts.ParameterDeclaration): string {
+  return ts.isIdentifier(param.name) ? param.name.text : nodeText(param.name);
+}
+
+function decoratorsOf(node: ts.Node): readonly ts.Decorator[] {
+  return ts.canHaveDecorators(node) ? ts.getDecorators(node) ?? [] : [];
+}
+
+function decoratorArguments(dec: ts.Decorator): readonly ts.Expression[] {
+  return ts.isCallExpression(dec.expression) ? dec.expression.arguments : [];
+}
+
+function hasMethod(cls: ts.ClassDeclaration, name: string): boolean {
+  return cls.members.some((member) =>
+    (ts.isMethodDeclaration(member) || ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) &&
+    member.name !== undefined &&
+    propertyName(member.name) === name,
+  );
+}
+
+function descendantsOfKind<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T,
+): T[] {
+  const result: T[] = [];
+  const visit = (node: ts.Node): void => {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  };
+  visit(root);
+  return result;
+}
+
 /**
- * Analyzes source code under rootDir (via ts-morph AST, without typecheck dependency) to build ApplicationGraph.
+ * Analyzes source code under rootDir via the native TypeScript Program API.
  * Decorators are matched by name only (Module/Injectable/Inject/Command/Query/Controller/Get/...),
  * without checking import origins, so this package does not need to depend on @supacloud/app.
  */
@@ -79,30 +135,45 @@ export async function analyzeProject(
   rootDir: string,
   include?: string[],
   cache?: DependencyGraphCache,
+  changedPaths?: string[],
 ): Promise<ApplicationGraph> {
-  let project: Project;
-  if (cache?.project) {
-    project = cache.project;
-    for (const sf of project.getSourceFiles()) {
-      sf.refreshFromFileSystemSync();
-    }
-  } else {
-    project = createProject(rootDir);
-    const patterns = (include ?? DEFAULT_INCLUDE).map((glob) => join(rootDir, glob));
-    project.addSourceFilesAtPaths(patterns);
-    if (cache) cache.project = project;
-  }
-  const sourceFiles = project
-    .getSourceFiles()
-    .filter((sf) => !sf.getFilePath().includes("node_modules") && !sf.isDeclarationFile())
-    .sort((a, b) => a.getFilePath().localeCompare(b.getFilePath()));
+  const session = cache?.programSession ?? createIncrementalProgramSession(rootDir);
+  if (cache) cache.programSession = session;
+  const rootNames = ts.sys.readDirectory(
+    rootDir,
+    [".ts", ".tsx"],
+    ["node_modules", "dist"],
+    include ?? DEFAULT_INCLUDE,
+  );
+  const update = session.update(rootNames, changedPaths);
+  const program = update.program;
+  const checker = program.getTypeChecker();
+  const sourceFiles = program.getSourceFiles()
+    .filter((sf) =>
+      !sf.isDeclarationFile &&
+      !sf.fileName.includes("/node_modules/") &&
+      !sf.fileName.includes("/dist/") &&
+      isProjectSourceFile(sf, rootDir),
+    )
+    .sort((a, b) => a.fileName.localeCompare(b.fileName));
 
   const ctx: AnalysisContext = {
     rootDir,
+    program,
+    checker,
     tokensByName: new Map(),
     classesByName: new Map(),
     diagnostics: [],
   };
+  const nativeTraitFiles = new Map<string, Set<string>>();
+  for (const diagnostic of session.getDiagnostics()) {
+    ctx.diagnostics.push(toCompilerDiagnostic(diagnostic, rootDir));
+  }
+  for (const trait of session.getTraits()) {
+    const kinds = nativeTraitFiles.get(trait.file) ?? new Set<string>();
+    kinds.add(trait.kind);
+    nativeTraitFiles.set(trait.file, kinds);
+  }
   for (const sf of sourceFiles) {
     indexFile(sf, ctx);
   }
@@ -118,35 +189,40 @@ export async function analyzeProject(
   }
   const candidates: ModuleCandidate[] = [];
   for (const sf of sourceFiles) {
-    for (const cls of sf.getClasses()) {
-      const moduleDec = findDecorator(cls, "Module");
-      if (!moduleDec) continue;
-      const options = decoratorObjectArg(moduleDec);
-      if (!options) continue;
-      candidates.push({
-        node: cls,
-        options,
-        className: cls.getName() ?? "<anonymous>",
-        file: sf.getFilePath(),
-        line: cls.getStartLineNumber(),
-      });
+    const traits = nativeTraitFiles.get(sf.fileName);
+    if (!cache || traits?.has("module")) {
+      for (const cls of sf.statements.filter(ts.isClassDeclaration)) {
+        const moduleDec = findDecorator(cls, "Module");
+        if (!moduleDec) continue;
+        const options = decoratorObjectArg(moduleDec);
+        if (!options) continue;
+        candidates.push({
+          node: cls,
+          options,
+          className: cls.name?.text ?? "<anonymous>",
+          file: sf.fileName,
+          line: lineOf(cls),
+        });
+      }
     }
-    for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
-      if (call.getExpression().getText() !== "defineModule") continue;
-      const parent = call.getParent();
-      if (!parent || !Node.isVariableDeclaration(parent)) continue;
-      const arg = call.getArguments()[0];
-      if (!arg || !Node.isObjectLiteralExpression(arg)) continue;
-      candidates.push({
-        node: parent,
-        options: arg,
-        className: parent.getName(),
-        file: sf.getFilePath(),
-        line: parent.getStartLineNumber(),
-      });
+    if (!cache || traits?.has("defineModule")) {
+      for (const call of descendantsOfKind<CallExpression>(sf, ts.isCallExpression)) {
+        if (nodeText(call.expression) !== "defineModule") continue;
+        const parent = call.parent;
+        if (!parent || !ts.isVariableDeclaration(parent)) continue;
+        const arg = call.arguments[0];
+        if (!arg || !ts.isObjectLiteralExpression(arg)) continue;
+        candidates.push({
+          node: parent,
+          options: arg,
+          className: variableName(parent),
+          file: sf.fileName,
+          line: lineOf(parent),
+        });
+      }
     }
   }
-  const nameByNode = new Map<Node, string>();
+  const nameByNode = new Map<AstNode, string>();
   for (const c of candidates) {
     nameByNode.set(c.node, stringLiteralProp(c.options, "name") ?? c.className);
   }
@@ -158,7 +234,7 @@ export async function analyzeProject(
   if (cache) {
     const currentFileHashes = new Map<string, string>();
     for (const sf of sourceFiles) {
-      const rel = sourcePath(rootDir, sf.getFilePath());
+      const rel = sourcePath(rootDir, sf.fileName);
       const hash = createHash("sha256").update(sf.getFullText()).digest("hex");
       currentFileHashes.set(rel, hash);
     }
@@ -177,7 +253,7 @@ export async function analyzeProject(
 
     const modulesToKeep = new Map<string, CachedModuleEntry>();
     const finalModules: ModuleNode[] = [];
-    const finalDiagnostics: Diagnostic[] = [];
+    const finalDiagnostics: Diagnostic[] = [...ctx.diagnostics];
     const affectedModuleNames = (cache.dependencyGraph && typeof cache.dependencyGraph.getAffectedModules === "function")
       ? new Set<string>(cache.dependencyGraph.getAffectedModules(Array.from(changedFiles)))
       : new Set<string>();
@@ -203,10 +279,7 @@ export async function analyzeProject(
       const parsed = parseModule(c, nameByNode, ctx);
       const moduleDiagnostics = ctx.diagnostics.slice(diagBefore);
 
-      const ownedFiles = new Set<string>();
-      ownedFiles.add(parsed.file);
-      for (const p of parsed.providers) if (p.file) ownedFiles.add(p.file);
-      for (const ctrl of parsed.controllers) if (ctrl.file) ownedFiles.add(ctrl.file);
+      const ownedFiles = collectModuleSourceClosure(parsed, ctx);
 
       const fileHashes: Record<string, string> = {};
       for (const f of ownedFiles) {
@@ -237,6 +310,7 @@ export async function analyzeProject(
   } else {
     modules = candidates.map((c) => parseModule(c, nameByNode, ctx));
   }
+  modules.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
 
   // Auto-collect standalone @Injectable({ providedIn: 'root' }) services
   // standalone @Controller({ standalone: true }) controllers,
@@ -266,7 +340,7 @@ export async function analyzeProject(
       if (injectable?.providedIn === "root") {
         const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing } = classDeps(classInfo.decl, ctx);
         const file = sourcePath(ctx.rootDir, classInfo.file);
-        const line = classInfo.decl.getStartLineNumber();
+        const line = lineOf(classInfo.decl);
         if (missing) {
           warn(ctx, "missing-deps", `root provider ${name} 的部分构造依赖无法静态解析`, file, line);
         }
@@ -282,7 +356,7 @@ export async function analyzeProject(
           skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
           hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
           providedIn: "root",
-          hasOnDestroy: classInfo.decl.getMethod("onDestroy") !== undefined || undefined,
+          hasOnDestroy: hasMethod(classInfo.decl, "onDestroy") || undefined,
           exported: true,
           file,
           line,
@@ -294,8 +368,8 @@ export async function analyzeProject(
     if (!allRegisteredControllers.has(name)) {
       const controllerDec = findDecorator(classInfo.decl, "Controller");
       if (controllerDec) {
-        const arg = controllerDec.getArguments()[0];
-        const isStandalone = arg && Node.isObjectLiteralExpression(arg) && booleanProp(arg, "standalone");
+        const arg = decoratorArguments(controllerDec)[0];
+        const isStandalone = arg && ts.isObjectLiteralExpression(arg) && booleanProp(arg, "standalone");
         if (isStandalone) {
           const ctrl = parseController(classInfo.decl, ctx);
           if (ctrl) standaloneControllers.push(ctrl);
@@ -309,8 +383,8 @@ export async function analyzeProject(
         const meta = decoratorObjectArg(commandDec);
         if (meta && booleanProp(meta, "standalone")) {
           standaloneCommands.push({
-            className: classInfo.decl.getName() ?? name,
-            name: stringLiteralProp(meta, "name") ?? classInfo.decl.getName() ?? name,
+            className: classInfo.decl.name?.text ?? name,
+            name: stringLiteralProp(meta, "name") ?? classInfo.decl.name?.text ?? name,
             permission: stringLiteralProp(meta, "permission"),
             transaction: commandModeProp(meta, "transaction") ?? "none",
             audit: stringLiteralProp(meta, "audit"),
@@ -342,12 +416,13 @@ export async function analyzeProject(
   if (rootProviders.length > 0 || standaloneControllers.length > 0 || standaloneCommands.length > 0) {
     const existingRoot = modules.find((m) => m.name === "root" || m.name === "app");
     if (existingRoot) {
-      existingRoot.providers.push(...rootProviders);
-      existingRoot.controllers.push(...standaloneControllers);
-      existingRoot.commands.push(...standaloneCommands);
-      for (const p of rootProviders) {
-        if (!existingRoot.exports.includes(p.token)) existingRoot.exports.push(p.token);
-      }
+      modules = modules.map((module) => module === existingRoot ? {
+        ...module,
+        providers: [...module.providers, ...rootProviders],
+        controllers: [...module.controllers, ...standaloneControllers],
+        commands: [...module.commands, ...standaloneCommands],
+        exports: [...new Set([...module.exports, ...rootProviders.map((provider) => provider.token)])],
+      } : module);
     } else {
       const fallbackFile = rootProviders[0]?.file ?? standaloneControllers[0]?.file ?? "root.ts";
       modules.unshift({
@@ -391,27 +466,86 @@ export async function analyzeProject(
   };
 }
 
-function createProject(rootDir: string): Project {
-  const tsConfigFilePath = join(rootDir, "tsconfig.json");
-  if (existsSync(tsConfigFilePath)) {
-    return new Project({ tsConfigFilePath, skipAddingFilesFromTsConfig: true });
+/**
+ * A module's semantic inputs include imported tokens, schemas, factories, and
+ * transitive local imports, not only the declaration files of its providers.
+ * Keeping this closure in the cache prevents shared source edits from being
+ * incorrectly treated as cache hits.
+ */
+function collectModuleSourceClosure(module: ModuleNode, ctx: AnalysisContext): Set<string> {
+  const seeds = new Set<string>();
+  const addRelativeModule = (path: string | undefined): void => {
+    if (!path) return;
+    const withExtension = /\.(tsx?|mts|cts|js)$/.test(path) ? path : `${path}.ts`;
+    seeds.add(resolveSourcePath(ctx.rootDir, withExtension));
+  };
+
+  addRelativeModule(module.file);
+  for (const provider of module.providers) addRelativeModule(provider.importPath);
+  for (const controller of module.controllers) addRelativeModule(controller.importPath);
+
+  const ownedFiles = new Set<string>();
+  const queue = [...seeds];
+  while (queue.length > 0) {
+    const fileName = queue.shift();
+    if (!fileName) continue;
+    const sourceFile = ctx.program.getSourceFile(fileName);
+    if (!sourceFile || sourceFile.isDeclarationFile || !isProjectSourceFile(sourceFile, ctx.rootDir)) continue;
+    const relativeFile = sourcePath(ctx.rootDir, sourceFile.fileName);
+    if (ownedFiles.has(relativeFile)) continue;
+    ownedFiles.add(relativeFile);
+
+    for (const statement of sourceFile.statements) {
+      let moduleName: string | undefined;
+      if (ts.isImportDeclaration(statement) && ts.isStringLiteral(statement.moduleSpecifier)) {
+        moduleName = statement.moduleSpecifier.text;
+      } else if (ts.isExportDeclaration(statement) && statement.moduleSpecifier && ts.isStringLiteral(statement.moduleSpecifier)) {
+        moduleName = statement.moduleSpecifier.text;
+      } else if (ts.isImportEqualsDeclaration(statement)
+        && ts.isExternalModuleReference(statement.moduleReference)
+        && ts.isStringLiteral(statement.moduleReference.expression)) {
+        moduleName = statement.moduleReference.expression.text;
+      }
+      if (!moduleName || moduleName.startsWith("node:")) continue;
+      const resolved = ts.resolveModuleName(
+        moduleName,
+        sourceFile.fileName,
+        ctx.program.getCompilerOptions(),
+        ts.sys,
+      ).resolvedModule?.resolvedFileName;
+      if (resolved && isProjectSourcePath(resolved, ctx.rootDir)) queue.push(resolved);
+    }
   }
-  return new Project({
-    compilerOptions: { experimentalDecorators: true, allowJs: false },
-  });
+  return ownedFiles;
+}
+
+function resolveSourcePath(rootDir: string, file: string): string {
+  const normalized = file.replace(/\\/g, "/");
+  return resolvePath(rootDir, normalized);
+}
+
+function isProjectSourcePath(fileName: string, rootDir: string): boolean {
+  const normalized = fileName.replace(/\\/g, "/");
+  const root = rootDir.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized === root || normalized.startsWith(`${root}/`);
+}
+
+function isProjectSourceFile(sourceFile: SourceFile, rootDir: string): boolean {
+  return isProjectSourcePath(sourceFile.fileName, rootDir)
+    && /\.(tsx?|mts|cts)$/.test(sourceFile.fileName);
 }
 
 /** Indexes InjectionToken variables and class declarations in the file. */
 function indexFile(sf: SourceFile, ctx: AnalysisContext): void {
-  for (const cls of sf.getClasses()) {
-    const name = cls.getName();
+  for (const cls of sf.statements.filter(ts.isClassDeclaration)) {
+    const name = cls.name?.text;
     if (name && !ctx.classesByName.has(name)) {
-      ctx.classesByName.set(name, { name, decl: cls, file: sf.getFilePath() });
+      ctx.classesByName.set(name, { name, decl: cls, file: sf.fileName });
     }
   }
-  for (const statement of sf.getVariableStatements()) {
-    for (const decl of statement.getDeclarations()) {
-      const info = parseTokenVariable(decl, sf.getFilePath());
+  for (const statement of sf.statements.filter(ts.isVariableStatement)) {
+    for (const decl of statement.declarationList.declarations) {
+      const info = parseTokenVariable(decl, sf.fileName);
       if (info && !ctx.tokensByName.has(info.name)) {
         ctx.tokensByName.set(info.name, info);
       }
@@ -421,18 +555,18 @@ function indexFile(sf: SourceFile, ctx: AnalysisContext): void {
 
 /** Parses `const X = new InjectionToken("name", { scope })` variable declaration. */
 function parseTokenVariable(decl: VariableDeclaration, file: string): TokenInfo | undefined {
-  const init = decl.getInitializer();
-  if (!init || !Node.isNewExpression(init)) return undefined;
-  if (init.getExpression().getText() !== "InjectionToken") return undefined;
-  const [nameArg, optionsArg] = init.getArguments();
-  const info: TokenInfo = { name: decl.getName(), file, line: decl.getStartLineNumber() };
-  if (nameArg && Node.isStringLiteral(nameArg)) {
-    info.stringName = nameArg.getLiteralText();
+  const init = decl.initializer;
+  if (!init || !ts.isNewExpression(init)) return undefined;
+  if (nodeText(init.expression) !== "InjectionToken") return undefined;
+  const [nameArg, optionsArg] = init.arguments ?? [];
+  const info: TokenInfo = { name: variableName(decl), file, line: lineOf(decl) };
+  if (nameArg && ts.isStringLiteral(nameArg)) {
+    info.stringName = nameArg.text;
   }
-  if (optionsArg && Node.isObjectLiteralExpression(optionsArg)) {
+  if (optionsArg && ts.isObjectLiteralExpression(optionsArg)) {
     const scope = stringLiteralProp(optionsArg, "scope");
-    if (scope && (SCOPES as string[]).includes(scope)) {
-      info.scope = scope as Scope;
+    if (scope && isScope(scope)) {
+      info.scope = scope;
     }
     const providedIn = stringLiteralProp(optionsArg, "providedIn");
     if (providedIn === "root") {
@@ -447,33 +581,33 @@ function parseTokenVariable(decl: VariableDeclaration, file: string): TokenInfo 
 }
 
 function parseModule(
-  candidate: { node: Node; options: ObjectLiteralExpression; className: string; file: string; line: number },
-  nameByNode: Map<Node, string>,
+  candidate: { node: AstNode; options: ObjectLiteralExpression; className: string; file: string; line: number },
+  nameByNode: Map<AstNode, string>,
   ctx: AnalysisContext,
 ): ModuleNode {
   const { options, className, file, line } = candidate;
   const name = nameByNode.get(candidate.node) ?? className;
 
   const tags = arrayProp(options, "tags")
-    .map((el) => (Node.isStringLiteral(el) ? el.getLiteralText() : el.getText().replace(/['"]/g, "")))
+    .map((el) => (ts.isStringLiteral(el) ? el.text : nodeText(el).replace(/['"]/g, "")))
     .filter(Boolean);
 
   const imports = arrayProp(options, "imports")
     .map((el) => {
       const unwrapped = unwrapForwardRef(el);
-      const decl = Node.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped)[0] : undefined;
+      const decl = ts.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped, ctx)[0] : undefined;
       if (decl) {
         const known = nameByNode.get(decl);
         if (known) return known;
-        if (Node.isClassDeclaration(decl)) {
+        if (ts.isClassDeclaration(decl)) {
           const dec = findDecorator(decl, "Module");
           const decOptions = dec && decoratorObjectArg(dec);
           const decName = decOptions && stringLiteralProp(decOptions, "name");
-          return decName ?? decl.getName() ?? el.getText();
+          return decName ?? decl.name?.text ?? nodeText(el);
         }
-        if (Node.isVariableDeclaration(decl)) return decl.getName();
+        if (ts.isVariableDeclaration(decl)) return variableName(decl);
       }
-      return el.getText();
+      return nodeText(el);
     })
     .filter((v, i, arr) => arr.indexOf(v) === i);
 
@@ -496,16 +630,16 @@ function parseModule(
   const handlerClasses: ClassDeclaration[] = [];
   const seenHandlers = new Set<string>();
   const collectHandler = (expr: Expression) => {
-    if (!Node.isIdentifier(expr)) return;
-    const decl = resolveDeclaration(expr)[0];
-    if (decl && Node.isClassDeclaration(decl) && !seenHandlers.has(decl.getName() ?? "")) {
-      seenHandlers.add(decl.getName() ?? "");
+    if (!ts.isIdentifier(expr)) return;
+    const decl = resolveDeclaration(expr, ctx)[0];
+    if (decl && ts.isClassDeclaration(decl) && !seenHandlers.has(decl.name?.text ?? "")) {
+      seenHandlers.add(decl.name?.text ?? "");
       handlerClasses.push(decl);
     }
   };
   for (const el of arrayProp(options, "providers")) {
-    if (Node.isIdentifier(el)) collectHandler(el);
-    if (Node.isObjectLiteralExpression(el)) {
+    if (ts.isIdentifier(el)) collectHandler(el);
+    if (ts.isObjectLiteralExpression(el)) {
       const useClass = getProp(el, "useClass");
       if (useClass) collectHandler(useClass);
     }
@@ -521,8 +655,8 @@ function parseModule(
       const meta = decoratorObjectArg(commandDec);
       if (meta) {
         commands.push({
-          className: cls.getName() ?? "<anonymous>",
-          name: stringLiteralProp(meta, "name") ?? cls.getName() ?? "<anonymous>",
+          className: cls.name?.text ?? "<anonymous>",
+          name: stringLiteralProp(meta, "name") ?? cls.name?.text ?? "<anonymous>",
           permission: stringLiteralProp(meta, "permission"),
           transaction: commandModeProp(meta, "transaction") ?? "none",
           audit: stringLiteralProp(meta, "audit"),
@@ -536,8 +670,8 @@ function parseModule(
       const meta = decoratorObjectArg(queryDec);
       if (meta) {
         queries.push({
-          className: cls.getName() ?? "<anonymous>",
-          name: stringLiteralProp(meta, "name") ?? cls.getName() ?? "<anonymous>",
+          className: cls.name?.text ?? "<anonymous>",
+          name: stringLiteralProp(meta, "name") ?? cls.name?.text ?? "<anonymous>",
         });
       }
     }
@@ -571,15 +705,15 @@ function parseProvider(
   exportsSet: Set<string>,
   ctx: AnalysisContext,
 ): ProviderNode | undefined {
-  const file = sourcePath(ctx.rootDir, el.getSourceFile().getFilePath());
-  const line = el.getStartLineNumber();
+  const file = sourcePath(ctx.rootDir, el.getSourceFile().fileName);
+  const line = lineOf(el);
 
   const unwrappedEl = unwrapForwardRef(el);
   // Bare class reference -> class provider, token = class name
-  if (Node.isIdentifier(unwrappedEl)) {
-    const decl = resolveDeclaration(unwrappedEl)[0];
-    const cls = decl && Node.isClassDeclaration(decl) ? decl : undefined;
-    const className = cls?.getName() ?? unwrappedEl.getText();
+  if (ts.isIdentifier(unwrappedEl)) {
+    const decl = resolveDeclaration(unwrappedEl, ctx)[0];
+    const cls = decl && ts.isClassDeclaration(decl) ? decl : undefined;
+    const className = cls?.name?.text ?? unwrappedEl.text;
     const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing } = cls
       ? classDeps(cls, ctx)
       : { deps: [], optionalDeps: [], selfDeps: [], skipSelfDeps: [], hostDeps: [], missing: false };
@@ -599,15 +733,15 @@ function parseProvider(
       skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
       hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
       providedIn: injectable?.providedIn,
-      hasOnDestroy: cls?.getMethod("onDestroy") !== undefined || undefined,
+      hasOnDestroy: cls ? hasMethod(cls, "onDestroy") || undefined : undefined,
       exported: exportsSet.has(className),
       file,
       line,
-      importPath: cls ? modulePath(ctx.rootDir, cls.getSourceFile().getFilePath()) : undefined,
+      importPath: cls ? modulePath(ctx.rootDir, cls.getSourceFile().fileName) : undefined,
     };
   }
 
-  if (!Node.isObjectLiteralExpression(el)) return undefined;
+  if (!ts.isObjectLiteralExpression(el)) return undefined;
   const provideExpr = getProp(el, "provide");
   if (!provideExpr) return undefined;
   const { name: token, kind: tokenKind } = tokenNameOf(provideExpr, ctx);
@@ -622,9 +756,9 @@ function parseProvider(
 
   if (useClassExpr) {
     const unwrappedClass = unwrapForwardRef(useClassExpr);
-    const decl = Node.isIdentifier(unwrappedClass) ? resolveDeclaration(unwrappedClass)[0] : undefined;
-    const cls = decl && Node.isClassDeclaration(decl) ? decl : undefined;
-    const useClass = cls?.getName() ?? unwrappedClass.getText();
+    const decl = ts.isIdentifier(unwrappedClass) ? resolveDeclaration(unwrappedClass, ctx)[0] : undefined;
+    const cls = decl && ts.isClassDeclaration(decl) ? decl : undefined;
+    const useClass = cls?.name?.text ?? nodeText(unwrappedClass);
     let deps = explicitDeps;
     let optionalDeps: string[] = [];
     let selfDeps: string[] = [];
@@ -642,6 +776,7 @@ function parseProvider(
       }
     }
     const injectable = cls ? parseInjectableOptions(cls, ctx) : undefined;
+    validateProviderCompatibility(provideExpr, useClassExpr, "class", token, ctx, file, line);
     return {
       token,
       tokenKind,
@@ -655,41 +790,43 @@ function parseProvider(
       hostDeps: hostDeps.length > 0 ? hostDeps : undefined,
       multi: multi ?? undefined,
       providedIn: injectable?.providedIn,
-      hasOnDestroy: cls?.getMethod("onDestroy") !== undefined || undefined,
+      hasOnDestroy: cls ? hasMethod(cls, "onDestroy") || undefined : undefined,
       exported: exportsSet.has(token),
       file,
       line,
-      importPath: cls ? modulePath(ctx.rootDir, cls.getSourceFile().getFilePath()) : undefined,
+      importPath: cls ? modulePath(ctx.rootDir, cls.getSourceFile().fileName) : undefined,
     };
   }
 
   if (useValueExpr) {
+    validateProviderCompatibility(provideExpr, useValueExpr, "value", token, ctx, file, line);
     return {
       token,
       tokenKind,
       kind: "value",
-      useValueExpr: useValueExpr.getText(),
+      useValueExpr: nodeText(useValueExpr),
       scope: resolveScope({ explicit: explicitScope, tokenName: token }, ctx),
       deps: [],
       multi: multi ?? undefined,
       exported: exportsSet.has(token),
       file,
       line,
-      importPath: Node.isIdentifier(useValueExpr)
+      importPath: ts.isIdentifier(useValueExpr)
         ? importPathOf(useValueExpr, ctx)
         : undefined,
     };
   }
 
   if (useFactoryExpr) {
-    const factoryName = Node.isIdentifier(useFactoryExpr)
+    const factoryName = ts.isIdentifier(useFactoryExpr)
       ? (() => {
-          const decl = resolveDeclaration(useFactoryExpr)[0];
-          return decl && (Node.isFunctionDeclaration(decl) || Node.isVariableDeclaration(decl))
-            ? decl.getName() ?? useFactoryExpr.getText()
-            : useFactoryExpr.getText();
+          const decl = resolveDeclaration(useFactoryExpr, ctx)[0];
+          return decl && (ts.isFunctionDeclaration(decl) || ts.isVariableDeclaration(decl))
+            ? (ts.isFunctionDeclaration(decl) ? decl.name?.text : variableName(decl)) ?? useFactoryExpr.text
+            : useFactoryExpr.text;
         })()
-      : useFactoryExpr.getText();
+      : nodeText(useFactoryExpr);
+    validateProviderCompatibility(provideExpr, useFactoryExpr, "factory", token, ctx, file, line);
     return {
       token,
       tokenKind,
@@ -701,7 +838,7 @@ function parseProvider(
       exported: exportsSet.has(token),
       file,
       line,
-      importPath: Node.isIdentifier(useFactoryExpr)
+      importPath: ts.isIdentifier(useFactoryExpr)
         ? importPathOf(useFactoryExpr, ctx)
         : undefined,
     };
@@ -709,6 +846,7 @@ function parseProvider(
 
   if (useExistingExpr) {
     const target = tokenNameOf(useExistingExpr, ctx).name;
+    validateProviderCompatibility(provideExpr, useExistingExpr, "existing", token, ctx, file, line);
     return {
       token,
       tokenKind,
@@ -726,30 +864,120 @@ function parseProvider(
   return undefined;
 }
 
+/**
+ * Validates Angular-style provider contracts during compilation. The emitted
+ * application still uses static factories and never performs runtime type
+ * inspection or dynamic dependency resolution.
+ */
+function validateProviderCompatibility(
+  provideExpr: Expression,
+  implementationExpr: Expression,
+  kind: "class" | "value" | "factory" | "existing",
+  tokenName: string,
+  ctx: AnalysisContext,
+  file: string,
+  line: number,
+): void {
+  const expected = providerTokenValueType(provideExpr, ctx);
+  const actual = providerImplementationType(implementationExpr, kind, ctx);
+  if (!expected || !actual || isUnknownOrAny(expected) || isUnknownOrAny(actual)) return;
+  if (ctx.checker.isTypeAssignableTo(actual, expected)) return;
+
+  const providerKind = kind === "class" ? "useClass" : `use${kind.charAt(0).toUpperCase()}${kind.slice(1)}`;
+  ctx.diagnostics.push({
+    severity: "error",
+    code: "provider-type-mismatch",
+    message: `Provider '${tokenName}' 的 ${providerKind} 类型不满足 Token 契约：需要 ${ctx.checker.typeToString(expected, provideExpr)}，实际为 ${ctx.checker.typeToString(actual, implementationExpr)}`,
+    file,
+    line,
+    errorCode: "SC2010",
+    docsUrl: "https://supacloud.dev/errors/SC2010",
+  });
+}
+
+function providerTokenValueType(expr: Expression, ctx: AnalysisContext): ts.Type | undefined {
+  const type = ctx.checker.getTypeAtLocation(expr);
+  const typeArguments = typeArgumentsOf(type, ctx);
+  if (typeArguments.length > 0) return typeArguments[0];
+
+  if (ts.isIdentifier(expr)) {
+    const declaration = resolveDeclaration(expr, ctx)[0];
+    if (declaration && ts.isClassDeclaration(declaration)) {
+      return declaredClassType(declaration, ctx);
+    }
+  }
+  return undefined;
+}
+
+function providerImplementationType(
+  expr: Expression,
+  kind: "class" | "value" | "factory" | "existing",
+  ctx: AnalysisContext,
+): ts.Type | undefined {
+  if (kind === "class" || kind === "existing") {
+    if (ts.isIdentifier(expr)) {
+      const declaration = resolveDeclaration(expr, ctx)[0];
+      if (declaration && ts.isClassDeclaration(declaration)) {
+        return declaredClassType(declaration, ctx);
+      }
+    }
+    const type = ctx.checker.getTypeAtLocation(expr);
+    const typeArguments = typeArgumentsOf(type, ctx);
+    return typeArguments.length > 0 ? typeArguments[0] : undefined;
+  }
+
+  if (kind === "factory") {
+    const type = ctx.checker.getTypeAtLocation(expr);
+    const signature = ctx.checker.getSignaturesOfType(type, ts.SignatureKind.Call)[0];
+    return signature?.getReturnType();
+  }
+
+  return ctx.checker.getTypeAtLocation(expr);
+}
+
+function declaredClassType(declaration: ClassDeclaration, ctx: AnalysisContext): ts.Type | undefined {
+  const name = declaration.name;
+  if (!name) return undefined;
+  const symbol = ctx.checker.getSymbolAtLocation(name);
+  return symbol ? ctx.checker.getDeclaredTypeOfSymbol(symbol) : undefined;
+}
+
+function typeArgumentsOf(type: ts.Type, ctx: AnalysisContext): readonly ts.Type[] {
+  return isTypeReference(type) ? ctx.checker.getTypeArguments(type) : [];
+}
+
+function isTypeReference(type: ts.Type): type is ts.TypeReference {
+  return "target" in type;
+}
+
+function isUnknownOrAny(type: ts.Type): boolean {
+  return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+}
+
 function parseController(
   input: Expression | ClassDeclaration,
   ctx: AnalysisContext,
 ): ControllerNode | undefined {
   let decl: ClassDeclaration | undefined;
-  if (Node.isClassDeclaration(input)) {
+  if (ts.isClassDeclaration(input)) {
     decl = input;
   } else {
     const unwrapped = unwrapForwardRef(input);
-    const resolved = Node.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped)[0] : undefined;
-    if (resolved && Node.isClassDeclaration(resolved)) {
+    const resolved = ts.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped, ctx)[0] : undefined;
+    if (resolved && ts.isClassDeclaration(resolved)) {
       decl = resolved;
     }
   }
   if (!decl) return undefined;
   const controllerDec = findDecorator(decl, "Controller");
   if (!controllerDec) return undefined;
-  let path = "/";
+  let path: string = "/";
   let standalone: boolean | undefined;
-  const pathArg = controllerDec.getArguments()[0];
+  const pathArg = decoratorArguments(controllerDec)[0];
   if (pathArg) {
-    if (Node.isStringLiteral(pathArg)) {
-      path = pathArg.getLiteralText();
-    } else if (Node.isObjectLiteralExpression(pathArg)) {
+    if (ts.isStringLiteral(pathArg)) {
+      path = pathArg.text;
+    } else if (ts.isObjectLiteralExpression(pathArg)) {
       const p = stringLiteralProp(pathArg, "path");
       if (p) path = p;
       standalone = booleanProp(pathArg, "standalone");
@@ -757,35 +985,35 @@ function parseController(
   }
 
   const { deps, optionalDeps, selfDeps, skipSelfDeps, missing } = classDeps(decl, ctx);
-  const file = sourcePath(ctx.rootDir, decl.getSourceFile().getFilePath());
+  const file = sourcePath(ctx.rootDir, decl.getSourceFile().fileName);
   if (missing) {
-    warn(ctx, "missing-deps", `controller ${decl.getName()} 的部分构造依赖无法静态解析`, file, decl.getStartLineNumber());
+    warn(ctx, "missing-deps", `controller ${decl.name?.text} 的部分构造依赖无法静态解析`, file, lineOf(decl));
   }
 
   const injectable = parseInjectableOptions(decl, ctx);
   const routes: RouteNode[] = [];
   const schemaImports: Record<string, string> = {};
   const classGuards: string[] = [];
-  for (const dec of decl.getDecorators()) {
+  for (const dec of decoratorsOf(decl)) {
     if (decoratorName(dec) === "UseGuards") {
-      for (const gArg of dec.getArguments()) {
-        classGuards.push(tokenText(gArg as Expression));
+      for (const gArg of decoratorArguments(dec)) {
+        classGuards.push(tokenText(gArg, ctx));
       }
     }
   }
 
-  for (const method of decl.getMethods()) {
-    for (const dec of method.getDecorators()) {
+  for (const method of decl.members.filter(ts.isMethodDeclaration)) {
+    for (const dec of decoratorsOf(method)) {
       const name = decoratorName(dec);
       const httpMethod = name ? ROUTE_DECORATORS[name] : undefined;
       if (!httpMethod) continue;
-      const args = dec.getArguments();
+      const args = decoratorArguments(dec);
       const pathArg = args[0];
-      const routePath = pathArg && Node.isStringLiteral(pathArg) ? pathArg.getLiteralText() : "/";
+      const routePath = pathArg && ts.isStringLiteral(pathArg) ? pathArg.text : "/";
       const route: RouteNode = {
         method: httpMethod,
         path: routePath,
-        handler: method.getName(),
+        handler: propertyName(method.name),
       };
       const pathParams: string[] = [];
       const paramRegex = /:([a-zA-Z0-9_]+)/g;
@@ -801,15 +1029,15 @@ function parseController(
       const paramDefaults: Record<string, unknown> = {};
       const queryTransforms: Record<string, "number" | "boolean" | "string"> = {};
       const queryDefaults: Record<string, unknown> = {};
-      let hasBodyBinding = false;
+      let hasBodyBinding: boolean = false;
       const handlerParams: HandlerParamNode[] = [];
-      for (const p of method.getParameters()) {
-        const pName = p.getName();
-        let hasBindingDecorator = false;
+      for (const p of method.parameters) {
+        const pName = parameterName(p);
+        let hasBindingDecorator: boolean = false;
         let paramNode: HandlerParamNode | undefined;
-        for (const pDec of p.getDecorators()) {
+        for (const pDec of decoratorsOf(p)) {
           const dName = decoratorName(pDec);
-          const dArgs = pDec.getArguments();
+          const dArgs = decoratorArguments(pDec);
           if (dName === "Param") {
             hasBindingDecorator = true;
             const parsed = parseBindingOptions(dArgs, pName);
@@ -850,7 +1078,7 @@ function parseController(
         // automatically infer the path parameter binding and deduce its primitive transform.
         if (!hasBindingDecorator && pathParams.includes(pName)) {
           paramBindings.push(pName);
-          const typeText = p.getType().getText();
+          const typeText = p.type ? nodeText(p.type) : "";
           let inferredTransform: "number" | "boolean" | "string" | undefined;
           if (typeText === "number") {
             paramTransforms[pName] = "number";
@@ -885,36 +1113,36 @@ function parseController(
 
       const routeGuards: string[] = [...classGuards];
       const routeCanDeactivate: string[] = [];
-      for (const mDec of method.getDecorators()) {
+      for (const mDec of decoratorsOf(method)) {
         const dName = decoratorName(mDec);
-        const mArgs = mDec.getArguments();
+        const mArgs = decoratorArguments(mDec);
         if (dName === "UseGuards") {
           for (const gArg of mArgs) {
-            routeGuards.push(tokenText(gArg as Expression));
+            routeGuards.push(tokenText(gArg, ctx));
           }
         } else if (dName === "CanDeactivate") {
           for (const gArg of mArgs) {
-            routeCanDeactivate.push(tokenText(gArg as Expression));
+            routeCanDeactivate.push(tokenText(gArg, ctx));
           }
         } else if (dName === "Title") {
           const tArg = mArgs[0];
-          if (tArg && Node.isStringLiteral(tArg)) {
-            route.title = tArg.getLiteralText();
+          if (tArg && ts.isStringLiteral(tArg)) {
+            route.title = tArg.text;
           }
         } else if (dName === "Data") {
           const dArg = mArgs[0];
-          if (dArg && Node.isObjectLiteralExpression(dArg)) {
+          if (dArg && ts.isObjectLiteralExpression(dArg)) {
             route.data = { ...route.data, ...parseObjectLiteralValues(dArg) };
           }
         } else if (dName === "Resolve") {
           const rArg = mArgs[0];
-          if (rArg && Node.isObjectLiteralExpression(rArg)) {
+          if (rArg && ts.isObjectLiteralExpression(rArg)) {
             const resolvers: Record<string, string> = route.resolvers ?? {};
-            for (const prop of rArg.getProperties()) {
-              if (Node.isPropertyAssignment(prop)) {
-                const rName = prop.getName();
-                const init = prop.getInitializer();
-                if (init) resolvers[rName] = tokenText(init);
+            for (const prop of rArg.properties) {
+              if (ts.isPropertyAssignment(prop)) {
+                const rName = propertyName(prop.name);
+                const init = prop.initializer;
+                if (init) resolvers[rName] = tokenText(init, ctx);
               }
             }
             if (Object.keys(resolvers).length > 0) {
@@ -925,52 +1153,52 @@ function parseController(
       }
 
       const optionsArg = args[1];
-      if (optionsArg && Node.isObjectLiteralExpression(optionsArg)) {
+      if (optionsArg && ts.isObjectLiteralExpression(optionsArg)) {
         for (const field of ["body", "params", "query", "response"] as const) {
           const schemaExpr = getProp(optionsArg, field);
-          if (schemaExpr && Node.isIdentifier(schemaExpr)) {
-            route[field] = schemaExpr.getText();
+          if (schemaExpr && ts.isIdentifier(schemaExpr)) {
+            route[field] = nodeText(schemaExpr);
             const importPath = importPathOf(schemaExpr, ctx);
-            if (importPath) schemaImports[schemaExpr.getText()] = importPath;
+            if (importPath) schemaImports[schemaExpr.text] = importPath;
           }
         }
         const commandExpr = getProp(optionsArg, "command");
-        if (commandExpr && Node.isIdentifier(commandExpr)) {
-          const commandDecl = resolveDeclaration(commandExpr)[0];
-          route.command = commandDecl && Node.isClassDeclaration(commandDecl)
-            ? (commandDecl.getName() ?? commandExpr.getText())
-            : commandExpr.getText();
+        if (commandExpr && ts.isIdentifier(commandExpr)) {
+          const commandDecl = resolveDeclaration(commandExpr, ctx)[0];
+          route.command = commandDecl && ts.isClassDeclaration(commandDecl)
+            ? (commandDecl.name?.text ?? commandExpr.text)
+            : commandExpr.text;
         }
         const guardsExpr = getProp(optionsArg, "guards");
-        if (guardsExpr && Node.isArrayLiteralExpression(guardsExpr)) {
-          for (const el of guardsExpr.getElements()) {
-            routeGuards.push(tokenText(el));
+        if (guardsExpr && ts.isArrayLiteralExpression(guardsExpr)) {
+          for (const el of guardsExpr.elements) {
+            routeGuards.push(tokenText(el, ctx));
           }
         }
         const canMatchExpr = getProp(optionsArg, "canMatch");
-        if (canMatchExpr && Node.isArrayLiteralExpression(canMatchExpr)) {
+        if (canMatchExpr && ts.isArrayLiteralExpression(canMatchExpr)) {
           const canMatchList: string[] = [];
-          for (const el of canMatchExpr.getElements()) {
-            canMatchList.push(tokenText(el));
+          for (const el of canMatchExpr.elements) {
+            canMatchList.push(tokenText(el, ctx));
           }
           if (canMatchList.length > 0) {
             route.canMatch = canMatchList;
           }
         }
         const canDeactivateExpr = getProp(optionsArg, "canDeactivate");
-        if (canDeactivateExpr && Node.isArrayLiteralExpression(canDeactivateExpr)) {
-          for (const el of canDeactivateExpr.getElements()) {
-            routeCanDeactivate.push(tokenText(el));
+        if (canDeactivateExpr && ts.isArrayLiteralExpression(canDeactivateExpr)) {
+          for (const el of canDeactivateExpr.elements) {
+            routeCanDeactivate.push(tokenText(el, ctx));
           }
         }
         const resolversExpr = getProp(optionsArg, "resolvers");
-        if (resolversExpr && Node.isObjectLiteralExpression(resolversExpr)) {
+        if (resolversExpr && ts.isObjectLiteralExpression(resolversExpr)) {
           const resolvers: Record<string, string> = {};
-          for (const prop of resolversExpr.getProperties()) {
-            if (Node.isPropertyAssignment(prop)) {
-              const rName = prop.getName();
-              const init = prop.getInitializer();
-              if (init) resolvers[rName] = tokenText(init);
+          for (const prop of resolversExpr.properties) {
+            if (ts.isPropertyAssignment(prop)) {
+              const rName = propertyName(prop.name);
+              const init = prop.initializer;
+              if (init) resolvers[rName] = tokenText(init, ctx);
             }
           }
           if (Object.keys(resolvers).length > 0) {
@@ -978,22 +1206,22 @@ function parseController(
           }
         }
         const redirectToExpr = getProp(optionsArg, "redirectTo");
-        if (redirectToExpr && Node.isStringLiteral(redirectToExpr)) {
-          route.redirectTo = redirectToExpr.getLiteralText();
+        if (redirectToExpr && ts.isStringLiteral(redirectToExpr)) {
+          route.redirectTo = redirectToExpr.text;
         }
         const pathMatchExpr = getProp(optionsArg, "pathMatch");
-        if (pathMatchExpr && Node.isStringLiteral(pathMatchExpr)) {
-          const val = pathMatchExpr.getLiteralText();
+        if (pathMatchExpr && ts.isStringLiteral(pathMatchExpr)) {
+          const val = pathMatchExpr.text;
           if (val === "full" || val === "prefix") {
             route.pathMatch = val;
           }
         }
         const titleExpr = getProp(optionsArg, "title");
-        if (titleExpr && Node.isStringLiteral(titleExpr)) {
-          route.title = titleExpr.getLiteralText();
+        if (titleExpr && ts.isStringLiteral(titleExpr)) {
+          route.title = titleExpr.text;
         }
         const dataExpr = getProp(optionsArg, "data");
-        if (dataExpr && Node.isObjectLiteralExpression(dataExpr)) {
+        if (dataExpr && ts.isObjectLiteralExpression(dataExpr)) {
           route.data = { ...route.data, ...parseObjectLiteralValues(dataExpr) };
         }
       }
@@ -1008,17 +1236,18 @@ function parseController(
   }
 
   return {
-    className: decl.getName() ?? "<anonymous>",
+    className: decl.name?.text ?? "<anonymous>",
     path,
     scope: injectable?.scope ?? "request",
     deps,
+    hasOnDestroy: hasMethod(decl, "onDestroy") || undefined,
     optionalDeps: optionalDeps.length > 0 ? optionalDeps : undefined,
     selfDeps: selfDeps.length > 0 ? selfDeps : undefined,
     skipSelfDeps: skipSelfDeps.length > 0 ? skipSelfDeps : undefined,
     standalone: standalone || undefined,
     routes,
     file,
-    importPath: modulePath(ctx.rootDir, decl.getSourceFile().getFilePath()),
+    importPath: modulePath(ctx.rootDir, decl.getSourceFile().fileName),
     schemaImports: Object.keys(schemaImports).length > 0 ? schemaImports : undefined,
   };
 }
@@ -1051,21 +1280,21 @@ function classDeps(
     };
   }
 
-  const ctor = cls.getConstructors()[0];
+  const ctor = cls.members.find(ts.isConstructorDeclaration);
   const deps: string[] = [];
   const optionalDeps: string[] = [];
   const selfDeps: string[] = [];
   const skipSelfDeps: string[] = [];
   const hostDeps: string[] = [];
-  let missing = false;
+  let missing: boolean = false;
 
-  if (ctor && ctor.getParameters().length > 0) {
-    const injectParams = parseInjectParams(cls);
+  if (ctor && ctor.parameters.length > 0) {
+    const injectParams = parseInjectParams(cls, ctx);
     const optionalIndices = parseOptionalParams(cls);
     const selfIndices = parseModifierParams(cls, "Self");
     const skipSelfIndices = parseModifierParams(cls, "SkipSelf");
     const hostIndices = parseModifierParams(cls, "Host");
-    ctor.getParameters().forEach((param, index) => {
+    ctor.parameters.forEach((param, index) => {
       const isOptional = optionalIndices.has(index);
       const injected = injectParams.get(index);
       const tokenName = injected ?? paramTypeTokenName(param, ctx);
@@ -1082,17 +1311,17 @@ function classDeps(
   }
 
   // Property-level inject() calls (Angular functional DI syntax: private foo = inject(TOKEN))
-  for (const prop of cls.getProperties()) {
-    const init = prop.getInitializer();
-    if (init && Node.isCallExpression(init)) {
-      const callName = init.getExpression().getText().split(".").pop();
+  for (const prop of cls.members.filter(ts.isPropertyDeclaration)) {
+    const init = prop.initializer;
+    if (init && ts.isCallExpression(init)) {
+      const callName = nodeText(init.expression).split(".").pop();
       if (callName === "inject") {
-        const [tokenArg, optionsArg] = init.getArguments();
+        const [tokenArg, optionsArg] = init.arguments;
         if (tokenArg) {
-          const tokenName = tokenText(tokenArg as Expression);
+          const tokenName = tokenText(tokenArg, ctx);
           if (tokenName) {
             if (!deps.includes(tokenName)) deps.push(tokenName);
-            if (optionsArg && Node.isObjectLiteralExpression(optionsArg)) {
+            if (optionsArg && ts.isObjectLiteralExpression(optionsArg)) {
               const isOptional = booleanProp(optionsArg, "optional");
               if (isOptional && !optionalDeps.includes(tokenName)) {
                 optionalDeps.push(tokenName);
@@ -1121,9 +1350,9 @@ function classDeps(
 
 /** Fallback for constructor parameter type name: only used if type name references a known class or known InjectionToken variable. */
 function paramTypeTokenName(param: ParameterDeclaration, ctx: AnalysisContext): string | undefined {
-  const typeNode = param.getTypeNode();
+  const typeNode = param.type;
   if (!typeNode) return undefined;
-  const text = typeNode.getText().replace(/<.*>$/, "").replace(/\[\]$/, "").trim();
+  const text = nodeText(typeNode).replace(/<.*>$/, "").replace(/\[\]$/, "").trim();
   if (ctx.classesByName.has(text)) return text;
   if (ctx.tokensByName.has(text)) return text;
   return undefined;
@@ -1145,24 +1374,24 @@ function parseInjectableOptions(
   const providedIn = stringLiteralProp(obj, "providedIn");
   const depsExpr = getProp(obj, "deps");
   return {
-    scope: scope && (SCOPES as string[]).includes(scope) ? (scope as Scope) : undefined,
+    scope: scope && isScope(scope) ? scope : undefined,
     providedIn: providedIn === "root" ? "root" : undefined,
     deps: depsExpr
-      ? arrayProp(obj, "deps").map((el) => (ctx ? tokenNameOf(el, ctx).name : el.getText()))
+      ? arrayProp(obj, "deps").map((el) => (ctx ? tokenNameOf(el, ctx).name : nodeText(el)))
       : undefined,
   };
 }
 
 /** Constructor @Inject(token) parameter decorator -> parameter index -> token name. */
-function parseInjectParams(cls: ClassDeclaration): Map<number, string> {
+function parseInjectParams(cls: ClassDeclaration, ctx: AnalysisContext): Map<number, string> {
   const result = new Map<number, string>();
-  const ctor = cls.getConstructors()[0];
+  const ctor = cls.members.find(ts.isConstructorDeclaration);
   if (!ctor) return result;
-  ctor.getParameters().forEach((param, index) => {
-    for (const dec of param.getDecorators()) {
+  ctor.parameters.forEach((param, index) => {
+    for (const dec of decoratorsOf(param)) {
       if (decoratorName(dec) !== "Inject") continue;
-      const arg = dec.getArguments()[0];
-      if (arg) result.set(index, tokenText(arg as Expression));
+      const arg = decoratorArguments(dec)[0];
+      if (arg) result.set(index, tokenText(arg, ctx));
     }
   });
   return result;
@@ -1171,23 +1400,23 @@ function parseInjectParams(cls: ClassDeclaration): Map<number, string> {
 /** Constructor @Optional() parameter decorator or question token -> parameter indices. */
 function parseOptionalParams(cls: ClassDeclaration): Set<number> {
   const result = new Set<number>();
-  const ctor = cls.getConstructors()[0];
+  const ctor = cls.members.find(ts.isConstructorDeclaration);
   if (!ctor) return result;
-  ctor.getParameters().forEach((param, index) => {
-    for (const dec of param.getDecorators()) {
+  ctor.parameters.forEach((param, index) => {
+    for (const dec of decoratorsOf(param)) {
       if (decoratorName(dec) === "Optional") result.add(index);
     }
-    if (param.hasQuestionToken()) result.add(index);
+    if (param.questionToken) result.add(index);
   });
   return result;
 }
 
 function parseModifierParams(cls: ClassDeclaration, modifierName: string): Set<number> {
   const result = new Set<number>();
-  const ctor = cls.getConstructors()[0];
+  const ctor = cls.members.find(ts.isConstructorDeclaration);
   if (!ctor) return result;
-  ctor.getParameters().forEach((param, index) => {
-    for (const dec of param.getDecorators()) {
+  ctor.parameters.forEach((param, index) => {
+    for (const dec of decoratorsOf(param)) {
       if (decoratorName(dec) === modifierName) result.add(index);
     }
   });
@@ -1195,13 +1424,13 @@ function parseModifierParams(cls: ClassDeclaration, modifierName: string): Set<n
 }
 
 function unwrapForwardRef(expr: Expression): Expression {
-  if (Node.isCallExpression(expr)) {
-    const exprText = expr.getExpression().getText();
+  if (ts.isCallExpression(expr)) {
+    const exprText = nodeText(expr.expression);
     if (exprText === "forwardRef" || exprText.endsWith(".forwardRef")) {
-      const arg = expr.getArguments()[0];
-      if (arg && (Node.isArrowFunction(arg) || Node.isFunctionExpression(arg))) {
-        const body = arg.getBody();
-        if (body && Node.isExpression(body)) {
+      const arg = expr.arguments[0];
+      if (arg && (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
+        const body = arg.body;
+        if (body && ts.isExpression(body)) {
           return unwrapForwardRef(body);
         }
       }
@@ -1210,15 +1439,15 @@ function unwrapForwardRef(expr: Expression): Expression {
   return expr;
 }
 
-function tokenText(expr: Expression): string {
+function tokenText(expr: Expression, ctx: AnalysisContext): string {
   const unwrapped = unwrapForwardRef(expr);
-  if (Node.isStringLiteral(unwrapped)) return unwrapped.getLiteralText();
-  if (Node.isIdentifier(unwrapped)) {
-    const decl = resolveDeclaration(unwrapped)[0];
-    if (decl && Node.isClassDeclaration(decl)) return decl.getName() ?? unwrapped.getText();
-    if (decl && Node.isVariableDeclaration(decl)) return decl.getName();
+  if (ts.isStringLiteral(unwrapped)) return unwrapped.text;
+  if (ts.isIdentifier(unwrapped)) {
+    const decl = resolveDeclaration(unwrapped, ctx)[0];
+    if (decl && ts.isClassDeclaration(decl)) return decl.name?.text ?? unwrapped.text;
+    if (decl && ts.isVariableDeclaration(decl)) return variableName(decl);
   }
-  return unwrapped.getText();
+  return nodeText(unwrapped);
 }
 
 function resolveScope(
@@ -1238,105 +1467,114 @@ function resolveScope(
 /** Identifier -> token name + kind (resolves across imports to declaration). */
 function tokenNameOf(expr: Expression, ctx: AnalysisContext): { name: string; kind: TokenKind } {
   const unwrapped = unwrapForwardRef(expr);
-  if (Node.isIdentifier(unwrapped)) {
-    const decl = resolveDeclaration(unwrapped)[0];
-    if (decl && Node.isClassDeclaration(decl)) {
-      return { name: decl.getName() ?? expr.getText(), kind: "class" };
+  if (ts.isIdentifier(unwrapped)) {
+    const decl = resolveDeclaration(unwrapped, ctx)[0];
+    if (decl && ts.isClassDeclaration(decl)) {
+      return { name: decl.name?.text ?? nodeText(expr), kind: "class" };
     }
-    if (decl && Node.isVariableDeclaration(decl)) {
-      const name = decl.getName();
+    if (decl && ts.isVariableDeclaration(decl)) {
+      const name = variableName(decl);
       return { name, kind: ctx.tokensByName.has(name) ? "injection-token" : "class" };
     }
-    if (ctx.tokensByName.has(expr.getText())) {
-      return { name: expr.getText(), kind: "injection-token" };
+    if (ctx.tokensByName.has(unwrapped.text)) {
+      return { name: unwrapped.text, kind: "injection-token" };
     }
   }
-  return { name: expr.getText(), kind: "class" };
+  return { name: nodeText(expr), kind: "class" };
 }
 
 /** Resolves identifier to its declarations (following import aliases). */
-function resolveDeclaration(id: Identifier): Node[] {
-  let symbol: TsSymbol | undefined = id.getSymbol();
+function resolveDeclaration(id: Identifier, ctx: AnalysisContext): ts.Declaration[] {
+  let symbol = ctx.checker.getSymbolAtLocation(id);
   if (!symbol) return [];
-  let declarations = symbol.getDeclarations();
-  for (let guard = 0; guard < 4; guard += 1) {
+  let declarations = symbol.declarations ?? [];
+  for (let guard: number = 0; guard < 4; guard += 1) {
     const isAlias = declarations.some(
       (d) =>
-        Node.isImportSpecifier(d) || Node.isImportClause(d) || Node.isNamespaceImport(d),
+        ts.isImportSpecifier(d) || ts.isImportClause(d) || ts.isNamespaceImport(d),
     );
     if (!isAlias) break;
-    const aliased: TsSymbol | undefined = symbol.getAliasedSymbol();
-    if (!aliased) break;
+    if (!(symbol.flags & ts.SymbolFlags.Alias)) break;
+    const aliased = ctx.checker.getAliasedSymbol(symbol);
     symbol = aliased;
-    declarations = aliased.getDeclarations();
+    declarations = aliased.declarations ?? [];
   }
   return declarations;
 }
 
 /** File path where identifier is defined (relative to rootDir, stripped of extension) for import generation. */
 function importPathOf(id: Identifier, ctx: AnalysisContext): string | undefined {
-  const symbol = id.getSymbol();
-  const first = symbol?.getDeclarations()[0];
-  if (first && (Node.isImportSpecifier(first) || Node.isImportClause(first))) {
-    const importDecl = first.getFirstAncestorByKind(SyntaxKind.ImportDeclaration);
-    const target = importDecl?.getModuleSpecifierSourceFile();
-    if (target) return modulePath(ctx.rootDir, target.getFilePath());
-  }
-  const decl = resolveDeclaration(id)[0];
-  if (decl) return modulePath(ctx.rootDir, decl.getSourceFile().getFilePath());
+  const decl = resolveDeclaration(id, ctx)[0];
+  if (decl) return modulePath(ctx.rootDir, decl.getSourceFile().fileName);
   return undefined;
 }
 
 function findDecorator(cls: ClassDeclaration, name: string): Decorator | undefined {
-  return cls.getDecorators().find((dec) => decoratorName(dec) === name);
+  return decoratorsOf(cls).find((dec) => decoratorName(dec) === name);
 }
 
 function decoratorName(dec: Decorator): string | undefined {
-  const expr = dec.getExpression();
-  if (Node.isCallExpression(expr)) {
-    return expr.getExpression().getText().split(".").pop();
+  const expr = dec.expression;
+  if (ts.isCallExpression(expr)) {
+    return nodeText(expr.expression).split(".").pop();
   }
-  if (Node.isIdentifier(expr)) return expr.getText();
+  if (ts.isIdentifier(expr)) return expr.text;
   return undefined;
 }
 
 function decoratorObjectArg(dec: Decorator): ObjectLiteralExpression | undefined {
-  const expr = dec.getExpression();
-  if (!Node.isCallExpression(expr)) return undefined;
-  const arg = expr.getArguments()[0];
-  return arg && Node.isObjectLiteralExpression(arg) ? arg : undefined;
+  const expr = dec.expression;
+  if (!ts.isCallExpression(expr)) return undefined;
+  const arg = expr.arguments[0];
+  return arg && ts.isObjectLiteralExpression(arg) ? arg : undefined;
 }
 
 function getProp(obj: ObjectLiteralExpression, name: string): Expression | undefined {
-  const prop = obj.getProperty(name);
-  if (prop && Node.isPropertyAssignment(prop)) return prop.getInitializer();
-  return undefined;
+  const prop = obj.properties.find((item) =>
+    ts.isPropertyAssignment(item) && propertyName(item.name) === name,
+  );
+  return prop && ts.isPropertyAssignment(prop) ? prop.initializer : undefined;
+}
+
+function toCompilerDiagnostic(diagnostic: ts.Diagnostic, rootDir: string): Diagnostic {
+  const file = diagnostic.file;
+  const position = file && diagnostic.start !== undefined
+    ? file.getLineAndCharacterOfPosition(diagnostic.start)
+    : undefined;
+  return {
+    severity: diagnostic.category === ts.DiagnosticCategory.Error ? "error" : "warn",
+    code: `typescript-${diagnostic.code}`,
+    errorCode: `TS${diagnostic.code}`,
+    message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    file: file ? sourcePath(rootDir, file.fileName) : undefined,
+    line: position ? position.line + 1 : undefined,
+  };
 }
 
 function stringLiteralProp(obj: ObjectLiteralExpression, name: string): string | undefined {
   const expr = getProp(obj, name);
-  return expr && Node.isStringLiteral(expr) ? expr.getLiteralText() : undefined;
+  return expr && ts.isStringLiteral(expr) ? expr.text : undefined;
 }
 
 function arrayProp(obj: ObjectLiteralExpression, name: string): Expression[] {
   const expr = getProp(obj, name);
-  return expr && Node.isArrayLiteralExpression(expr) ? expr.getElements() : [];
+  return expr && ts.isArrayLiteralExpression(expr) ? [...expr.elements] : [];
 }
 
 function booleanProp(obj: ObjectLiteralExpression, name: string): boolean | undefined {
   const expr = getProp(obj, name);
   if (!expr) return undefined;
-  if (expr.getKind() === SyntaxKind.TrueKeyword) return true;
-  if (expr.getKind() === SyntaxKind.FalseKeyword) return false;
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) return false;
   return undefined;
 }
 
 function parseScopeProp(obj: ObjectLiteralExpression): Scope | undefined {
   const scope = stringLiteralProp(obj, "scope");
-  return scope && (SCOPES as string[]).includes(scope) ? (scope as Scope) : undefined;
+  return scope && isScope(scope) ? scope : undefined;
 }
 
-function parseBindingOptions(args: Node[], defaultName: string): {
+function parseBindingOptions(args: readonly Expression[], defaultName: string): {
   name: string;
   transform?: "number" | "boolean" | "string";
   default?: unknown;
@@ -1348,16 +1586,16 @@ function parseBindingOptions(args: Node[], defaultName: string): {
   const first = args[0];
   const second = args[1];
 
-  if (first && Node.isStringLiteral(first)) {
-    name = first.getLiteralText();
-  } else if (first && Node.isObjectLiteralExpression(first)) {
+  if (first && ts.isStringLiteral(first)) {
+    name = first.text;
+  } else if (first && ts.isObjectLiteralExpression(first)) {
     const nameProp = getProp(first, "name");
-    if (nameProp && Node.isStringLiteral(nameProp)) {
-      name = nameProp.getLiteralText();
+    if (nameProp && ts.isStringLiteral(nameProp)) {
+      name = nameProp.text;
     }
     const trProp = getProp(first, "transform");
-    if (trProp && Node.isStringLiteral(trProp)) {
-      const val = trProp.getLiteralText();
+    if (trProp && ts.isStringLiteral(trProp)) {
+      const val = trProp.text;
       if (val === "number" || val === "boolean" || val === "string") {
         transform = val;
       }
@@ -1368,10 +1606,10 @@ function parseBindingOptions(args: Node[], defaultName: string): {
     }
   }
 
-  if (second && Node.isObjectLiteralExpression(second)) {
+  if (second && ts.isObjectLiteralExpression(second)) {
     const trProp = getProp(second, "transform");
-    if (trProp && Node.isStringLiteral(trProp)) {
-      const val = trProp.getLiteralText();
+    if (trProp && ts.isStringLiteral(trProp)) {
+      const val = trProp.text;
       if (val === "number" || val === "boolean" || val === "string") {
         transform = val;
       }
@@ -1385,15 +1623,15 @@ function parseBindingOptions(args: Node[], defaultName: string): {
   return { name, transform, default: defaultValue };
 }
 
-function parseLiteralValue(node: Node): unknown {
-  if (Node.isStringLiteral(node)) return node.getLiteralText();
-  if (Node.isNumericLiteral(node)) return node.getLiteralValue();
-  if (node.getKindName() === "TrueKeyword") return true;
-  if (node.getKindName() === "FalseKeyword") return false;
-  if (Node.isArrayLiteralExpression(node)) {
-    return node.getElements().map(parseLiteralValue);
+function parseLiteralValue(node: AstNode): unknown {
+  if (ts.isStringLiteral(node)) return node.text;
+  if (ts.isNumericLiteral(node)) return Number(node.text);
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.map(parseLiteralValue);
   }
-  if (Node.isObjectLiteralExpression(node)) {
+  if (ts.isObjectLiteralExpression(node)) {
     return parseObjectLiteralValues(node);
   }
   return undefined;
@@ -1401,10 +1639,10 @@ function parseLiteralValue(node: Node): unknown {
 
 function parseObjectLiteralValues(obj: ObjectLiteralExpression): Record<string, unknown> {
   const result: Record<string, unknown> = {};
-  for (const prop of obj.getProperties()) {
-    if (Node.isPropertyAssignment(prop)) {
-      const name = prop.getName();
-      const init = prop.getInitializer();
+  for (const prop of obj.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      const name = propertyName(prop.name);
+      const init = prop.initializer;
       if (init) {
         result[name] = parseLiteralValue(init);
       }

--- a/packages/compiler/src/cli.ts
+++ b/packages/compiler/src/cli.ts
@@ -29,7 +29,7 @@ Commands:
 Options:
   --root, -r <dir>    Application source root (default: current directory or first positional argument)
   --out, -o <dir>     Artifact output directory (default: <rootDir>/generated)
-  --strict            Treat all warnings as errors
+  --strict            Enable type-safety gates and treat all warnings as errors
   --client            Generate typed API client in client.ts
   --permissions       Generate typed permissions registry in permissions.ts
   --debounce <ms>     Debounce source changes in dev mode (default: 100)

--- a/packages/compiler/src/cli.ts
+++ b/packages/compiler/src/cli.ts
@@ -6,6 +6,16 @@ import { doctorProject, explainGraph, formatGraph } from "./inspect";
 import { watchProject } from "./watch";
 import type { Diagnostic, ModuleBoundaryPresetName } from "./types";
 
+function isModuleBoundaryPresetName(value: string | undefined): value is ModuleBoundaryPresetName {
+  return value === "modular-monolith"
+    || value === "feature-slices"
+    || value === "vertical-slices"
+    || value === "angular-enterprise"
+    || value === "angular"
+    || value === "clean-architecture"
+    || value === "domain-driven";
+}
+
 function printUsage(): void {
   console.log(`
 @supacloud/compiler CLI
@@ -53,17 +63,17 @@ async function run(): Promise<void> {
     process.exit(1);
   }
 
-  let rootDir = ".";
+  let rootDir: string = ".";
   let outDir: string | undefined;
-  let strict = false;
-  let generateClient = false;
-  let generatePermissions = false;
+  let strict: boolean = false;
+  let generateClient: boolean = false;
+  let generatePermissions: boolean = false;
   let preset: ModuleBoundaryPresetName | undefined;
-  let debounceMs = 100;
+  let debounceMs: number = 100;
   let query: string | undefined;
-  let json = false;
+  let json: boolean = false;
 
-  for (let i = 1; i < args.length; i++) {
+  for (let i: number = 1; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--root" || arg === "-r") {
       rootDir = args[++i];
@@ -84,7 +94,12 @@ async function run(): Promise<void> {
     } else if (arg === "--json") {
       json = true;
     } else if (arg === "--preset" || arg === "-p") {
-      preset = args[++i] as ModuleBoundaryPresetName;
+      const presetArg = args[++i];
+      if (!isModuleBoundaryPresetName(presetArg)) {
+        console.error(`Error: --preset requires a known preset, received "${presetArg ?? ""}"`);
+        process.exit(1);
+      }
+      preset = presetArg;
     } else if (!arg.startsWith("-") && rootDir === ".") {
       if (command === "explain" && !query) query = arg;
       else rootDir = arg;
@@ -225,7 +240,7 @@ function printDiagnostics(diagnostics: Diagnostic[]): void {
   }
 }
 
-run().catch((err) => {
+run().catch((err: unknown) => {
   console.error("Unhandled error:", err);
   process.exit(1);
 });

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -4,6 +4,7 @@ import type { CheckProjectResult, CompileOptions, CompileResult, Diagnostic } fr
 import { validateGraph } from "./validate";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
 
 /**
  * Complete compilation pipeline: AST analysis -> validation -> generate static factory code and manifest.
@@ -27,6 +28,30 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
     for (const diagnostic of diagnostics) {
       if (diagnostic.severity === "warn") diagnostic.severity = "error";
     }
+  }
+  const typeSafety = resolveTypeSafety(options);
+  const rendered = renderApplication(graph, {
+    rootDir: options.rootDir,
+    outDir: options.outDir,
+    generateClient: options.generateClient,
+    generatePermissions: options.generatePermissions,
+    treeShakeUnusedProviders: options.treeShakeUnusedProviders,
+  });
+  if (typeSafety.scanProductionSource) {
+    diagnostics.push(...scanProductionSource({
+      rootDir: options.rootDir,
+      include: options.include,
+      outDir: options.outDir,
+      strict: options.strict,
+      ...typeSafety,
+    }));
+  }
+  if (typeSafety.noAnyInGenerated) {
+    diagnostics.push(...scanGeneratedArtifacts({
+      "application.ts": rendered.applicationCode,
+      "client.ts": rendered.clientCode,
+      "permissions.ts": rendered.permissionsCode,
+    }, options.strict ?? false));
   }
   const hasErrors = diagnostics.some((diagnostic) => diagnostic.severity === "error");
   const written = !hasErrors || options.writeOnError !== false
@@ -74,6 +99,7 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     }
   }
 
+  const typeSafety = resolveTypeSafety(options);
   const rendered = renderApplication(graph, {
     rootDir: options.rootDir,
     outDir: options.outDir,
@@ -81,6 +107,22 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     generatePermissions: options.generatePermissions,
     treeShakeUnusedProviders: options.treeShakeUnusedProviders,
   });
+  if (typeSafety.scanProductionSource) {
+    diagnostics.push(...scanProductionSource({
+      rootDir: options.rootDir,
+      include: options.include,
+      outDir: options.outDir,
+      strict: options.strict,
+      ...typeSafety,
+    }));
+  }
+  if (typeSafety.noAnyInGenerated) {
+    diagnostics.push(...scanGeneratedArtifacts({
+      "application.ts": rendered.applicationCode,
+      "client.ts": rendered.clientCode,
+      "permissions.ts": rendered.permissionsCode,
+    }, options.strict ?? false));
+  }
 
   const expectedFiles: Record<string, string> = {
     "application.ts": rendered.applicationCode,
@@ -111,5 +153,13 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
     mismatches,
     diagnostics,
     graph,
+  };
+}
+
+function resolveTypeSafety(options: CompileOptions): NonNullable<CompileOptions["typeSafety"]> {
+  return {
+    noAnyInGenerated: options.typeSafety?.noAnyInGenerated ?? options.strict ?? false,
+    scanProductionSource: options.typeSafety?.scanProductionSource ?? options.strict ?? false,
+    exclude: options.typeSafety?.exclude,
   };
 }

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -11,7 +11,7 @@ import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
  * Files are emitted even when error-level diagnostics exist; caller decides adoption based on diagnostics.
  */
 export async function compileProject(options: CompileOptions): Promise<CompileResult> {
-  const graph = await analyzeProject(options.rootDir, options.include, options.cache);
+  const graph = await analyzeProject(options.rootDir, options.include, options.cache, options.changedPaths);
   const diagnostics: Diagnostic[] = [
     ...(graph.diagnostics ?? []),
     ...validateGraph(graph, {
@@ -54,14 +54,16 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
     }, options.strict ?? false));
   }
   const hasErrors = diagnostics.some((diagnostic) => diagnostic.severity === "error");
+  const generatedOptions = {
+    rootDir: options.rootDir,
+    outDir: options.outDir,
+    generateClient: options.generateClient,
+    generatePermissions: options.generatePermissions,
+    treeShakeUnusedProviders: options.treeShakeUnusedProviders,
+    artifactHashes: options.cache?.generatedHashes,
+  };
   const written = !hasErrors || options.writeOnError !== false
-    ? await generateApplication(graph, {
-        rootDir: options.rootDir,
-        outDir: options.outDir,
-        generateClient: options.generateClient,
-        generatePermissions: options.generatePermissions,
-        treeShakeUnusedProviders: options.treeShakeUnusedProviders,
-      })
+    ? await generateApplication(graph, generatedOptions)
     : [];
   const stats = graph.cacheStats
     ? {
@@ -75,12 +77,13 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
   return { diagnostics, graph, written, stats };
 }
 
+
 /**
  * Check generated artifacts without writing files to disk.
  * Analyze the AST, run governance checks, and compare application.ts and app.manifest.json.
  */
 export async function checkProject(options: CompileOptions): Promise<CheckProjectResult> {
-  const graph = await analyzeProject(options.rootDir, options.include, options.cache);
+  const graph = await analyzeProject(options.rootDir, options.include, options.cache, options.changedPaths);
   const diagnostics: Diagnostic[] = [
     ...(graph.diagnostics ?? []),
     ...validateGraph(graph, {

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -147,6 +147,7 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
       ctx: unknown,
       imported?: Record<string, Partial<RuntimeServices>>,
     ) => RuntimeServices;
+    destroyRequestScope?: (scope: RuntimeServices) => Promise<void>;
   };
   let compiled: {
     createCompiledModules: () => RuntimeModule[];
@@ -171,6 +172,7 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
       permission: "case.accept",
     });
     expect(typeof modules[1].createRequestScope).toBe("function");
+    expect(typeof modules[1].destroyRequestScope).toBe("function");
     expect(modules[2].createRequestScope).toBeUndefined();
   });
 
@@ -802,5 +804,60 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
     expect(rendered.applicationCode).toContain('Number(req.params?.["id"])');
     expect(rendered.applicationCode).toContain('Number(req.query?.["limit"])');
     expect(rendered.applicationCode).toContain(": 20");
+  });
+
+  test("renderApplication emits static request-scope destruction plans", () => {
+    const rendered = renderApplication(
+      {
+        modules: [
+          {
+            name: "scoped",
+            className: "ScopedModule",
+            file: "src/scoped.module.ts",
+            line: 1,
+            imports: [],
+            providers: [
+              {
+                token: "REQUEST_RESOURCE",
+                tokenKind: "injection-token",
+                kind: "class",
+                useClass: "RequestResource",
+                scope: "request",
+                deps: [],
+                hasOnDestroy: true,
+                exported: false,
+                file: "src/request-resource.ts",
+                line: 1,
+                importPath: "./request-resource",
+              },
+            ],
+            controllers: [
+              {
+                className: "ScopedController",
+                path: "/scoped",
+                scope: "request",
+                deps: [],
+                hasOnDestroy: true,
+                routes: [],
+                file: "src/scoped.controller.ts",
+                importPath: "./scoped.controller",
+              },
+            ],
+            commands: [],
+            queries: [],
+            exports: [],
+          },
+        ],
+        externalTokens: [],
+      },
+      { rootDir: "/app", outDir: "/app/generated" },
+    );
+
+    expect(rendered.applicationCode).toContain(
+      "async function destroyScopedRequestScope(scope: Record<string, unknown>): Promise<void>",
+    );
+    expect(rendered.applicationCode).toContain(
+      'await destroyScopeInstances(scope, [{"key":"requestResource"},{"key":"scopedController"}]);',
+    );
   });
 });

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -8,6 +8,7 @@ import { renderApplication } from "./generate";
 import { BAD_PROJECT_FILES } from "./fixtures/bad-project";
 import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
 import { writeFixtureProject } from "./fixtures/helpers";
+import { scanGeneratedArtifacts } from "./type-safety";
 import type { ApplicationGraph, CompileResult } from "./types";
 
 let rootDir: string;
@@ -30,6 +31,10 @@ describe("compileProject：总体结果", () => {
       join(outDir, "application.ts"),
       join(outDir, "app.manifest.json"),
     ]);
+  });
+
+  test("严格生成产物不包含 any", () => {
+    expect(scanGeneratedArtifacts({ "application.ts": applicationCode })).toEqual([]);
   });
 
   test("app.manifest.json 是 graph 的 JSON 序列化", async () => {
@@ -111,14 +116,41 @@ describe("generate：application.ts 关键内容", () => {
     expect(applicationCode).toContain('serviceKey: "caseController"');
     expect(applicationCode).toContain('path: "/cases"');
     expect(applicationCode).toContain(
-      '{ method: "POST", path: "/:caseId/accept", handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult, command: "AcceptCaseCommand", invoker: async (ctrl: any, req: any) => await (ctrl as any).accept(req) }',
+      'handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult, command: "AcceptCaseCommand", invoker: async (ctrl: unknown',
     );
   });
 });
 
 describe("generate：application.ts 可被 bun 直接执行", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let compiled: any;
+  type RuntimeServices = {
+    auditConfig: { level: string };
+    logger: { level: string };
+    auditService: { config: unknown; logger: unknown };
+    caseRepository: { db: unknown };
+    caseService: { repository: unknown; audit: unknown };
+    acceptCaseCommand: { caseService: unknown };
+    healthService: { status: () => string };
+    caseController: { ctx: unknown; repository: unknown; audit: unknown };
+  };
+  type RuntimeModule = {
+    name: string;
+    commands: Array<{ className: string; name: string; permission: string }>;
+    controllers: Array<{
+      path: string;
+      serviceKey: string;
+      scope: string;
+      routes: Array<{ body?: unknown; params?: unknown; response?: unknown }>;
+    }>;
+    createServices: (deps: Record<string, unknown>, imported: Record<string, Partial<RuntimeServices>>) => RuntimeServices;
+    createRequestScope?: (
+      services: RuntimeServices,
+      ctx: unknown,
+      imported?: Record<string, Partial<RuntimeServices>>,
+    ) => RuntimeServices;
+  };
+  let compiled: {
+    createCompiledModules: () => RuntimeModule[];
+  };
 
   beforeAll(async () => {
     const url = pathToFileURL(join(outDir, "application.ts")).href;
@@ -173,8 +205,10 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
     const ctx1 = { requestId: "r1" };
     const ctx2 = { requestId: "r2" };
     const imported = { audit: modules[0].createServices(deps, {}) };
-    const scope1 = caseModule.createRequestScope(services, ctx1, imported);
-    const scope2 = caseModule.createRequestScope(services, ctx2, imported);
+    const createRequestScope = caseModule.createRequestScope;
+    if (!createRequestScope) throw new Error("request scope factory is missing");
+    const scope1 = createRequestScope(services, ctx1, imported);
+    const scope2 = createRequestScope(services, ctx2, imported);
 
     expect(scope1.caseController.ctx).toBe(ctx1);
     expect(scope1.caseController.repository).toBe(services.caseRepository);
@@ -587,7 +621,7 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
     );
 
     expect(rendered.applicationCode).toContain('canDeactivate: ["UnsavedGuard"]');
-    expect(rendered.applicationCode).toContain('const apiUrl = typeof API_URL === "object" && API_URL && "factory" in API_URL');
+    expect(rendered.applicationCode).toContain("const apiUrl = resolveFactoryValue(API_URL);");
     expect(rendered.clientCode).toContain('"canDeactivate": [\n      "UnsavedGuard"\n    ]');
   });
 
@@ -762,7 +796,9 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
       rootDir: "/app",
       outDir: "/app/gen",
     });
-    expect(rendered.applicationCode).toContain("invoker: async (ctrl: any, req: any) => await (ctrl as any).getUser(");
+    expect(rendered.applicationCode).toContain("invoker: async (ctrl: unknown, req:");
+    expect(rendered.applicationCode).toContain('const handler = ctrl["getUser"];');
+    expect(rendered.applicationCode).toContain("Reflect.apply(handler, ctrl");
     expect(rendered.applicationCode).toContain('Number(req.params?.["id"])');
     expect(rendered.applicationCode).toContain('Number(req.query?.["limit"])');
     expect(rendered.applicationCode).toContain(": 20");

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -105,6 +105,58 @@ describe("generate：application.ts 关键内容", () => {
     );
   });
 
+  test("property-level inject() uses a generated static token identity context", () => {
+    const rendered = renderApplication({
+      modules: [{
+        name: "functional",
+        className: "FunctionalModule",
+        file: "src/functional.module.ts",
+        line: 1,
+        imports: [],
+        providers: [{
+          token: "CONFIG",
+          tokenKind: "injection-token",
+          kind: "value",
+          useValueExpr: '{ mode: "strict" }',
+          scope: "application",
+          deps: [],
+          exported: false,
+          file: "src/functional.module.ts",
+          line: 1,
+        }, {
+          token: "FunctionalService",
+          tokenKind: "class",
+          kind: "class",
+          useClass: "FunctionalService",
+          scope: "application",
+          deps: ["CONFIG"],
+          functionalInjects: [{
+            token: "CONFIG",
+            expression: "CONFIG",
+            importPath: "src/functional.module",
+          }],
+          exported: false,
+          file: "src/functional.module.ts",
+          line: 1,
+          importPath: "src/functional.service",
+        }],
+        controllers: [],
+        commands: [],
+        queries: [],
+        exports: [],
+      }],
+      externalTokens: [],
+    }, {
+      rootDir: "/app",
+      outDir: "/app/generated",
+    });
+
+    expect(rendered.applicationCode).toContain('import { runInInjectionContext } from "@supacloud/app";');
+    expect(rendered.applicationCode).toContain("if (token === CONFIG) return config as T;");
+    expect(rendered.applicationCode).toContain("runInInjectionContext({");
+    expect(rendered.applicationCode).not.toContain("new StaticInjector");
+  });
+
   test("request 工厂：REQUEST_CONTEXT 传 ctx，其余从 services 解析", () => {
     expect(applicationCode).toContain("createCaseRequestScope");
     expect(applicationCode).toContain(

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -87,6 +87,19 @@ export interface CompiledModule {
   commands: CompiledCommand[];
 }`;
 
+const TYPE_GUARDS = `function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+  return typeof value === "function";
+}
+
+function resolveFactoryValue(value: unknown): unknown {
+  if (!isRecord(value) || !isFunction(value.factory)) return undefined;
+  return value.factory();
+}`;
+
 export interface GenerateOptions {
   rootDir: string;
   outDir: string;
@@ -149,6 +162,8 @@ export function renderApplication(
     ...(imports.size > 0 ? [""] : []),
     INTERFACES,
     "",
+    TYPE_GUARDS,
+    "",
     "export function createCompiledModules(): CompiledModule[] {",
     "  return [",
     ...descriptorEntries.map((entry) => indent(entry, 4) + ","),
@@ -156,29 +171,29 @@ export function renderApplication(
     "}",
     "",
     "export async function initializeApplication(services: Record<string, unknown>): Promise<void> {",
-    '  const initializers = (services.appInitializer ?? (services as any)["supacloud.app-initializer"]) as unknown;',
+    '  const initializers = services.appInitializer ?? services["supacloud.app-initializer"];',
     "  if (Array.isArray(initializers)) {",
     "    for (const init of initializers) {",
     '      if (typeof init === "function") await init();',
     "    }",
-    '  } else if (typeof initializers === "function") {',
-    "    await (initializers as () => unknown)();",
+    '  } else if (isFunction(initializers)) {',
+    "    await initializers();",
     "  }",
     "}",
     "",
     "export async function destroyApplication(services: Record<string, unknown>): Promise<void> {",
-    '  const destroyRef = (services.destroyRef ?? (services as any)["supacloud.destroy-ref"]) as { destroy?: () => Promise<void>; _teardowns?: Array<() => void | Promise<void>> } | undefined;',
-    '  if (destroyRef && typeof destroyRef.destroy === "function") {',
+    '  const destroyRef = services.destroyRef ?? services["supacloud.destroy-ref"];',
+    '  if (isRecord(destroyRef) && isFunction(destroyRef.destroy)) {',
     "    await destroyRef.destroy();",
-    "  } else if (destroyRef && Array.isArray(destroyRef._teardowns)) {",
+    "  } else if (isRecord(destroyRef) && Array.isArray(destroyRef._teardowns)) {",
     "    for (const teardown of [...destroyRef._teardowns].reverse()) {",
-    '      if (typeof teardown === "function") await teardown();',
+    "      if (isFunction(teardown)) await teardown();",
     "    }",
     "  }",
     "  const instances = Object.values(services);",
     "  for (const inst of instances.reverse()) {",
-    '    if (inst && typeof (inst as any).onDestroy === "function") {',
-    "      await (inst as any).onDestroy();",
+    '    if (isRecord(inst) && isFunction(inst.onDestroy)) {',
+    "      await inst.onDestroy();",
     "    }",
     "  }",
     "}",
@@ -472,7 +487,13 @@ class ModuleGenerator {
           return "undefined";
         });
         const callArgs = invokerArgs.length > 0 ? invokerArgs.join(", ") : "req";
-        fields.push(`invoker: async (ctrl: any, req: any) => await (ctrl as any).${route.handler}(${callArgs})`);
+        fields.push(
+          `invoker: async (ctrl: unknown, req: { params?: Record<string, unknown>; query?: Record<string, unknown>; body?: unknown; headers?: Record<string, unknown>; context?: unknown }) => { ` +
+          `if (!isRecord(ctrl)) throw new TypeError("Route controller is not an object"); ` +
+          `const handler = ctrl[${JSON.stringify(route.handler)}]; ` +
+          `if (typeof handler !== "function") throw new TypeError("Route handler ${route.handler} is not callable"); ` +
+          `return await Reflect.apply(handler, ctrl, [${callArgs}]); }`,
+        );
         return `{ ${fields.join(", ")} }`;
       });
       return [
@@ -578,7 +599,7 @@ class ModuleGenerator {
         if (provider.tokenKind === "injection-token" && !provider.useFactoryName) {
           const tokenIdent = this.imports.add(provider.token, provider.importPath);
           const local = this.localVar(isMulti ? `${provider.token}Item` : provider.token, kind);
-          const constLine = `const ${local} = typeof ${tokenIdent} === "object" && ${tokenIdent} && "factory" in ${tokenIdent} && typeof (${tokenIdent} as any).factory === "function" ? (${tokenIdent} as any).factory() : undefined;`;
+          const constLine = `const ${local} = resolveFactoryValue(${tokenIdent});`;
           return { constLine, key, expr: local };
         }
         const factory = this.imports.add(provider.useFactoryName ?? "", provider.importPath);

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -1,4 +1,5 @@
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { access, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   ApplicationGraph,
@@ -78,11 +79,13 @@ export interface CompiledModule {
     ctx: unknown,
     imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
+  destroyRequestScope?(scope: Record<string, unknown>): Promise<void>;
   createJobScope?(
     services: Record<string, unknown>,
     ctx: unknown,
     imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
+  destroyJobScope?(scope: Record<string, unknown>): Promise<void>;
   controllers: CompiledController[];
   commands: CompiledCommand[];
 }`;
@@ -98,6 +101,37 @@ function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
 function resolveFactoryValue(value: unknown): unknown {
   if (!isRecord(value) || !isFunction(value.factory)) return undefined;
   return value.factory();
+}
+
+const scopeDestructions = new WeakMap<object, Promise<void>>();
+
+function destroyScopeInstances(
+  scope: Record<string, unknown>,
+  plan: readonly { key: string; index?: number }[],
+): Promise<void> {
+  const pending = scopeDestructions.get(scope);
+  if (pending) return pending;
+  const destruction = Promise.resolve().then(async () => {
+    const errors: unknown[] = [];
+    const seen = new Set<unknown>();
+    for (const entry of [...plan].reverse()) {
+      const value = scope[entry.key];
+      const instance = entry.index === undefined ? value
+        : Array.isArray(value) ? value[entry.index] : undefined;
+      if (seen.has(instance)) continue;
+      seen.add(instance);
+      try {
+        if (isRecord(instance) && isFunction(instance.onDestroy)) {
+          await instance.onDestroy();
+        }
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) throw new AggregateError(errors, "Scope destruction failed");
+  });
+  scopeDestructions.set(scope, destruction);
+  return destruction;
 }`;
 
 export interface GenerateOptions {
@@ -107,6 +141,8 @@ export interface GenerateOptions {
   generatePermissions?: boolean;
   /** Prune unused root providers from compiled output (Angular Ivy AOT tree-shaking). */
   treeShakeUnusedProviders?: boolean;
+  /** Incremental emitter state. Unchanged artifacts are not rewritten. */
+  artifactHashes?: Map<string, string>;
 }
 
 export interface RenderedArtifacts {
@@ -202,7 +238,7 @@ export function renderApplication(
     "",
   ].join("\n");
 
-  const manifest = {
+  const manifest: { version: number; modules: ModuleNode[]; externalTokens: string[] } = {
     version: 1,
     modules: graph.modules,
     externalTokens: graph.externalTokens,
@@ -232,21 +268,45 @@ export async function generateApplication(
   await mkdir(options.outDir, { recursive: true });
   const applicationPath = join(options.outDir, "application.ts");
   const manifestPath = join(options.outDir, "app.manifest.json");
-  await writeFileAtomic(applicationPath, rendered.applicationCode);
-  await writeFileAtomic(manifestPath, rendered.manifestJson);
-
-  const written = [applicationPath, manifestPath];
+  const written: string[] = [];
+  if (await writeFileIfChanged(applicationPath, rendered.applicationCode, options.artifactHashes)) {
+    written.push(applicationPath);
+  }
+  if (await writeFileIfChanged(manifestPath, rendered.manifestJson, options.artifactHashes)) {
+    written.push(manifestPath);
+  }
   if (rendered.clientCode) {
     const clientPath = join(options.outDir, "client.ts");
-    await writeFileAtomic(clientPath, rendered.clientCode);
-    written.push(clientPath);
+    if (await writeFileIfChanged(clientPath, rendered.clientCode, options.artifactHashes)) {
+      written.push(clientPath);
+    }
   }
   if (rendered.permissionsCode) {
     const permissionsPath = join(options.outDir, "permissions.ts");
-    await writeFileAtomic(permissionsPath, rendered.permissionsCode);
-    written.push(permissionsPath);
+    if (await writeFileIfChanged(permissionsPath, rendered.permissionsCode, options.artifactHashes)) {
+      written.push(permissionsPath);
+    }
   }
   return written;
+}
+
+async function writeFileIfChanged(
+  path: string,
+  content: string,
+  hashes?: Map<string, string>,
+): Promise<boolean> {
+  const hash = createHash("sha1").update(content).digest("hex");
+  if (hashes?.get(path) === hash) {
+    try {
+      await access(path);
+      return false;
+    } catch {
+      // The cache is stale because the artifact was removed externally.
+    }
+  }
+  await writeFileAtomic(path, content);
+  hashes?.set(path, hash);
+  return true;
 }
 
 async function writeFileAtomic(path: string, content: string): Promise<void> {
@@ -316,7 +376,7 @@ class ImportManager {
       if (entry.path === importPath && entry.exported === exported) return local;
     }
     let local = exported;
-    let counter = 2;
+    let counter: number = 2;
     while (this.entries.has(local)) {
       local = `${exported}${counter}`;
       counter += 1;
@@ -367,9 +427,11 @@ class ModuleGenerator {
     const sections: string[] = [this.renderServicesFactory()];
     if (this.hasFactoryContent("request")) {
       sections.push(this.renderScopeFactory("request"));
+      sections.push(this.renderScopeDestroyer("request"));
     }
     if (this.hasFactoryContent("job")) {
       sections.push(this.renderScopeFactory("job"));
+      sections.push(this.renderScopeDestroyer("job"));
     }
     return sections;
   }
@@ -382,9 +444,11 @@ class ModuleGenerator {
     ];
     if (this.hasFactoryContent("request")) {
       lines.push(`  createRequestScope: create${this.pascal}RequestScope,`);
+      lines.push(`  destroyRequestScope: destroy${this.pascal}RequestScope,`);
     }
     if (this.hasFactoryContent("job")) {
       lines.push(`  createJobScope: create${this.pascal}JobScope,`);
+      lines.push(`  destroyJobScope: destroy${this.pascal}JobScope,`);
     }
     lines.push(`  controllers: ${this.renderControllers()},`);
     lines.push(`  commands: ${JSON.stringify(this.module.commands)},`);
@@ -532,6 +596,29 @@ class ModuleGenerator {
     ].join("\n");
   }
 
+  private renderScopeDestroyer(kind: "request" | "job"): string {
+    const suffix = kind === "request" ? "RequestScope" : "JobScope";
+    const plan: Array<{ key: string; index?: number }> = [];
+    const multiIndices = new Map<string, number>();
+    for (const provider of orderProviders(this.module.providers.filter((p) => factoryOfScope(p.scope) === kind))) {
+      const index = provider.multi ? (multiIndices.get(provider.token) ?? 0) : undefined;
+      if (index !== undefined) multiIndices.set(provider.token, index + 1);
+      if (provider.kind !== "existing" && provider.hasOnDestroy) {
+        plan.push({ key: camelName(provider.token), index });
+      }
+    }
+    for (const controller of this.module.controllers) {
+      if (factoryOfScope(controller.scope) === kind && controller.hasOnDestroy) {
+        plan.push({ key: camelName(controller.className) });
+      }
+    }
+    return [
+      `async function destroy${this.pascal}${suffix}(scope: Record<string, unknown>): Promise<void> {`,
+      `  await destroyScopeInstances(scope, ${JSON.stringify(plan)});`,
+      `}`,
+    ].join("\n");
+  }
+
   /** Factory function body: instantiates providers and controllers for this scope in dependency topological order. */
   private renderFactoryBody(kind: FactoryKind): string {
     const providers = orderProviders(
@@ -636,7 +723,7 @@ class ModuleGenerator {
     if (existing) return existing;
     const base = camelName(token);
     let local = base;
-    let counter = 2;
+    let counter: number = 2;
     while ([...locals.values()].includes(local)) {
       local = `${base}${counter}`;
       counter += 1;

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type {
   ApplicationGraph,
   ControllerNode,
+  FunctionalInjectNode,
   ModuleNode,
   ProviderNode,
   Scope,
@@ -123,6 +124,8 @@ function destroyScopeInstances(
       try {
         if (isRecord(instance) && isFunction(instance.onDestroy)) {
           await instance.onDestroy();
+        } else if (isRecord(instance) && isFunction(instance.ngOnDestroy)) {
+          await instance.ngOnDestroy();
         }
       } catch (error) {
         errors.push(error);
@@ -167,12 +170,14 @@ export function renderApplication(
         for (const d of ctrl.optionalDeps ?? []) referencedTokens.add(d);
         for (const d of ctrl.selfDeps ?? []) referencedTokens.add(d);
         for (const d of ctrl.skipSelfDeps ?? []) referencedTokens.add(d);
+        for (const d of ctrl.hostDeps ?? []) referencedTokens.add(d);
       }
       for (const p of mod.providers) {
         for (const d of p.deps ?? []) referencedTokens.add(d);
         for (const d of p.optionalDeps ?? []) referencedTokens.add(d);
         for (const d of p.selfDeps ?? []) referencedTokens.add(d);
         for (const d of p.skipSelfDeps ?? []) referencedTokens.add(d);
+        for (const d of p.hostDeps ?? []) referencedTokens.add(d);
         if (p.useExisting) referencedTokens.add(p.useExisting);
       }
     }
@@ -207,13 +212,15 @@ export function renderApplication(
     "}",
     "",
     "export async function initializeApplication(services: Record<string, unknown>): Promise<void> {",
-    '  const initializers = services.appInitializer ?? services["supacloud.app-initializer"];',
-    "  if (Array.isArray(initializers)) {",
-    "    for (const init of initializers) {",
-    '      if (typeof init === "function") await init();',
+    '  const initializers = [services.environmentInitializer ?? services["supacloud.environment-initializer"], services.appInitializer ?? services["supacloud.app-initializer"]];',
+    "  for (const group of initializers) {",
+    "    if (Array.isArray(group)) {",
+    "      for (const init of group) {",
+    '        if (isFunction(init)) await init();',
+    "      }",
+    '    } else if (isFunction(group)) {',
+    "      await group();",
     "    }",
-    '  } else if (isFunction(initializers)) {',
-    "    await initializers();",
     "  }",
     "}",
     "",
@@ -230,6 +237,8 @@ export function renderApplication(
     "  for (const inst of instances.reverse()) {",
     '    if (isRecord(inst) && isFunction(inst.onDestroy)) {',
     "      await inst.onDestroy();",
+    '    } else if (isRecord(inst) && isFunction(inst.ngOnDestroy)) {',
+    "      await inst.ngOnDestroy();",
     "    }",
     "  }",
     "}",
@@ -363,17 +372,19 @@ function indent(text: string, spaces: number): string {
 
 /** Manages generated file imports: automatically aliases symbols with the same name from different sources. */
 class ImportManager {
-  private readonly entries = new Map<string, { path: string; exported: string }>();
+  private readonly entries = new Map<string, { path: string; exported: string; package: boolean }>();
 
   get size(): number {
     return this.entries.size;
   }
 
   /** Registers a symbol and returns local identifier for generated code. importPath is relative to rootDir without extension. */
-  add(exported: string, importPath?: string): string {
-    if (!importPath) return exported;
+  add(exported: string, importPath?: string, importModule?: string): string {
+    const path = importModule ?? importPath;
+    const packageImport = importModule !== undefined;
+    if (!path) return exported;
     for (const [local, entry] of this.entries) {
-      if (entry.path === importPath && entry.exported === exported) return local;
+      if (entry.path === path && entry.exported === exported && entry.package === packageImport) return local;
     }
     let local = exported;
     let counter: number = 2;
@@ -381,21 +392,23 @@ class ImportManager {
       local = `${exported}${counter}`;
       counter += 1;
     }
-    this.entries.set(local, { path: importPath, exported });
+    this.entries.set(local, { path, exported, package: packageImport });
     return local;
   }
 
   render(rootDir: string, outDir: string): string[] {
     const byPath = new Map<string, { exported: string; local: string }[]>();
     for (const [local, entry] of this.entries) {
-      const list = byPath.get(entry.path) ?? [];
+      const spec = entry.package
+        ? entry.path
+        : relativeImportPath(outDir, join(rootDir, `${entry.path}.ts`));
+      const list = byPath.get(spec) ?? [];
       list.push({ exported: entry.exported, local });
-      byPath.set(entry.path, list);
+      byPath.set(spec, list);
     }
     return [...byPath.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([path, symbols]) => {
-        const spec = relativeImportPath(outDir, join(rootDir, `${path}.ts`));
+      .map(([spec, symbols]) => {
         const names = symbols
           .sort((a, b) => a.exported.localeCompare(b.exported))
           .map((s) => (s.local === s.exported ? s.exported : `${s.exported} as ${s.local}`))
@@ -421,6 +434,12 @@ class ModuleGenerator {
     private readonly imports: ImportManager,
   ) {
     this.pascal = pascalName(module.name);
+    if (
+      module.providers.some((provider) => (provider.functionalInjects?.length ?? 0) > 0) ||
+      module.controllers.some((controller) => (controller.functionalInjects?.length ?? 0) > 0)
+    ) {
+      imports.add("runInInjectionContext", undefined, "@supacloud/app");
+    }
   }
 
   renderFactories(): string[] {
@@ -668,37 +687,48 @@ class ModuleGenerator {
     const key = camelName(provider.token);
     switch (provider.kind) {
       case "class": {
-        const useClass = this.imports.add(provider.useClass ?? provider.token, provider.importPath);
+        const useClass = this.imports.add(provider.useClass ?? provider.token, provider.importPath, provider.importModule);
         const args = provider.deps
-          .map((dep) => this.depExpr(dep, kind, provider.optionalDeps?.includes(dep)))
+          .map((dep) => this.depExpr(dep, kind, this.depOptions(provider, dep)))
           .join(", ");
         const local = this.localVar(isMulti ? (provider.useClass ?? `${provider.token}Item`) : provider.token, kind);
-        return { constLine: `const ${local} = new ${useClass}(${args});`, key, expr: local };
+        return {
+          constLine: `const ${local} = ${this.instantiate(useClass, args, kind, provider.functionalInjects)};`,
+          key,
+          expr: local,
+        };
       }
       case "value": {
-        const expr = provider.importPath
-          ? this.imports.add(provider.useValueExpr ?? "undefined", provider.importPath)
+        const expr = provider.importPath || provider.importModule
+          ? this.imports.add(provider.useValueExpr ?? "undefined", provider.importPath, provider.importModule)
           : (provider.useValueExpr ?? "undefined");
         const local = this.localVar(isMulti ? `${provider.token}Item` : provider.token, kind);
         return { constLine: `const ${local} = ${expr};`, key, expr: local };
       }
       case "factory": {
         if (provider.tokenKind === "injection-token" && !provider.useFactoryName) {
-          const tokenIdent = this.imports.add(provider.token, provider.importPath);
+          const tokenIdent = this.imports.add(provider.token, provider.importPath, provider.importModule);
           const local = this.localVar(isMulti ? `${provider.token}Item` : provider.token, kind);
           const constLine = `const ${local} = resolveFactoryValue(${tokenIdent});`;
           return { constLine, key, expr: local };
         }
-        const factory = this.imports.add(provider.useFactoryName ?? "", provider.importPath);
+        const factory = this.imports.add(provider.useFactoryName ?? "", provider.importPath, provider.importModule);
         const args = provider.deps
-          .map((dep) => this.depExpr(dep, kind, provider.optionalDeps?.includes(dep)))
+          .map((dep) => this.depExpr(dep, kind, this.depOptions(provider, dep)))
           .join(", ");
         const local = this.localVar(isMulti ? (provider.useFactoryName ?? `${provider.token}Item`) : provider.token, kind);
         return { constLine: `const ${local} = ${factory}(${args});`, key, expr: local };
       }
       case "existing": {
         // Alias provider: does not create a new instance, directly references target expression.
-        return { key, expr: this.depExpr(provider.useExisting ?? provider.token, kind, provider.optionalDeps?.includes(provider.token)) };
+        return {
+          key,
+          expr: this.depExpr(
+            provider.useExisting ?? provider.token,
+            kind,
+            this.depOptions(provider, provider.useExisting ?? provider.token),
+          ),
+        };
       }
     }
   }
@@ -709,11 +739,52 @@ class ModuleGenerator {
   ): { constLine: string; key: string; expr: string } {
     const className = this.imports.add(controller.className, controller.importPath);
     const args = controller.deps
-      .map((dep) => this.depExpr(dep, kind, controller.optionalDeps?.includes(dep)))
+      .map((dep) => this.depExpr(dep, kind, this.depOptions(controller, dep)))
       .join(", ");
     const key = camelName(controller.className);
     const local = this.localVar(controller.className, kind);
-    return { constLine: `const ${local} = new ${className}(${args});`, key, expr: local };
+    return {
+      constLine: `const ${local} = ${this.instantiate(className, args, kind, controller.functionalInjects)};`,
+      key,
+      expr: local,
+    };
+  }
+
+  /**
+   * Functional inject() property initializers execute during `new`.
+   * The compiler supplies a finite, generated token identity table for that
+   * constructor call; it never performs provider discovery or token lookup.
+   */
+  private instantiate(
+    className: string,
+    args: string,
+    kind: FactoryKind,
+    functionalInjects?: FunctionalInjectNode[],
+  ): string {
+    if (!functionalInjects || functionalInjects.length === 0) {
+      return `new ${className}(${args})`;
+    }
+
+    const clauses = functionalInjects.map((entry) => {
+      const token = this.imports.add(entry.expression, entry.importPath, entry.importModule);
+      const value = this.depExpr(entry.token, kind, {
+        optional: entry.optional,
+        self: entry.self,
+        skipSelf: entry.skipSelf,
+        host: entry.host,
+      });
+      return `if (token === ${token}) return ${value} as T;`;
+    });
+    const missing = `if (options?.optional) return undefined; throw new Error("Static inject token not available: " + String(token));`;
+    const injector = [
+      `{`,
+      `get<T>(token: unknown, options?: { optional?: boolean; self?: boolean; skipSelf?: boolean; host?: boolean }): T | undefined {`,
+      ...clauses,
+      missing,
+      `},`,
+      `}`,
+    ].join("\n");
+    return `runInInjectionContext(${injector}, () => new ${className}(${args}))`;
   }
 
   /** Token -> local variable name in factory (camelCase, suffixed with digits on conflict). */
@@ -738,25 +809,45 @@ class ModuleGenerator {
    * Services exported by imported modules (imported.<module>.<key>, accessed via services param in
    * request/job factories) > Platform deps (deps.<camelName>).
    */
-  private depExpr(token: string, kind: FactoryKind, isOptional = false): string {
+  private depOptions(
+    node: Pick<ProviderNode, "optionalDeps" | "selfDeps" | "skipSelfDeps" | "hostDeps"> | Pick<ControllerNode, "optionalDeps" | "selfDeps" | "skipSelfDeps">,
+    token: string,
+  ): { optional: boolean; self: boolean; skipSelf: boolean; host: boolean } {
+    return {
+      optional: node.optionalDeps?.includes(token) ?? false,
+      self: node.selfDeps?.includes(token) ?? false,
+      skipSelf: node.skipSelfDeps?.includes(token) ?? false,
+      host: "hostDeps" in node ? (node.hostDeps?.includes(token) ?? false) : false,
+    };
+  }
+
+  private depExpr(
+    token: string,
+    kind: FactoryKind,
+    options: { optional?: boolean; self?: boolean; skipSelf?: boolean; host?: boolean } = {},
+  ): string {
+    const isOptional = options.optional ?? false;
+    const isSelf = options.self ?? false;
+    const isSkipSelf = options.skipSelf ?? false;
     if (kind === "request" && isRequestContextToken(token, this.graph.tokenNames)) return "ctx";
     if (kind === "job" && isJobContextToken(token, this.graph.tokenNames)) return "ctx";
 
     const own = this.module.providers.find((p) => p.token === token);
-    if (own) {
+    const ownIsLocal = own && factoryOfScope(own.scope) === kind;
+    if (own && ownIsLocal && !isSkipSelf) {
       if (factoryOfScope(own.scope) === kind && own.kind !== "existing") {
         return this.locals[kind].get(token) ?? camelName(token);
       }
-      if (own.kind === "existing" && factoryOfScope(own.scope) === kind) {
-        return this.depExpr(own.useExisting ?? token, kind, isOptional);
+      if (own.kind === "existing") {
+        return this.depExpr(own.useExisting ?? token, kind, options);
       }
-      if (kind === "services") {
-        // Application factory referencing request/job provider: scope-violation, already flagged by validator.
-        return `services.${camelName(token)}`;
-      }
-      return `services.${camelName(token)}`;
+    }
+    if (isSelf) {
+      return isOptional ? "undefined" : `services.${camelName(token)}`;
     }
 
+    // @Host() is intentionally a no-op for EnvironmentInjector-style scopes:
+    // SupaCloud has no element-injector tree to impose a host boundary.
     for (const importName of this.module.imports) {
       const imported = this.graph.modules.find((m) => m.name === importName);
       if (!imported?.exports.includes(token)) continue;
@@ -775,6 +866,7 @@ class ModuleGenerator {
       return "undefined";
     }
 
+    if (isSelf) return isOptional ? "undefined" : `services.${camelName(token)}`;
     if (kind === "services") return isOptional ? `(deps.${camelName(token)} ?? undefined)` : `deps.${camelName(token)}`;
     // request/job factories have no deps parameter; platform/external tokens are also passed via services.
     return isOptional ? `(services.${camelName(token)} ?? undefined)` : `services.${camelName(token)}`;

--- a/packages/compiler/src/incremental.test.ts
+++ b/packages/compiler/src/incremental.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { appendFile, mkdtemp, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDependencyGraphCache, createIncrementalCompiler, ModuleDependencyGraph } from "./incremental";
@@ -34,8 +34,9 @@ describe("createIncrementalCompiler", () => {
 
     await writeFile(join(rootDir, "src/plain.ts"), "export const value = 1;\n", "utf8");
     const fourth = await compiler.compile({ rootDir, outDir }, ["src/plain.ts"]);
-    expect(fourth.stats.cacheHit).toBe(true);
+    expect(fourth.stats.cacheHit).toBe(false);
     expect(fourth.stats.changedFiles).toEqual(["src/plain.ts"]);
+    expect(fourth.stats.reanalyzedModules).toEqual([]);
     expect(fourth.written).toEqual([]);
   });
 
@@ -140,5 +141,38 @@ describe("createIncrementalCompiler", () => {
     expect(second.stats.reanalyzedModules).toContain("audit");
     expect(second.stats.reanalyzedModules).toContain("case");
     expect(second.stats.reusedModules).toContain("health");
+  });
+
+  test("修改共享 token 文件会使引用它的模块重新分析", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-shared-token-"));
+    await writeFixtureProject(rootDir, GOOD_PROJECT_FILES);
+    const outDir = join(rootDir, "generated");
+    const cache = createDependencyGraphCache();
+    const compiler = createIncrementalCompiler();
+
+    await compiler.compile({ rootDir, outDir, cache });
+    await appendFile(join(rootDir, "src/features/shared/tokens.ts"), "\n// token update\n", "utf8");
+
+    const result = await compiler.compile({ rootDir, outDir, cache });
+    expect(result.stats.changedFiles).toContain("src/features/shared/tokens.ts");
+    expect(result.stats.reanalyzedModules).toContain("audit");
+    expect(result.stats.reanalyzedModules).toContain("case");
+    expect(result.stats.reusedModules).toContain("health");
+  });
+
+  test("删除源文件会从快照中移除，且不会把项目外路径纳入快照", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-delete-"));
+    await writeFixtureProject(rootDir, GOOD_PROJECT_FILES);
+    const outDir = join(rootDir, "generated");
+    const compiler = createIncrementalCompiler();
+    const extraFile = join(rootDir, "src/removed.ts");
+    await writeFile(extraFile, "export const removed = true;\n", "utf8");
+
+    await compiler.compile({ rootDir, outDir });
+    await rm(extraFile);
+    const result = await compiler.compile({ rootDir, outDir }, ["src/removed.ts", join(rootDir, "..", "outside.ts")]);
+
+    expect(result.stats.changedFiles).toContain("src/removed.ts");
+    expect(result.stats.changedFiles).not.toContain("../outside.ts");
   });
 });

--- a/packages/compiler/src/incremental.ts
+++ b/packages/compiler/src/incremental.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { access, readdir, readFile } from "node:fs/promises";
-import { relative, resolve, sep } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { compileProject } from "./compile";
 import type {
   CompileOptions,
@@ -24,6 +24,7 @@ export function createDependencyGraphCache(): DependencyGraphCache {
   return {
     modules: new Map(),
     fileHashes: new Map(),
+    generatedHashes: new Map(),
   };
 }
 
@@ -36,17 +37,25 @@ interface Snapshot {
 export function createIncrementalCompiler(): IncrementalCompiler {
   let previousSnapshot: Snapshot | undefined;
   let previousResult: CompileResult | undefined;
+  let previousCache: DependencyGraphCache | undefined;
   const cache: DependencyGraphCache = createDependencyGraphCache();
 
   return {
     async compile(options, changedPaths): Promise<IncrementalCompileResult> {
-      const snapshot = changedPaths && previousSnapshot
+      const optionsKey = optionsKeyOf(options);
+      const snapshot = changedPaths && previousSnapshot && previousSnapshot.optionsKey === optionsKey
         ? await updateSnapshot(previousSnapshot, options, changedPaths)
         : await createSnapshot(options);
       const changedFiles = changedPaths && previousSnapshot
         ? diffFiles(previousSnapshot.files, snapshot.files)
         : diffFiles(previousSnapshot?.files, snapshot.files);
-      const cacheHit = Boolean(previousSnapshot && previousSnapshot.optionsKey === snapshot.optionsKey && changedFiles.length === 0);
+      const activeCache = options.cache ?? cache;
+      const cacheHit = Boolean(
+        previousSnapshot
+        && previousSnapshot.optionsKey === snapshot.optionsKey
+        && previousCache === activeCache
+        && changedFiles.length === 0,
+      );
 
       if (cacheHit && previousResult) {
         return {
@@ -61,23 +70,14 @@ export function createIncrementalCompiler(): IncrementalCompiler {
         };
       }
 
-      if (previousResult && previousSnapshot && changedFiles.length > 0 && !(await requiresGraphRebuild(options.rootDir, changedFiles))) {
-        const stats: CompileStats = {
-          cacheHit: true,
-          changedFiles,
-          affectedModules: findAffectedModules(previousResult.graph.modules, previousResult.graph.modules, changedFiles),
-          reusedModules: previousResult.graph.modules.map((m) => m.name),
-          reanalyzedModules: [],
-        };
-        previousSnapshot = snapshot;
-        return { ...previousResult, written: [], stats };
-      }
-
-      const activeCache = options.cache ?? cache;
       if (!activeCache.dependencyGraph && previousResult) {
         activeCache.dependencyGraph = new ModuleDependencyGraph(previousResult.graph.modules);
       }
-      const result = await compileProject({ ...options, cache: activeCache });
+      const result = await compileProject({
+        ...options,
+        cache: activeCache,
+        changedPaths: changedFiles,
+      });
       const affectedModules = previousResult
         ? findAffectedModules(previousResult.graph.modules, result.graph.modules, changedFiles)
         : result.graph.modules.map((module) => module.name);
@@ -95,14 +95,18 @@ export function createIncrementalCompiler(): IncrementalCompiler {
       };
       previousSnapshot = snapshot;
       previousResult = result;
+      previousCache = activeCache;
       return { ...result, stats };
     },
     reset(): void {
       previousSnapshot = undefined;
       previousResult = undefined;
+      previousCache = undefined;
       cache.modules.clear();
       cache.fileHashes.clear();
+      cache.generatedHashes?.clear();
       cache.dependencyGraph = undefined;
+      cache.programSession?.reset();
     },
     getCache(): DependencyGraphCache {
       return cache;
@@ -115,7 +119,9 @@ async function updateSnapshot(previous: Snapshot, options: CompileOptions, chang
   const outDir = resolve(options.outDir);
   const files = { ...previous.files };
   for (const changedPath of changedPaths) {
-    const absolutePath = resolve(rootDir, changedPath);
+    const absolutePath = isAbsolute(changedPath) ? resolve(changedPath) : resolve(rootDir, changedPath);
+    const relativeChangedPath = relative(rootDir, absolutePath);
+    if (relativeChangedPath === ".." || relativeChangedPath.startsWith(`..${sep}`)) continue;
     if (absolutePath === outDir || absolutePath.startsWith(`${outDir}/`)) continue;
     const relativePath = relative(rootDir, absolutePath).split(sep).join("/");
     try {
@@ -143,8 +149,11 @@ async function createSnapshot(options: CompileOptions): Promise<Snapshot> {
 
 function optionsKeyOf(options: CompileOptions): string {
   return JSON.stringify({
+    rootDir: resolve(options.rootDir),
+    outDir: resolve(options.outDir),
     include: options.include,
     strict: options.strict,
+    writeOnError: options.writeOnError,
     moduleBoundaryPreset: options.moduleBoundaryPreset,
     moduleBoundaries: options.moduleBoundaries,
     allowRouteCommandBindings: options.allowRouteCommandBindings,
@@ -154,20 +163,8 @@ function optionsKeyOf(options: CompileOptions): string {
     generateClient: options.generateClient,
     generatePermissions: options.generatePermissions,
     typeSafety: options.typeSafety,
+    treeShakeUnusedProviders: options.treeShakeUnusedProviders,
   });
-}
-
-async function requiresGraphRebuild(rootDir: string, changedFiles: string[]): Promise<boolean> {
-  for (const relativePath of changedFiles) {
-    const path = resolve(rootDir, relativePath);
-    try {
-      const source = await readFile(path, "utf8");
-      if (/@(?:Module|Injectable|Inject|Controller|Command|Query)\b|new\s+InjectionToken\b|\bdefineModule\s*\(/.test(source)) return true;
-    } catch {
-      return true;
-    }
-  }
-  return false;
 }
 
 async function listSourceFiles(rootDir: string, outDir: string): Promise<string[]> {
@@ -236,7 +233,8 @@ export class ModuleDependencyGraph {
         if (!this.dependents.has(imp)) {
           this.dependents.set(imp, new Set());
         }
-        this.dependents.get(imp)!.add(modName);
+        const dependents = this.dependents.get(imp);
+        if (dependents) dependents.add(modName);
       }
     }
   }
@@ -247,7 +245,8 @@ export class ModuleDependencyGraph {
     if (!this.fileOwners.has(normalized)) {
       this.fileOwners.set(normalized, new Set());
     }
-    this.fileOwners.get(normalized)!.add(moduleName);
+    const owners = this.fileOwners.get(normalized);
+    if (owners) owners.add(moduleName);
   }
 
   getModulesOwningFile(filePath: string): string[] {
@@ -264,13 +263,17 @@ export class ModuleDependencyGraph {
       }
     }
     if (directlyAffected.size === 0) {
-      return Array.from(this.moduleMap.keys());
+      // An unrelated source file is not a graph dependency. Shared semantic
+      // files are indexed by their provider/controller import paths above;
+      // unknown files therefore remain outside the module closure.
+      return [];
     }
 
     const affected = new Set(directlyAffected);
     const queue = Array.from(directlyAffected);
     while (queue.length > 0) {
-      const current = queue.shift()!;
+      const current = queue.shift();
+      if (!current) continue;
       const dependents = this.dependents.get(current);
       if (dependents) {
         for (const dep of dependents) {

--- a/packages/compiler/src/incremental.ts
+++ b/packages/compiler/src/incremental.ts
@@ -153,6 +153,7 @@ function optionsKeyOf(options: CompileOptions): string {
     detectOrphanModules: options.detectOrphanModules,
     generateClient: options.generateClient,
     generatePermissions: options.generatePermissions,
+    typeSafety: options.typeSafety,
   });
 }
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -5,6 +5,11 @@ export { doctorProject, explainGraph, formatGraph, exportGraphDot, exportGraphMe
 export { createIncrementalCompiler } from "./incremental";
 export { createDependencyGraphCache } from "./incremental";
 export { ModuleDependencyGraph } from "./incremental";
+export { createIncrementalProgramSession } from "./program";
+export type { IncrementalProgramSession, ProgramUpdate } from "./program";
+export { compileTraits } from "./traits";
+export { TraitCompiler } from "./traits";
+export type { TraitCompilation, TraitHandler, TraitKind, TraitRecord } from "./traits";
 export { generateApplication, renderApplication } from "./generate";
 export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -10,6 +10,7 @@ export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";
 export { validateGraph, COMPILER_DIAGNOSTIC_CODES } from "./validate";
 export { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
+export type { TypeSafetyScanOptions } from "./type-safety";
 export { camelName } from "./util";
 export {
   ANGULAR_ENTERPRISE_RULES,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -9,6 +9,7 @@ export { generateApplication, renderApplication } from "./generate";
 export type { GenerateOptions, RenderedArtifacts } from "./generate";
 export type { DoctorResult } from "./inspect";
 export { validateGraph, COMPILER_DIAGNOSTIC_CODES } from "./validate";
+export { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
 export { camelName } from "./util";
 export {
   ANGULAR_ENTERPRISE_RULES,
@@ -30,6 +31,7 @@ export type {
   CompileStats,
   ControllerNode,
   DependencyGraphCache,
+  DependencyGraphIndex,
   Diagnostic,
   ModuleBoundaryPresetName,
   ModuleBoundaryProfile,
@@ -41,6 +43,7 @@ export type {
   RouteNode,
   Scope,
   TokenKind,
+  TypeSafetyOptions,
   ValidateOptions,
   WatchEvent,
   WatchHandle,

--- a/packages/compiler/src/profiles.test.ts
+++ b/packages/compiler/src/profiles.test.ts
@@ -42,7 +42,7 @@ describe("Architecture governance presets (profiles.ts)", () => {
   });
 
   test("getModuleBoundaryProfile rejects unknown presets with a useful error", () => {
-    expect(() => getModuleBoundaryProfile("unknown-preset" as any)).toThrow(
+    expect(() => getModuleBoundaryProfile("unknown-preset" as never)).toThrow(
       "Unknown module boundary preset: 'unknown-preset'",
     );
   });

--- a/packages/compiler/src/program.test.ts
+++ b/packages/compiler/src/program.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { createIncrementalProgramSession } from "./program";
+import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
+import { writeFixtureProject } from "./fixtures/helpers";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function fixture(files: Record<string, string>): Promise<string> {
+  const rootDir = await mkdtemp(join(process.env.TMPDIR ?? "/tmp", "supacloud-program-"));
+  roots.push(rootDir);
+  await writeFixtureProject(rootDir, files);
+  return rootDir;
+}
+
+describe("IncrementalProgramSession", () => {
+  test("复用未变更 SourceFile，并只重编译发生变化文件的 traits", async () => {
+    const rootDir = await fixture(GOOD_PROJECT_FILES);
+    const session = createIncrementalProgramSession(rootDir);
+    const files = [
+      join(rootDir, "src/features/audit/audit.module.ts"),
+      join(rootDir, "src/features/case/case.service.ts"),
+      join(rootDir, "src/features/health/health.module.ts"),
+    ];
+
+    const first = session.update(files);
+    const auditBefore = first.program.getSourceFile(files[0]);
+    const caseBefore = first.program.getSourceFile(files[1]);
+    expect(session.getTraits().some((trait) => trait.kind === "module" && trait.name === "AuditModule")).toBe(true);
+    expect(session.getTraits().some((trait) => trait.kind === "defineModule" && trait.name === "HealthModule")).toBe(true);
+    expect(session.getTraits().some((trait) => trait.kind === "injectionToken")).toBe(true);
+
+    await appendFile(join(rootDir, "src/features/audit/audit.module.ts"), "\n// changed\n", "utf8");
+    const second = session.update(files, ["src/features/audit/audit.module.ts"]);
+    expect(second.reusedFiles).toContain(files[1]);
+    expect(second.changedFiles).toContain(files[0]);
+    expect(second.program.getSourceFile(files[1]) === caseBefore).toBe(true);
+    expect(second.program.getSourceFile(files[0])?.text).not.toBe(auditBefore?.text);
+  });
+
+  test("refreshes imported files even when the change hints omit them", async () => {
+    const root = await fixture({
+      "src/main.ts": 'export { value } from "./dependency";\n',
+      "src/dependency.ts": "export const value = 1;\n",
+    });
+    const session = createIncrementalProgramSession(root);
+    const dependency = join(root, "src/dependency.ts");
+    const files = [join(root, "src/main.ts"), dependency];
+    session.update(files);
+    await writeFile(dependency, "export const value = 2;\n");
+    const updated = session.update(files, []);
+    expect(updated.program.getSourceFile(dependency)?.text).toContain("value = 2");
+    expect(updated.changedFiles).toContain(dependency);
+  });
+
+  test("reloads inherited compiler options without requiring a new session", async () => {
+    const root = await fixture({
+      "tsconfig.json": '{"extends":"./base.json","include":["src"]}',
+      "base.json": '{"compilerOptions":{"target":"ES2022","module":"ESNext"}}',
+      "src/main.ts": "export const value = 1;\n",
+    });
+    const session = createIncrementalProgramSession(root);
+    const file = join(root, "src/main.ts");
+    const first = session.update([file]);
+    expect(first.program.getCompilerOptions().target).toBe(ts.ScriptTarget.ES2022);
+    await writeFile(join(root, "base.json"), '{"compilerOptions":{"target":"ES5","module":"ESNext"}}');
+    const next = session.update([file], ["base.json"]);
+    expect(next.program.getCompilerOptions().target).toBe(ts.ScriptTarget.ES5);
+    expect(next.program.getSourceFile(file)?.languageVersion).toBe(ts.ScriptTarget.ES5);
+  });
+
+  test("invalidates missing-file caches on import creation, deletion and recreation", async () => {
+    const root = await fixture({
+      "src/main.ts": 'export { value } from "./dependency";\n',
+    });
+    const session = createIncrementalProgramSession(root);
+    const files = [join(root, "src/main.ts")];
+    const dependency = join(root, "src/dependency.ts");
+    session.update(files);
+    await writeFile(dependency, "export const value = 1;\n");
+    expect(session.update(files, [dependency]).program.getSourceFile(dependency)?.text).toContain("value = 1");
+    await rm(dependency);
+    const removed = session.update(files, [dependency]);
+    expect(removed.program.getSourceFile(dependency)).toBeUndefined();
+    expect(removed.changedFiles).toContain(dependency);
+    await writeFile(dependency, "export const value = 2;\n");
+    expect(session.update(files, [dependency]).program.getSourceFile(dependency)?.text).toContain("value = 2");
+  });
+
+  test("retains the builder emit state for unaffected files", async () => {
+    const root = await fixture({
+      "tsconfig.json": '{"compilerOptions":{"target":"ES2022","module":"ESNext","outDir":"dist"},"include":["src"]}',
+      "src/a.ts": "export const a = 1;\n",
+      "src/b.ts": "export const b = 1;\n",
+    });
+    const session = createIncrementalProgramSession(root);
+    const files = [join(root, "src/a.ts"), join(root, "src/b.ts")];
+    session.update(files);
+    expect(session.emit().emitSkipped).toBe(false);
+    const output = join(root, "dist/b.js");
+    await writeFile(output, "// unchanged output\n");
+    await writeFile(files[0], "export const a = 2;\n");
+    session.update(files, [files[0]]);
+    expect(session.emit().emitSkipped).toBe(false);
+    expect(await readFile(join(root, "dist/a.js"), "utf8")).toContain("a = 2");
+    expect(await readFile(output, "utf8")).toBe("// unchanged output\n");
+    session.reset();
+    session.update(files);
+    session.emit();
+    expect(await readFile(output, "utf8")).toContain("b = 1");
+  });
+});

--- a/packages/compiler/src/program.ts
+++ b/packages/compiler/src/program.ts
@@ -240,6 +240,14 @@ function hashText(text: string): string {
   return createHash("sha1").update(text).digest("hex");
 }
 
+function sourceVersion(fileName: string): string {
+  try {
+    return hashText(readFileSync(fileName, "utf8"));
+  } catch {
+    return "missing";
+  }
+}
+
 function sourceFileVersion(sourceFile: ts.SourceFile): string | undefined {
   const descriptor = Object.getOwnPropertyDescriptor(sourceFile, "version");
   return typeof descriptor?.value === "string" ? descriptor.value : undefined;

--- a/packages/compiler/src/program.ts
+++ b/packages/compiler/src/program.ts
@@ -1,0 +1,295 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { compileTraits, type TraitCompilation, type TraitRecord } from "./traits";
+
+export interface IncrementalProgramSession {
+  /** The current TypeScript program used as the semantic compilation boundary. */
+  getProgram(): ts.Program;
+  /** The current TypeScript type checker. */
+  getTypeChecker(): ts.TypeChecker;
+  /** Update the program while preserving TypeScript's incremental state. */
+  update(rootNames: string[], changedPaths?: string[]): ProgramUpdate;
+  /** Local Angular-style metadata records compiled from the current Program. */
+  getTraits(): readonly TraitRecord[];
+  /** TypeScript syntactic diagnostics for the current Program. */
+  getDiagnostics(): readonly ts.Diagnostic[];
+  /** Emit the current TypeScript program using the builder's incremental state. */
+  emit(): ts.EmitResult;
+  /** Drop the retained builder and source versions. */
+  reset(): void;
+}
+
+export interface ProgramUpdate {
+  changedFiles: string[];
+  reusedFiles: string[];
+  program: ts.Program;
+}
+
+interface ProjectConfig {
+  options: ts.CompilerOptions;
+  errors: readonly ts.Diagnostic[];
+  projectReferences?: readonly ts.ProjectReference[];
+  configFingerprint: string;
+}
+
+interface CachedSourceFile {
+  sourceFile: ts.SourceFile;
+  version: string;
+  parseKey: string;
+}
+
+/**
+ * Angular-style semantic boundary around TypeScript's incremental program.
+ *
+ * This deliberately owns only TypeScript program state. SupaCloud metadata
+ * handlers and ApplicationGraph linking remain separate layers.
+ */
+export function createIncrementalProgramSession(projectRoot: string): IncrementalProgramSession {
+  const rootDir = resolve(projectRoot);
+  let projectConfig = readProjectConfig(rootDir);
+  let projectConfigKey = configKey(projectConfig);
+  let builder: ts.EmitAndSemanticDiagnosticsBuilderProgram | undefined;
+  let traits: TraitCompilation | undefined;
+  const sourceFileCache = new Map<string, CachedSourceFile>();
+
+  return {
+    getProgram(): ts.Program {
+      if (!builder) {
+        throw new Error("incremental TypeScript program has not been initialized");
+      }
+      return builder.getProgram();
+    },
+
+    getTypeChecker(): ts.TypeChecker {
+      return this.getProgram().getTypeChecker();
+    },
+
+    update(rootNames, changedPaths = rootNames): ProgramUpdate {
+      const oldProgram = builder?.getProgram();
+      const oldSourceFiles = new Map(
+        oldProgram?.getSourceFiles().map((sourceFile) => [canonical(sourceFile.fileName), sourceFile]) ?? [],
+      );
+
+      const nextProjectConfig = readProjectConfig(rootDir);
+      const nextProjectConfigKey = configKey(nextProjectConfig);
+      const configChanged = nextProjectConfigKey !== projectConfigKey;
+      const previousBuilder = configChanged ? undefined : builder;
+      if (configChanged) {
+        sourceFileCache.clear();
+        traits = undefined;
+      }
+      projectConfig = nextProjectConfig;
+      projectConfigKey = nextProjectConfigKey;
+
+      const normalizedRoots = [...new Set(rootNames.map((file) => resolve(rootDir, file)))].sort();
+      const normalizedChanged = [...new Set(changedPaths.map((file) => resolve(rootDir, file)))];
+      const invalidatedPaths = new Set(normalizedChanged.map(canonical));
+      for (const sourceFile of oldSourceFiles.values()) {
+        if (sourceVersion(sourceFile.fileName) !== sourceFileVersion(sourceFile)) {
+          invalidatedPaths.add(canonical(sourceFile.fileName));
+        }
+      }
+      const invalidateAllResolutions = configChanged || [...invalidatedPaths].some((fileName) => {
+        const wasInProgram = oldSourceFiles.has(fileName);
+        return wasInProgram !== existsSync(fileName);
+      });
+      for (const fileName of normalizedChanged) {
+        if (!existsSync(fileName)) sourceFileCache.delete(canonical(fileName));
+      }
+
+      const host = createHost(
+        projectConfig.options,
+        rootDir,
+        sourceFileCache,
+        invalidatedPaths,
+        invalidateAllResolutions,
+      );
+      builder = ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+        normalizedRoots,
+        projectConfig.options,
+        host,
+        previousBuilder,
+        projectConfig.errors,
+        projectConfig.projectReferences,
+      );
+
+      const program = builder.getProgram();
+      const changedFiles: string[] = [];
+      const reusedFiles: string[] = [];
+      const currentPaths = new Set(program.getSourceFiles().map((file) => canonical(file.fileName)));
+      for (const sourceFile of program.getSourceFiles()) {
+        if (sourceFile.isDeclarationFile) continue;
+        const previous = oldSourceFiles.get(canonical(sourceFile.fileName));
+        if (previous && previous === sourceFile) {
+          reusedFiles.push(sourceFile.fileName);
+        } else {
+          changedFiles.push(sourceFile.fileName);
+        }
+      }
+      for (const [path, sourceFile] of oldSourceFiles) {
+        if (!sourceFile.isDeclarationFile && !currentPaths.has(path)) {
+          changedFiles.push(sourceFile.fileName);
+        }
+      }
+      for (const path of sourceFileCache.keys()) {
+        if (!currentPaths.has(path)) sourceFileCache.delete(path);
+      }
+
+      traits = compileTraits(program, traits, new Set(changedFiles));
+      return { changedFiles, reusedFiles, program };
+    },
+
+    getTraits(): readonly TraitRecord[] {
+      return traits?.all ?? [];
+    },
+
+    getDiagnostics(): readonly ts.Diagnostic[] {
+      if (!builder) return projectConfig.errors;
+      const program = builder.getProgram();
+      return [
+        ...projectConfig.errors,
+        ...program.getSyntacticDiagnostics(),
+      ];
+    },
+
+    emit(): ts.EmitResult {
+      if (!builder) {
+        throw new Error("incremental TypeScript program has not been initialized");
+      }
+      return builder.emit();
+    },
+
+    reset(): void {
+      builder = undefined;
+      projectConfig = readProjectConfig(rootDir);
+      projectConfigKey = configKey(projectConfig);
+      traits = undefined;
+      sourceFileCache.clear();
+    },
+  };
+}
+
+function createHost(
+  options: ts.CompilerOptions,
+  rootDir: string,
+  sourceFileCache: Map<string, CachedSourceFile>,
+  invalidatedPaths: Set<string>,
+  invalidateAllResolutions: boolean,
+): ts.CompilerHost {
+  const host = ts.createIncrementalCompilerHost(options, {
+    ...ts.sys,
+    getCurrentDirectory: () => rootDir,
+  });
+  host.hasInvalidatedResolutions = (filePath) =>
+    invalidateAllResolutions || invalidatedPaths.has(canonical(filePath));
+  const originalGetSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+    const key = canonical(fileName);
+    const text = host.readFile(fileName);
+    if (text === undefined) {
+      sourceFileCache.delete(key);
+      return originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+    }
+
+    const version = hashText(text);
+    const parseKey = sourceFileParseKey(languageVersion);
+    const cached = sourceFileCache.get(key);
+    if (!shouldCreateNewSourceFile && cached?.version === version && cached.parseKey === parseKey) {
+      return cached.sourceFile;
+    }
+
+    const sourceFile = originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+    if (sourceFile) {
+      sourceFileCache.set(key, { sourceFile, version: hashText(sourceFile.text), parseKey });
+    } else {
+      sourceFileCache.delete(key);
+    }
+    return sourceFile;
+  };
+  return host;
+}
+
+function canonical(fileName: string): string {
+  const normalized = resolve(fileName);
+  return ts.sys.useCaseSensitiveFileNames ? normalized : normalized.toLowerCase();
+}
+
+function sourceFileParseKey(
+  languageVersion: ts.ScriptTarget | ts.CreateSourceFileOptions,
+): string {
+  return typeof languageVersion === "number"
+    ? `target:${languageVersion}`
+    : JSON.stringify({
+        languageVersion: languageVersion.languageVersion,
+        impliedNodeFormat: languageVersion.impliedNodeFormat,
+        jsDocParsingMode: languageVersion.jsDocParsingMode,
+      });
+}
+
+function configKey(config: ProjectConfig): string {
+  return JSON.stringify({
+    options: config.options,
+    projectReferences: config.projectReferences,
+    configFingerprint: config.configFingerprint,
+  });
+}
+
+function hashText(text: string): string {
+  return createHash("sha1").update(text).digest("hex");
+}
+
+function sourceFileVersion(sourceFile: ts.SourceFile): string | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(sourceFile, "version");
+  return typeof descriptor?.value === "string" ? descriptor.value : undefined;
+}
+
+function readProjectConfig(rootDir: string): ProjectConfig {
+  const configPath = join(rootDir, "tsconfig.json");
+  if (!existsSync(configPath)) {
+    return {
+      options: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        experimentalDecorators: true,
+        allowJs: false,
+        skipLibCheck: true,
+      },
+      errors: [],
+      projectReferences: undefined,
+      configFingerprint: "defaults",
+    };
+  }
+
+  const configReads = new Map<string, string>();
+  const readConfig = (fileName: string): string | undefined => {
+    const text = ts.sys.readFile(fileName);
+    configReads.set(canonical(fileName), text === undefined ? "missing" : hashText(text));
+    return text;
+  };
+  const config: ReturnType<typeof ts.readConfigFile> = ts.readConfigFile(
+    configPath,
+    readConfig,
+  );
+  if (config.error) {
+    return {
+      options: {},
+      errors: [config.error],
+      configFingerprint: JSON.stringify([...configReads]),
+    };
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    { ...ts.sys, readFile: readConfig },
+    dirname(configPath),
+  );
+  return {
+    options: parsed.options,
+    errors: parsed.errors,
+    projectReferences: parsed.projectReferences,
+    configFingerprint: JSON.stringify([...configReads]),
+  };
+}

--- a/packages/compiler/src/traits.ts
+++ b/packages/compiler/src/traits.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import * as ts from "@typescript/typescript6";
+
+export type TraitKind =
+  | "module"
+  | "injectable"
+  | "controller"
+  | "command"
+  | "query"
+  | "defineModule"
+  | "injectionToken";
+
+export interface TraitRecord {
+  kind: TraitKind;
+  name: string;
+  file: string;
+  start: number;
+  end: number;
+  fingerprint: string;
+}
+
+export interface TraitCompilation {
+  byFile: Map<string, TraitRecord[]>;
+  all: TraitRecord[];
+}
+
+export interface TraitHandler {
+  readonly kind: TraitKind;
+  detect(node: ts.Node): string | undefined;
+}
+
+const DECORATOR_TRAITS: Record<string, TraitKind> = {
+  Module: "module",
+  Injectable: "injectable",
+  Controller: "controller",
+  Command: "command",
+  Query: "query",
+};
+
+export class TraitCompiler {
+  private readonly handlers: readonly TraitHandler[];
+
+  constructor(handlers: readonly TraitHandler[] = createDefaultTraitHandlers()) {
+    this.handlers = handlers;
+  }
+
+  /**
+   * Angular-style local metadata compiler.
+   *
+   * This pass is intentionally syntax-only. It discovers candidate declarations
+   * cheaply; handlers that need symbols or types run later against the Program's
+   * TypeChecker.
+   */
+  compile(
+    program: ts.Program,
+    previous: TraitCompilation | undefined,
+    changedFiles: Set<string>,
+  ): TraitCompilation {
+    const byFile = new Map<string, TraitRecord[]>();
+
+    for (const sourceFile of program.getSourceFiles()) {
+      if (sourceFile.isDeclarationFile || sourceFile.fileName.includes("/node_modules/")) continue;
+      const previousTraits = previous?.byFile.get(sourceFile.fileName);
+      if (previousTraits && !changedFiles.has(sourceFile.fileName)) {
+        byFile.set(sourceFile.fileName, previousTraits);
+        continue;
+      }
+      byFile.set(sourceFile.fileName, this.compileSourceFile(sourceFile));
+    }
+
+    const all = [...byFile.values()].flat().sort((a, b) =>
+      a.file.localeCompare(b.file) || a.start - b.start || a.kind.localeCompare(b.kind),
+    );
+    return { byFile, all };
+  }
+
+  private compileSourceFile(sourceFile: ts.SourceFile): TraitRecord[] {
+    const traits: TraitRecord[] = [];
+    const visit = (node: ts.Node): void => {
+      for (const handler of this.handlers) {
+        const name = handler.detect(node);
+        if (name) traits.push(record(handler.kind, name, sourceFile, node));
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return traits;
+  }
+}
+
+export function compileTraits(
+  program: ts.Program,
+  previous: TraitCompilation | undefined,
+  changedFiles: Set<string>,
+): TraitCompilation {
+  return new TraitCompiler().compile(program, previous, changedFiles);
+}
+
+function record(
+  kind: TraitKind,
+  name: string,
+  sourceFile: ts.SourceFile,
+  node: ts.Node,
+): TraitRecord {
+  const text = node.getText(sourceFile);
+  return {
+    kind,
+    name,
+    file: sourceFile.fileName,
+    start: node.getStart(sourceFile),
+    end: node.end,
+    fingerprint: createHash("sha1").update(`${kind}:${text}`).digest("hex"),
+  };
+}
+
+function decoratorName(decorator: ts.Decorator): string {
+  return expressionName(
+    ts.isCallExpression(decorator.expression) ? decorator.expression.expression : decorator.expression,
+  );
+}
+
+function expressionName(expression: ts.Expression): string {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  return "";
+}
+
+function createDefaultTraitHandlers(): TraitHandler[] {
+  return [
+    {
+      kind: "module",
+      detect: decoratedDeclaration("Module"),
+    },
+    {
+      kind: "injectable",
+      detect: decoratedDeclaration("Injectable"),
+    },
+    {
+      kind: "controller",
+      detect: decoratedDeclaration("Controller"),
+    },
+    {
+      kind: "command",
+      detect: decoratedDeclaration("Command"),
+    },
+    {
+      kind: "query",
+      detect: decoratedDeclaration("Query"),
+    },
+    {
+      kind: "defineModule",
+      detect: (node) => {
+        if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name)) return undefined;
+        const initializer = node.initializer;
+        return initializer && ts.isCallExpression(initializer) && expressionName(initializer.expression) === "defineModule"
+          ? node.name.text
+          : undefined;
+      },
+    },
+    {
+      kind: "injectionToken",
+      detect: (node) => {
+        if (!ts.isVariableDeclaration(node) || !ts.isIdentifier(node.name)) return undefined;
+        const initializer = node.initializer;
+        return initializer && ts.isNewExpression(initializer) && expressionName(initializer.expression) === "InjectionToken"
+          ? node.name.text
+          : undefined;
+      },
+    },
+  ];
+}
+
+function decoratedDeclaration(decorator: string): (node: ts.Node) => string | undefined {
+  return (node) => {
+    if (!ts.isClassDeclaration(node) || !node.name) return undefined;
+    return (ts.getDecorators(node) ?? []).some((item) => decoratorName(item) === decorator)
+      ? node.name.text
+      : undefined;
+  };
+}

--- a/packages/compiler/src/type-safety.test.ts
+++ b/packages/compiler/src/type-safety.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
 import { writeFixtureProject } from "./fixtures/helpers";
 
@@ -63,5 +63,64 @@ describe("compiler type-safety gates", () => {
     });
 
     expect(scanProductionSource({ rootDir, strict: true })).toEqual([]);
+  });
+
+  test("typed destructuring does not become any, but unsafe binding leaves are reported", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+      "src/production.ts": [
+        "declare const input: { value: string; nested: { count: number }; unsafe: any };",
+        "export const { value, nested: { count } } = input;",
+        "export const [first, ...rest] = [1, 2];",
+        "export const { unsafe: alias } = input;",
+        "export const handler: (input: { value: string }) => string = ({ value }) => value;",
+      ].join("\n"),
+    });
+    const diagnostics = scanProductionSource({ rootDir, strict: true });
+    expect(diagnostics.map(({ code, line }) => ({ code, line }))).toEqual([
+      { code: "source-any", line: 1 },
+      { code: "source-any", line: 4 },
+    ]);
+  });
+
+  test("project types resolve from the scanned package instead of the caller cwd", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true, types: ["scan-env"] } }),
+      "node_modules/@types/scan-env/index.d.ts": "declare function scanEnvValue(): string;",
+      "src/production.ts": "export const value = scanEnvValue();",
+    });
+    expect(scanProductionSource({ rootDir, strict: true })).toEqual([]);
+    expect(scanProductionSource({ rootDir: relative(process.cwd(), rootDir), strict: true })).toEqual([]);
+  });
+
+  test("default exclusions work at root and nested levels without excluding production lookalikes", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    const ignored = [
+      "root.test.ts", "root.spec.ts", "nested/file.test.ts", "__tests__/helper.ts",
+      "fixtures/input.ts", "generated/app.ts", "nested/fixtures/input.ts", "types.d.ts",
+    ];
+    await writeFixtureProject(rootDir, {
+      ...Object.fromEntries(ignored.map((file) => [file, "export const unsafe: any = 1;"])),
+      "src/test-utils.ts": "export const unsafe: any = 1;",
+    });
+    const diagnostics = scanProductionSource({ rootDir, strict: true });
+    expect(diagnostics.map(({ file, code }) => ({ file, code }))).toEqual([
+      { file: "src/test-utils.ts", code: "source-any" },
+    ]);
+  });
+
+  test("invalid configuration and missing type libraries cannot pass silently", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { types: ["missing-env"], invalidOption: true } }),
+      "src/production.ts": "export const value = 1;",
+    });
+    const diagnostics = scanProductionSource({ rootDir });
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ severity: "error", code: "source-config", errorCode: "TS5023" }),
+      expect.objectContaining({ severity: "error", code: "source-config", errorCode: "TS2688" }),
+    ]));
   });
 });

--- a/packages/compiler/src/type-safety.test.ts
+++ b/packages/compiler/src/type-safety.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
+import { writeFixtureProject } from "./fixtures/helpers";
+
+describe("compiler type-safety gates", () => {
+  test("strict generated-artifact scan rejects any", () => {
+    const diagnostics = scanGeneratedArtifacts({
+      "application.ts": "export function create(value: any): unknown { return value; }\n",
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      severity: "error",
+      code: "generated-any",
+      errorCode: "SC6001",
+      file: "application.ts",
+      line: 1,
+    });
+  });
+
+  test("production scan reports any, assertions, non-null assertions and widening", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+      "src/production.ts": [
+        "export const unsafe: any = 1;",
+        "export const asserted = unsafe as number;",
+        "export const required = unsafe!;",
+        "export let widened = 'mutable';",
+      ].join("\n"),
+      "src/ignored.test.ts": "export const ignored: any = 1;",
+      "src/ignored.ts": "export const ignored: any = 1;",
+    });
+
+    const diagnostics = scanProductionSource({
+      rootDir,
+      exclude: ["src/ignored.ts"],
+      strict: true,
+    });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "source-any",
+      "source-type-assertion",
+      "source-non-null-assertion",
+      "source-implicit-widening",
+    ]);
+    expect(diagnostics.every((diagnostic) => diagnostic.severity === "error")).toBe(true);
+    expect(diagnostics.every((diagnostic) => diagnostic.file === "src/production.ts")).toBe(true);
+  });
+
+  test("as const and excluded test files are accepted", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "supacloud-compiler-type-safety-"));
+    await writeFixtureProject(rootDir, {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { strict: true } }),
+      "src/production.ts": [
+        'export const stable = { mode: "strict" } as const;',
+        "export const typed: { mode: string } = { mode: 'strict' };",
+      ].join("\n"),
+      "src/production.test.ts": "export const ignored: any = 1;",
+    });
+
+    expect(scanProductionSource({ rootDir, strict: true })).toEqual([]);
+  });
+});

--- a/packages/compiler/src/type-safety.test.ts
+++ b/packages/compiler/src/type-safety.test.ts
@@ -44,6 +44,7 @@ describe("compiler type-safety gates", () => {
       "source-any",
       "source-type-assertion",
       "source-non-null-assertion",
+      "source-any",
       "source-implicit-widening",
     ]);
     expect(diagnostics.every((diagnostic) => diagnostic.severity === "error")).toBe(true);

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -1,7 +1,6 @@
-import { Node, Project, SyntaxKind, type SourceFile } from "ts-morph";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { relative, sep } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import * as ts from "@typescript/typescript6";
 import type { Diagnostic, TypeSafetyOptions } from "./types";
 
 const DEFAULT_EXCLUDES = [
@@ -33,16 +32,21 @@ export function scanGeneratedArtifacts(
   artifacts: Record<string, string | undefined>,
   strict = true,
 ): Diagnostic[] {
-  const project = new Project({ useInMemoryFileSystem: true });
   const diagnostics: Diagnostic[] = [];
   for (const [file, content] of Object.entries(artifacts)) {
     if (content === undefined) continue;
-    const sourceFile = project.createSourceFile(file, content, { overwrite: true });
-    for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+    const sourceFile = ts.createSourceFile(
+      file,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    for (const node of descendantsOfKind(sourceFile, isAnyKeyword)) {
       diagnostics.push(makeDiagnostic(
         "generated-any",
         `生成产物 ${file} 包含 any；严格生成模式要求使用 unknown、具体接口或泛型约束。`,
-        file,
+        sourceFile,
         node,
         strict,
       ));
@@ -52,39 +56,66 @@ export function scanGeneratedArtifacts(
 }
 
 export function scanProductionSource(options: TypeSafetyScanOptions): Diagnostic[] {
-  const project = new Project({
-    ...(existsSync(join(options.rootDir, "tsconfig.json"))
-      ? { tsConfigFilePath: join(options.rootDir, "tsconfig.json") }
-      : {
-          compilerOptions: {
-            strict: true,
-            skipLibCheck: true,
-          },
-        }),
-    skipAddingFilesFromTsConfig: true,
-  });
+  const rootDir = resolve(options.rootDir);
+  const configPath = join(rootDir, "tsconfig.json");
+  const projectConfig: { options: ts.CompilerOptions; errors: readonly ts.Diagnostic[] } = existsSync(configPath)
+    ? readProjectConfig(configPath)
+    : {
+        options: {
+          strict: true,
+          skipLibCheck: true,
+          target: ts.ScriptTarget.ES2022,
+          module: ts.ModuleKind.ESNext,
+        },
+        errors: [],
+      };
   const include = options.include ?? ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
-  project.addSourceFilesAtPaths(include.map((pattern) => `${options.rootDir}/${pattern}`));
-  const outDir = options.outDir ? normalizeRelative(options.rootDir, options.outDir) : undefined;
+  const rootNames = ts.sys.readDirectory(
+    rootDir,
+    [".ts", ".tsx", ".mts", ".cts"],
+    ["node_modules", "dist"],
+    include,
+  ).filter((file) => isProductionSourcePath(
+    rootDir,
+    file,
+    [...DEFAULT_EXCLUDES, ...(options.exclude ?? [])],
+  ));
+  const compilerOptions: ts.CompilerOptions = { ...projectConfig.options, noEmit: true };
+  const host = ts.createCompilerHost(compilerOptions);
+  host.getCurrentDirectory = () => rootDir;
+  const program = ts.createProgram(rootNames, compilerOptions, host);
+  const outDir = options.outDir ? normalizeRelative(rootDir, options.outDir) : undefined;
   const excludes = [...DEFAULT_EXCLUDES, ...(options.exclude ?? [])];
-  const sourceFiles = project
+  const sourceFiles = program
     .getSourceFiles()
-    .filter((sourceFile) => isProductionSource(options.rootDir, sourceFile, excludes, outDir));
+    .filter((sourceFile) => isProductionSource(rootDir, sourceFile, excludes, outDir));
 
-  const diagnostics: Diagnostic[] = [];
+  const diagnostics: Diagnostic[] = [...projectConfig.errors, ...program.getOptionsDiagnostics()]
+    .map((diagnostic) => ({
+      severity: "error",
+      code: "source-config",
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+      file: diagnostic.file ? normalizeRelative(rootDir, diagnostic.file.fileName) : normalizeRelative(rootDir, configPath),
+      line: diagnostic.file && diagnostic.start !== undefined
+        ? diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start).line + 1
+        : undefined,
+      errorCode: `TS${diagnostic.code}`,
+    }));
+  const checker = program.getTypeChecker();
   for (const sourceFile of sourceFiles) {
-    scanSourceFile(sourceFile, options.rootDir, diagnostics, options.strict ?? false);
+    scanSourceFile(sourceFile, checker, rootDir, diagnostics, options.strict ?? false);
   }
   return diagnostics;
 }
 
 function scanSourceFile(
-  sourceFile: SourceFile,
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
   rootDir: string,
   diagnostics: Diagnostic[],
   strict: boolean,
 ): void {
-  for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+  for (const node of descendantsOfKind(sourceFile, isAnyKeyword)) {
     diagnostics.push(makeDiagnostic(
       "source-any",
       "生产源码使用了显式 any；请改用 unknown、具体接口或泛型约束。",
@@ -95,33 +126,33 @@ function scanSourceFile(
     ));
   }
 
-  for (const node of sourceFile.getDescendants()) {
-    if (Node.isAsExpression(node)) {
-      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
-      const assertedType = node.getTypeNode()?.getText();
+  for (const node of descendants(sourceFile)) {
+    if (ts.isAsExpression(node)) {
+      if (ts.isAsExpression(node.parent) || ts.isTypeAssertionExpression(node.parent)) continue;
+      const assertedType = node.type.getText(sourceFile);
       if (assertedType === "const") continue;
       diagnostics.push(makeDiagnostic(
         "source-type-assertion",
-        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        `生产源码包含类型断言 ${node.getText(sourceFile)}；请优先使用类型守卫、satisfies 或显式边界解析。`,
         sourceFile,
         node,
         strict,
         rootDir,
       ));
-    } else if (Node.isTypeAssertion(node)) {
-      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
+    } else if (ts.isTypeAssertionExpression(node)) {
+      if (ts.isAsExpression(node.parent) || ts.isTypeAssertionExpression(node.parent)) continue;
       diagnostics.push(makeDiagnostic(
         "source-type-assertion",
-        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        `生产源码包含类型断言 ${node.getText(sourceFile)}；请优先使用类型守卫、satisfies 或显式边界解析。`,
         sourceFile,
         node,
         strict,
         rootDir,
       ));
-    } else if (Node.isNonNullExpression(node)) {
+    } else if (ts.isNonNullExpression(node)) {
       diagnostics.push(makeDiagnostic(
         "source-non-null-assertion",
-        `生产源码包含非空断言 ${node.getText()}；请显式处理 null/undefined。`,
+        `生产源码包含非空断言 ${node.getText(sourceFile)}；请显式处理 null/undefined。`,
         sourceFile,
         node,
         strict,
@@ -130,45 +161,47 @@ function scanSourceFile(
     }
   }
 
-  for (const declaration of sourceFile.getVariableDeclarations()) {
-    const initializer = declaration.getInitializer();
-    if (!initializer || declaration.getTypeNode()) continue;
-    const declarationType = declaration.getType();
-    const initializerType = initializer.getType();
-    if (declarationType.isAny()) {
-      diagnostics.push(makeDiagnostic(
-        "source-any",
-        "生产源码中的变量被推断为 any；请为边界数据提供解析类型或显式 unknown。",
-        sourceFile,
-        declaration,
-        strict,
-        rootDir,
-      ));
-      continue;
+  for (const declaration of descendantsOfKind(sourceFile, ts.isVariableDeclaration)) {
+    const initializer = declaration.initializer;
+    if (!initializer || declaration.type) continue;
+    const declarationType = checker.getTypeAtLocation(declaration.name);
+    const initializerType = checker.getTypeAtLocation(initializer);
+    for (const name of bindingNames(declaration.name)) {
+      if (isAnyType(checker.getTypeAtLocation(name))) {
+        diagnostics.push(makeDiagnostic(
+          "source-any",
+          "生产源码中的变量被推断为 any；请为边界数据提供解析类型或显式 unknown。",
+          sourceFile,
+          name,
+          strict,
+          rootDir,
+        ));
+      }
     }
-    if (declaration.getVariableStatement()?.getDeclarationKind() === "let"
+    if (isAnyType(declarationType)) continue;
+    if (isLetDeclaration(declaration)
       && isLiteralSyntax(initializer)
-      && !declarationType.isLiteral()) {
+      && !isLiteralType(declarationType)) {
       diagnostics.push(makeDiagnostic(
         "source-implicit-widening",
-        `变量 ${declaration.getName()} 的字面量类型从 ${initializerType.getText()} 隐式宽化为 ${declarationType.getText()}；请补充类型或使用 const。`,
+        `变量 ${declaration.name.getText(sourceFile)} 的字面量类型从 ${checker.typeToString(initializerType, initializer)} 隐式宽化为 ${checker.typeToString(declarationType, declaration)}；请补充类型或使用 const。`,
         sourceFile,
         declaration,
         strict,
         rootDir,
       ));
     }
-    if (Node.isObjectLiteralExpression(initializer)
-      && declaration.getVariableStatement()?.getDeclarationKind() === "const"
-      && initializer.getText().length > 0
-      && initializer.getProperties().some((property) => {
-        return Node.isPropertyAssignment(property)
-          && property.getInitializer()?.getKind() !== SyntaxKind.AsExpression
-          && isLiteralExpression(property.getInitializer());
-      })) {
+    if (ts.isObjectLiteralExpression(initializer)
+      && isConstDeclaration(declaration)
+      && initializer.getText(sourceFile).length > 0
+      && initializer.properties.some((property) =>
+        ts.isPropertyAssignment(property)
+        && property.initializer !== undefined
+        && !ts.isAsExpression(property.initializer)
+        && isLiteralExpression(property.initializer))) {
       diagnostics.push(makeDiagnostic(
         "source-implicit-widening",
-        `常量对象 ${declaration.getName()} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
+        `常量对象 ${declaration.name.getText(sourceFile)} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
         sourceFile,
         declaration,
         strict,
@@ -177,82 +210,157 @@ function scanSourceFile(
     }
   }
 
-  for (const parameter of sourceFile.getDescendantsOfKind(SyntaxKind.Parameter)) {
-    if (!parameter.getTypeNode() && parameter.getType().isAny()) {
-      diagnostics.push(makeDiagnostic(
-        "source-any",
-        "生产源码中的参数被推断为 any；请补充参数类型。",
-        sourceFile,
-        parameter,
-        strict,
-        rootDir,
-      ));
+  for (const parameter of descendantsOfKind(sourceFile, ts.isParameter)) {
+    if (parameter.type) continue;
+    for (const name of bindingNames(parameter.name)) {
+      if (isAnyType(checker.getTypeAtLocation(name))) {
+        diagnostics.push(makeDiagnostic(
+          "source-any",
+          "生产源码中的参数被推断为 any；请补充参数类型。",
+          sourceFile,
+          name,
+          strict,
+          rootDir,
+        ));
+      }
     }
   }
+}
 
+function readProjectConfig(configPath: string): {
+  options: ts.CompilerOptions;
+  errors: readonly ts.Diagnostic[];
+} {
+  const config = ts.readConfigFile(configPath, (file) => readFileSync(file, "utf8"));
+  if (config.error) return { options: {}, errors: [config.error] };
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(configPath));
+  return { options: parsed.options, errors: parsed.errors };
 }
 
 function isProductionSource(
   rootDir: string,
-  sourceFile: SourceFile,
+  sourceFile: ts.SourceFile,
   excludes: string[],
   outDir?: string,
 ): boolean {
-  const relativePath = normalizeRelative(rootDir, sourceFile.getFilePath());
-  if (relativePath.startsWith("../") || relativePath.includes("node_modules/")) return false;
+  const relativePath = normalizeRelative(rootDir, sourceFile.fileName);
+  if (sourceFile.isDeclarationFile || relativePath.startsWith("../") || relativePath.includes("node_modules/")) return false;
   if (outDir && (relativePath === outDir || relativePath.startsWith(`${outDir}/`))) return false;
   return !excludes.some((pattern) => globMatches(relativePath, pattern));
+}
+
+function isProductionSourcePath(rootDir: string, filePath: string, excludes: string[]): boolean {
+  const relativePath = normalizeRelative(rootDir, filePath);
+  return !relativePath.startsWith("../")
+    && !relativePath.includes("node_modules/")
+    && !excludes.some((pattern) => globMatches(relativePath, pattern));
 }
 
 function globMatches(value: string, pattern: string): boolean {
   const escaped = pattern
     .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*\//g, "§/")
     .replace(/\*\*/g, "§§")
     .replace(/\*/g, "[^/]*")
-    .replace(/§§/g, ".*")
-    .replace(/\?/g, "[^/]");
-  const optionalRoot = escaped.startsWith(".*\\/") ? "(?:.*\\/)?"
-    : escaped;
-  return new RegExp(`^${optionalRoot === escaped ? escaped : optionalRoot + escaped.slice(3)}$`).test(value);
+    .replace(/\?/g, "[^/]")
+    .replace(/§\//g, "(?:.*/)?")
+    .replace(/§§/g, ".*");
+  return new RegExp(`^${escaped}$`).test(value);
 }
 
-function isLiteralExpression(node: Node | undefined): boolean {
+function bindingNames(name: ts.BindingName): ts.Identifier[] {
+  if (ts.isIdentifier(name)) return [name];
+  return name.elements.flatMap((element) =>
+    ts.isBindingElement(element) ? bindingNames(element.name) : [],
+  );
+}
+
+function isLiteralExpression(node: ts.Node | undefined): node is ts.Expression {
   if (!node) return false;
   return [
-    SyntaxKind.StringLiteral,
-    SyntaxKind.NumericLiteral,
-    SyntaxKind.TrueKeyword,
-    SyntaxKind.FalseKeyword,
-  ].includes(node.getKind());
+    ts.SyntaxKind.StringLiteral,
+    ts.SyntaxKind.NumericLiteral,
+    ts.SyntaxKind.TrueKeyword,
+    ts.SyntaxKind.FalseKeyword,
+  ].includes(node.kind);
 }
 
-function isLiteralSyntax(node: Node): boolean {
-  return Node.isStringLiteral(node)
-    || Node.isNumericLiteral(node)
-    || node.getKind() === SyntaxKind.TrueKeyword
-    || node.getKind() === SyntaxKind.FalseKeyword;
+function isLiteralSyntax(node: ts.Node): boolean {
+  return ts.isStringLiteral(node)
+    || ts.isNumericLiteral(node)
+    || node.kind === ts.SyntaxKind.TrueKeyword
+    || node.kind === ts.SyntaxKind.FalseKeyword;
+}
+
+function isLiteralType(type: ts.Type): boolean {
+  return (type.flags & (
+    ts.TypeFlags.StringLiteral
+    | ts.TypeFlags.NumberLiteral
+    | ts.TypeFlags.BooleanLiteral
+    | ts.TypeFlags.BigIntLiteral
+  )) !== 0;
+}
+
+function isAnyType(type: ts.Type): boolean {
+  return (type.flags & ts.TypeFlags.Any) !== 0;
+}
+
+function isLetDeclaration(declaration: ts.VariableDeclaration): boolean {
+  return ts.isVariableDeclarationList(declaration.parent)
+    && (declaration.parent.flags & ts.NodeFlags.Let) !== 0;
+}
+
+function isConstDeclaration(declaration: ts.VariableDeclaration): boolean {
+  return ts.isVariableDeclarationList(declaration.parent)
+    && (declaration.parent.flags & ts.NodeFlags.Const) !== 0;
+}
+
+function descendants(root: ts.Node): ts.Node[] {
+  const result: ts.Node[] = [];
+  const visit = (node: ts.Node): void => {
+    result.push(node);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(root, visit);
+  return result;
+}
+
+function descendantsOfKind<T extends ts.Node>(
+  root: ts.Node,
+  predicate: (node: ts.Node) => node is T,
+): T[] {
+  const result: T[] = [];
+  const visit = (node: ts.Node): void => {
+    if (predicate(node)) result.push(node);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(root, visit);
+  return result;
 }
 
 function makeDiagnostic(
   code: keyof typeof DIAGNOSTIC_META,
   message: string,
-  fileOrSourceFile: string | SourceFile,
-  node: Node,
+  fileOrSourceFile: string | ts.SourceFile,
+  node: ts.Node,
   strict: boolean,
   rootDir?: string,
 ): Diagnostic {
+  const sourceFile = typeof fileOrSourceFile === "string" ? undefined : fileOrSourceFile;
   const file = typeof fileOrSourceFile === "string"
     ? fileOrSourceFile
     : rootDir
-      ? normalizeRelative(rootDir, fileOrSourceFile.getFilePath())
-      : fileOrSourceFile.getFilePath();
+      ? normalizeRelative(rootDir, fileOrSourceFile.fileName)
+      : fileOrSourceFile.fileName;
   const meta = DIAGNOSTIC_META[code];
   return {
     severity: strict ? "error" : "warn",
     code,
     message,
     file,
-    line: node.getStartLineNumber(),
+    line: sourceFile
+      ? sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+      : undefined,
     errorCode: meta.errorCode,
     docsUrl: meta.docsUrl,
   };
@@ -260,4 +368,8 @@ function makeDiagnostic(
 
 function normalizeRelative(rootDir: string, filePath: string): string {
   return relative(rootDir, filePath).split(sep).join("/").replace(/^\.\//, "");
+}
+
+function isAnyKeyword(node: ts.Node): node is ts.KeywordTypeNode {
+  return node.kind === ts.SyntaxKind.AnyKeyword;
 }

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -135,6 +135,17 @@ function scanSourceFile(
     if (!initializer || declaration.getTypeNode()) continue;
     const declarationType = declaration.getType();
     const initializerType = initializer.getType();
+    if (declarationType.isAny()) {
+      diagnostics.push(makeDiagnostic(
+        "source-any",
+        "生产源码中的变量被推断为 any；请为边界数据提供解析类型或显式 unknown。",
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+      continue;
+    }
     if (declaration.getVariableStatement()?.getDeclarationKind() === "let"
       && isLiteralSyntax(initializer)
       && !declarationType.isLiteral()) {
@@ -160,6 +171,19 @@ function scanSourceFile(
         `常量对象 ${declaration.getName()} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
         sourceFile,
         declaration,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+
+  for (const parameter of sourceFile.getDescendantsOfKind(SyntaxKind.Parameter)) {
+    if (!parameter.getTypeNode() && parameter.getType().isAny()) {
+      diagnostics.push(makeDiagnostic(
+        "source-any",
+        "生产源码中的参数被推断为 any；请补充参数类型。",
+        sourceFile,
+        parameter,
         strict,
         rootDir,
       ));

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -97,6 +97,7 @@ function scanSourceFile(
 
   for (const node of sourceFile.getDescendants()) {
     if (Node.isAsExpression(node)) {
+      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
       const assertedType = node.getTypeNode()?.getText();
       if (assertedType === "const") continue;
       diagnostics.push(makeDiagnostic(
@@ -108,6 +109,7 @@ function scanSourceFile(
         rootDir,
       ));
     } else if (Node.isTypeAssertion(node)) {
+      if (Node.isAsExpression(node.getParent()) || Node.isTypeAssertion(node.getParent())) continue;
       diagnostics.push(makeDiagnostic(
         "source-type-assertion",
         `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
@@ -163,6 +165,7 @@ function scanSourceFile(
       ));
     }
   }
+
 }
 
 function isProductionSource(

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -1,0 +1,236 @@
+import { Node, Project, SyntaxKind, type SourceFile } from "ts-morph";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { relative, sep } from "node:path";
+import type { Diagnostic, TypeSafetyOptions } from "./types";
+
+const DEFAULT_EXCLUDES = [
+  "**/*.test.ts",
+  "**/*.spec.ts",
+  "**/__tests__/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/dist/**",
+  "**/*.d.ts",
+];
+
+const DIAGNOSTIC_META = {
+  "generated-any": { errorCode: "SC6001", docsUrl: "https://supacloud.dev/errors/SC6001" },
+  "source-any": { errorCode: "SC6002", docsUrl: "https://supacloud.dev/errors/SC6002" },
+  "source-type-assertion": { errorCode: "SC6003", docsUrl: "https://supacloud.dev/errors/SC6003" },
+  "source-non-null-assertion": { errorCode: "SC6004", docsUrl: "https://supacloud.dev/errors/SC6004" },
+  "source-implicit-widening": { errorCode: "SC6005", docsUrl: "https://supacloud.dev/errors/SC6005" },
+} as const;
+
+export interface TypeSafetyScanOptions extends TypeSafetyOptions {
+  rootDir: string;
+  include?: string[];
+  outDir?: string;
+  strict?: boolean;
+}
+
+export function scanGeneratedArtifacts(
+  artifacts: Record<string, string | undefined>,
+  strict = true,
+): Diagnostic[] {
+  const project = new Project({ useInMemoryFileSystem: true });
+  const diagnostics: Diagnostic[] = [];
+  for (const [file, content] of Object.entries(artifacts)) {
+    if (content === undefined) continue;
+    const sourceFile = project.createSourceFile(file, content, { overwrite: true });
+    for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+      diagnostics.push(makeDiagnostic(
+        "generated-any",
+        `生成产物 ${file} 包含 any；严格生成模式要求使用 unknown、具体接口或泛型约束。`,
+        file,
+        node,
+        strict,
+      ));
+    }
+  }
+  return diagnostics;
+}
+
+export function scanProductionSource(options: TypeSafetyScanOptions): Diagnostic[] {
+  const project = new Project({
+    ...(existsSync(join(options.rootDir, "tsconfig.json"))
+      ? { tsConfigFilePath: join(options.rootDir, "tsconfig.json") }
+      : {
+          compilerOptions: {
+            strict: true,
+            skipLibCheck: true,
+          },
+        }),
+    skipAddingFilesFromTsConfig: true,
+  });
+  const include = options.include ?? ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"];
+  project.addSourceFilesAtPaths(include.map((pattern) => `${options.rootDir}/${pattern}`));
+  const outDir = options.outDir ? normalizeRelative(options.rootDir, options.outDir) : undefined;
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.exclude ?? [])];
+  const sourceFiles = project
+    .getSourceFiles()
+    .filter((sourceFile) => isProductionSource(options.rootDir, sourceFile, excludes, outDir));
+
+  const diagnostics: Diagnostic[] = [];
+  for (const sourceFile of sourceFiles) {
+    scanSourceFile(sourceFile, options.rootDir, diagnostics, options.strict ?? false);
+  }
+  return diagnostics;
+}
+
+function scanSourceFile(
+  sourceFile: SourceFile,
+  rootDir: string,
+  diagnostics: Diagnostic[],
+  strict: boolean,
+): void {
+  for (const node of sourceFile.getDescendantsOfKind(SyntaxKind.AnyKeyword)) {
+    diagnostics.push(makeDiagnostic(
+      "source-any",
+      "生产源码使用了显式 any；请改用 unknown、具体接口或泛型约束。",
+      sourceFile,
+      node,
+      strict,
+      rootDir,
+    ));
+  }
+
+  for (const node of sourceFile.getDescendants()) {
+    if (Node.isAsExpression(node)) {
+      const assertedType = node.getTypeNode()?.getText();
+      if (assertedType === "const") continue;
+      diagnostics.push(makeDiagnostic(
+        "source-type-assertion",
+        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    } else if (Node.isTypeAssertion(node)) {
+      diagnostics.push(makeDiagnostic(
+        "source-type-assertion",
+        `生产源码包含类型断言 ${node.getText()}；请优先使用类型守卫、satisfies 或显式边界解析。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    } else if (Node.isNonNullExpression(node)) {
+      diagnostics.push(makeDiagnostic(
+        "source-non-null-assertion",
+        `生产源码包含非空断言 ${node.getText()}；请显式处理 null/undefined。`,
+        sourceFile,
+        node,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+
+  for (const declaration of sourceFile.getVariableDeclarations()) {
+    const initializer = declaration.getInitializer();
+    if (!initializer || declaration.getTypeNode()) continue;
+    const declarationType = declaration.getType();
+    const initializerType = initializer.getType();
+    if (declaration.getVariableStatement()?.getDeclarationKind() === "let"
+      && isLiteralSyntax(initializer)
+      && !declarationType.isLiteral()) {
+      diagnostics.push(makeDiagnostic(
+        "source-implicit-widening",
+        `变量 ${declaration.getName()} 的字面量类型从 ${initializerType.getText()} 隐式宽化为 ${declarationType.getText()}；请补充类型或使用 const。`,
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+    }
+    if (Node.isObjectLiteralExpression(initializer)
+      && declaration.getVariableStatement()?.getDeclarationKind() === "const"
+      && initializer.getText().length > 0
+      && initializer.getProperties().some((property) => {
+        return Node.isPropertyAssignment(property)
+          && property.getInitializer()?.getKind() !== SyntaxKind.AsExpression
+          && isLiteralExpression(property.getInitializer());
+      })) {
+      diagnostics.push(makeDiagnostic(
+        "source-implicit-widening",
+        `常量对象 ${declaration.getName()} 的字面量属性会隐式宽化；请补充对象类型或使用 as const。`,
+        sourceFile,
+        declaration,
+        strict,
+        rootDir,
+      ));
+    }
+  }
+}
+
+function isProductionSource(
+  rootDir: string,
+  sourceFile: SourceFile,
+  excludes: string[],
+  outDir?: string,
+): boolean {
+  const relativePath = normalizeRelative(rootDir, sourceFile.getFilePath());
+  if (relativePath.startsWith("../") || relativePath.includes("node_modules/")) return false;
+  if (outDir && (relativePath === outDir || relativePath.startsWith(`${outDir}/`))) return false;
+  return !excludes.some((pattern) => globMatches(relativePath, pattern));
+}
+
+function globMatches(value: string, pattern: string): boolean {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "§§")
+    .replace(/\*/g, "[^/]*")
+    .replace(/§§/g, ".*")
+    .replace(/\?/g, "[^/]");
+  const optionalRoot = escaped.startsWith(".*\\/") ? "(?:.*\\/)?"
+    : escaped;
+  return new RegExp(`^${optionalRoot === escaped ? escaped : optionalRoot + escaped.slice(3)}$`).test(value);
+}
+
+function isLiteralExpression(node: Node | undefined): boolean {
+  if (!node) return false;
+  return [
+    SyntaxKind.StringLiteral,
+    SyntaxKind.NumericLiteral,
+    SyntaxKind.TrueKeyword,
+    SyntaxKind.FalseKeyword,
+  ].includes(node.getKind());
+}
+
+function isLiteralSyntax(node: Node): boolean {
+  return Node.isStringLiteral(node)
+    || Node.isNumericLiteral(node)
+    || node.getKind() === SyntaxKind.TrueKeyword
+    || node.getKind() === SyntaxKind.FalseKeyword;
+}
+
+function makeDiagnostic(
+  code: keyof typeof DIAGNOSTIC_META,
+  message: string,
+  fileOrSourceFile: string | SourceFile,
+  node: Node,
+  strict: boolean,
+  rootDir?: string,
+): Diagnostic {
+  const file = typeof fileOrSourceFile === "string"
+    ? fileOrSourceFile
+    : rootDir
+      ? normalizeRelative(rootDir, fileOrSourceFile.getFilePath())
+      : fileOrSourceFile.getFilePath();
+  const meta = DIAGNOSTIC_META[code];
+  return {
+    severity: strict ? "error" : "warn",
+    code,
+    message,
+    file,
+    line: node.getStartLineNumber(),
+    errorCode: meta.errorCode,
+    docsUrl: meta.docsUrl,
+  };
+}
+
+function normalizeRelative(rootDir: string, filePath: string): string {
+  return relative(rootDir, filePath).split(sep).join("/").replace(/^\.\//, "");
+}

--- a/packages/compiler/src/type-safety.ts
+++ b/packages/compiler/src/type-safety.ts
@@ -6,6 +6,8 @@ import type { Diagnostic, TypeSafetyOptions } from "./types";
 const DEFAULT_EXCLUDES = [
   "**/*.test.ts",
   "**/*.spec.ts",
+  "**/test/**",
+  "**/tests/**",
   "**/__tests__/**",
   "**/fixtures/**",
   "**/generated/**",

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -11,6 +11,21 @@ export type ProviderKind = "class" | "value" | "factory" | "existing";
 
 export type TokenKind = "injection-token" | "class";
 
+export interface FunctionalInjectNode {
+  /** Logical token name used by the application graph. */
+  token: string;
+  /** Source expression used to identify the runtime token. */
+  expression: string;
+  /** Relative source module path for the token expression. */
+  importPath?: string;
+  /** Package module specifier for a library token. */
+  importModule?: string;
+  optional?: boolean;
+  self?: boolean;
+  skipSelf?: boolean;
+  host?: boolean;
+}
+
 export interface Diagnostic {
   severity: "error" | "warn";
   code: string;
@@ -45,6 +60,8 @@ export interface ProviderNode {
   skipSelfDeps?: string[];
   /** Parameter tokens marked @Host(). */
   hostDeps?: string[];
+  /** Property-level Angular functional inject() calls compiled into a static context. */
+  functionalInjects?: FunctionalInjectNode[];
   /** When true, multiple providers can contribute to this token as an array of instances (Angular multi-providers). */
   multi?: boolean;
   /** Automatically provided in the root injector context without manual module declaration (Angular-style). */
@@ -56,6 +73,8 @@ export interface ProviderNode {
   line: number;
   /** Relative module path of useClass/useFactory/useValue symbol (for import generation). */
   importPath?: string;
+  /** Package module specifier for providers supplied by a library. */
+  importModule?: string;
 }
 
 export interface HandlerParamNode {
@@ -123,6 +142,10 @@ export interface ControllerNode {
   optionalDeps?: string[];
   selfDeps?: string[];
   skipSelfDeps?: string[];
+  /** Parameter tokens marked @Host(). */
+  hostDeps?: string[];
+  /** Property-level Angular functional inject() calls compiled into a static context. */
+  functionalInjects?: FunctionalInjectNode[];
   /** Automatically registered without manual module declaration (Angular standalone controller style). */
   standalone?: boolean;
   routes: RouteNode[];

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -3,7 +3,7 @@
  * No runtime reflection or container; all metadata is explicitly represented here and in generated code.
  */
 
-import type { Project } from "ts-morph";
+import type { IncrementalProgramSession } from "./program";
 
 export type Scope = "application" | "request" | "job";
 
@@ -117,6 +117,8 @@ export interface ControllerNode {
   path: string;
   scope: Scope;
   deps: string[];
+  /** Class implements OnDestroy interface or onDestroy method. */
+  hasOnDestroy?: boolean;
   /** Parameter tokens marked @Optional(). */
   optionalDeps?: string[];
   selfDeps?: string[];
@@ -217,6 +219,11 @@ export interface CompileOptions {
   treeShakeUnusedProviders?: boolean;
   /** Incremental dependency graph cache. */
   cache?: DependencyGraphCache;
+  /**
+   * Changed source paths supplied by the watch/incremental driver.
+   * This is an implementation hint and does not change the public graph shape.
+   */
+  changedPaths?: string[];
   /** Type-safety gates for generated artifacts and production source. */
   typeSafety?: TypeSafetyOptions;
 }
@@ -346,10 +353,12 @@ export interface DependencyGraphCache {
   modules: Map<string, CachedModuleEntry>;
   /** Global file hashes by relative file path. */
   fileHashes: Map<string, string>;
-  /** Retained AST project for true incremental graph re-analysis. */
-  project?: Project;
+  /** Retained native TypeScript BuilderProgram session. */
+  programSession?: IncrementalProgramSession;
   /** Retained module dependency graph tracking imports and reverse dependents. */
   dependencyGraph?: DependencyGraphIndex;
+  /** Content hashes for generated artifacts, used by the incremental emitter. */
+  generatedHashes?: Map<string, string>;
   lastStats?: {
     reusedModules: string[];
     reanalyzedModules: string[];

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -3,6 +3,8 @@
  * No runtime reflection or container; all metadata is explicitly represented here and in generated code.
  */
 
+import type { Project } from "ts-morph";
+
 export type Scope = "application" | "request" | "job";
 
 export type ProviderKind = "class" | "value" | "factory" | "existing";
@@ -215,6 +217,17 @@ export interface CompileOptions {
   treeShakeUnusedProviders?: boolean;
   /** Incremental dependency graph cache. */
   cache?: DependencyGraphCache;
+  /** Type-safety gates for generated artifacts and production source. */
+  typeSafety?: TypeSafetyOptions;
+}
+
+export interface TypeSafetyOptions {
+  /** Reject the `any` keyword in generated TypeScript artifacts. */
+  noAnyInGenerated?: boolean;
+  /** Scan non-test production source for unsafe type escapes and widening. */
+  scanProductionSource?: boolean;
+  /** Additional relative glob patterns excluded from the production-source scan. */
+  exclude?: string[];
 }
 
 export interface ModuleBoundaryRule {
@@ -334,11 +347,15 @@ export interface DependencyGraphCache {
   /** Global file hashes by relative file path. */
   fileHashes: Map<string, string>;
   /** Retained AST project for true incremental graph re-analysis. */
-  project?: any;
+  project?: Project;
   /** Retained module dependency graph tracking imports and reverse dependents. */
-  dependencyGraph?: any;
+  dependencyGraph?: DependencyGraphIndex;
   lastStats?: {
     reusedModules: string[];
     reanalyzedModules: string[];
   };
+}
+
+export interface DependencyGraphIndex {
+  getAffectedModules(changedFiles: string[]): string[];
 }

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -22,7 +22,7 @@ export function camelName(token: string): string {
 export function relativeImportPath(fromDir: string, toFile: string): string {
   const fromParts = fromDir.split("/").filter(Boolean);
   const toParts = toFile.split("/").filter(Boolean);
-  let common = 0;
+  let common: number = 0;
   while (
     common < fromParts.length &&
     common < toParts.length &&

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -381,7 +381,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
     };
 
     const diags = validateGraph(sampleGraph, {
-      moduleBoundaryPreset: "non-existent-preset" as any,
+      moduleBoundaryPreset: "non-existent-preset" as never,
     });
 
     const errors = diags.filter((d) => d.code === "invalid-boundary-preset");

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -57,6 +57,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "missing-param-colon": { code: "SC3019", docsUrl: "https://supacloud.dev/errors/SC3019" },
   "missing-token-factory": { code: "SC2009", docsUrl: "https://supacloud.dev/errors/SC2009" },
   "provider-type-mismatch": { code: "SC2010", docsUrl: "https://supacloud.dev/errors/SC2010" },
+  "unsupported-provider-helper": { code: "SC2011", docsUrl: "https://supacloud.dev/errors/SC2011" },
   "command-missing-permission": { code: "SC4001", docsUrl: "https://supacloud.dev/errors/SC4001" },
   "duplicate-command": { code: "SC4002", docsUrl: "https://supacloud.dev/errors/SC4002" },
   "route-command-unresolved": { code: "SC4003", docsUrl: "https://supacloud.dev/errors/SC4003" },
@@ -113,10 +114,17 @@ export function validateGraph(
     }
   }
 
-  /** Resolves dep token in module visibility scope: own providers > imported module exports. */
-  function resolveDep(module: ModuleNode, token: string): ProviderRef | undefined {
-    const own = module.providers.find((p) => p.token === token);
-    if (own) return { module, provider: own };
+  /** Resolves a token using the static equivalent of the current injector level. */
+  function resolveDep(
+    module: ModuleNode,
+    token: string,
+    flags: { self?: boolean; skipSelf?: boolean } = {},
+  ): ProviderRef | undefined {
+    if (!flags.skipSelf) {
+      const own = module.providers.find((p) => p.token === token);
+      if (own) return { module, provider: own };
+    }
+    if (flags.self) return undefined;
     for (const importName of module.imports) {
       const imported = graph.modules.find((m) => m.name === importName);
       if (!imported || !imported.exports.includes(token)) continue;
@@ -522,7 +530,9 @@ export function validateGraph(
 
       if (controller.selfDeps && controller.selfDeps.length > 0) {
         for (const dep of controller.selfDeps) {
-          const own = module.providers.find((p) => p.token === dep);
+          const own = module.providers.find((p) =>
+            p.token === dep && p.scope === controller.scope,
+          );
           if (!own) {
             error(
               "self-resolution-failed",
@@ -536,7 +546,9 @@ export function validateGraph(
       }
       if (controller.skipSelfDeps && controller.skipSelfDeps.length > 0) {
         for (const dep of controller.skipSelfDeps) {
-          const own = module.providers.find((p) => p.token === dep);
+          const own = module.providers.find((p) =>
+            p.token === dep && p.scope === controller.scope,
+          );
           if (own) {
             error(
               "skip-self-resolution-failed",
@@ -641,7 +653,9 @@ export function validateGraph(
     for (const provider of module.providers) {
       if (provider.selfDeps && provider.selfDeps.length > 0) {
         for (const dep of provider.selfDeps) {
-          const own = module.providers.find((p) => p.token === dep);
+          const own = module.providers.find((p) =>
+            p.token === dep && p.scope === provider.scope,
+          );
           if (!own) {
             error(
               "self-resolution-failed",
@@ -655,7 +669,9 @@ export function validateGraph(
       }
       if (provider.skipSelfDeps && provider.skipSelfDeps.length > 0) {
         for (const dep of provider.skipSelfDeps) {
-          const own = module.providers.find((p) => p.token === dep);
+          const own = module.providers.find((p) =>
+            p.token === dep && p.scope === provider.scope,
+          );
           if (own) {
             error(
               "skip-self-resolution-failed",
@@ -669,7 +685,10 @@ export function validateGraph(
       }
       for (const dep of provider.deps) {
         const isOptional = provider.optionalDeps?.includes(dep);
-        const resolved = resolveDep(module, dep);
+        const resolved = resolveDep(module, dep, {
+          self: provider.selfDeps?.includes(dep),
+          skipSelf: provider.skipSelfDeps?.includes(dep),
+        });
         if (!resolved) {
           if (isOptional) {
             continue;
@@ -832,12 +851,14 @@ export function validateGraph(
       for (const d of ctrl.optionalDeps ?? []) referencedTokens.add(d);
       for (const d of ctrl.selfDeps ?? []) referencedTokens.add(d);
       for (const d of ctrl.skipSelfDeps ?? []) referencedTokens.add(d);
+      for (const d of ctrl.hostDeps ?? []) referencedTokens.add(d);
     }
     for (const p of mod.providers) {
       for (const d of p.deps ?? []) referencedTokens.add(d);
       for (const d of p.optionalDeps ?? []) referencedTokens.add(d);
       for (const d of p.selfDeps ?? []) referencedTokens.add(d);
       for (const d of p.skipSelfDeps ?? []) referencedTokens.add(d);
+      for (const d of p.hostDeps ?? []) referencedTokens.add(d);
       if (p.useExisting) referencedTokens.add(p.useExisting);
     }
   }
@@ -967,7 +988,11 @@ function routeMatchesTarget(routePattern: string, targetPath: string): boolean {
 /** Provider-level circular dependency detection (DFS, reporting cycle path). */
 function detectCycles(
   graph: ApplicationGraph,
-  resolveDep: (module: ModuleNode, token: string) => ProviderRef | undefined,
+  resolveDep: (
+    module: ModuleNode,
+    token: string,
+    flags?: { self?: boolean; skipSelf?: boolean },
+  ) => ProviderRef | undefined,
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   const nodeId = (ref: ProviderRef) => `${ref.module.name}:${ref.provider.token}`;
@@ -1009,7 +1034,10 @@ function detectCycles(
     state.set(id, "visiting");
     stack.push(ref);
     for (const dep of ref.provider.deps) {
-      const resolved = resolveDep(ref.module, dep);
+      const resolved = resolveDep(ref.module, dep, {
+        self: ref.provider.selfDeps?.includes(dep),
+        skipSelf: ref.provider.skipSelfDeps?.includes(dep),
+      });
       if (resolved) visit(resolved);
     }
     stack.pop();

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -56,6 +56,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "conflicting-route-method": { code: "SC3018", docsUrl: "https://supacloud.dev/errors/SC3018" },
   "missing-param-colon": { code: "SC3019", docsUrl: "https://supacloud.dev/errors/SC3019" },
   "missing-token-factory": { code: "SC2009", docsUrl: "https://supacloud.dev/errors/SC2009" },
+  "provider-type-mismatch": { code: "SC2010", docsUrl: "https://supacloud.dev/errors/SC2010" },
   "command-missing-permission": { code: "SC4001", docsUrl: "https://supacloud.dev/errors/SC4001" },
   "duplicate-command": { code: "SC4002", docsUrl: "https://supacloud.dev/errors/SC4002" },
   "route-command-unresolved": { code: "SC4003", docsUrl: "https://supacloud.dev/errors/SC4003" },
@@ -675,7 +676,8 @@ export function validateGraph(
           }
           if (!graph.externalTokens.includes(dep)) {
             if (globalProviders.has(dep)) {
-              const owner = globalProviders.get(dep)!;
+              const owner = globalProviders.get(dep);
+              if (!owner) continue;
               error(
                 "module-boundary",
                 `模块 ${module.name} 的 provider ${provider.token} 依赖 ${dep}，该 token 由模块 ${owner.module.name} 提供但未被 import`,
@@ -805,7 +807,8 @@ export function validateGraph(
           }
 
           if (rule.onlyDependOnLibsWithTags && rule.onlyDependOnLibsWithTags.length > 0) {
-            const hasAllowed = targetTags.some((t) => rule.onlyDependOnLibsWithTags!.includes(t));
+            const allowedTags = rule.onlyDependOnLibsWithTags;
+            const hasAllowed = targetTags.some((t) => allowedTags.includes(t));
             if (!hasAllowed && targetTags.length > 0) {
               error(
                 "module-boundary-violation",
@@ -932,8 +935,8 @@ function isRouteShadowed(earlierPath: string, laterPath: string): boolean {
     return false;
   }
 
-  let hasParamShadowing = false;
-  for (let i = 0; i < earlierSegments.length; i += 1) {
+  let hasParamShadowing: boolean = false;
+  for (let i: number = 0; i < earlierSegments.length; i += 1) {
     const e = earlierSegments[i];
     const l = laterSegments[i];
 
@@ -954,7 +957,7 @@ function routeMatchesTarget(routePattern: string, targetPath: string): boolean {
   const pSegs = routePattern.split("/").filter(Boolean);
   const tSegs = targetPath.split("/").filter(Boolean);
   if (pSegs.length !== tSegs.length) return false;
-  for (let i = 0; i < pSegs.length; i += 1) {
+  for (let i: number = 0; i < pSegs.length; i += 1) {
     if (pSegs[i].startsWith(":")) continue;
     if (pSegs[i] !== tSegs[i]) return false;
   }
@@ -1139,7 +1142,8 @@ function detectOrphanModules(graph: ApplicationGraph): Diagnostic[] {
   }
 
   while (queue.length > 0) {
-    const current = queue.shift()!;
+      const current = queue.shift();
+      if (!current) continue;
     const mod = moduleMap.get(current);
     if (!mod) continue;
     for (const imp of mod.imports) {

--- a/packages/compiler/src/watch.ts
+++ b/packages/compiler/src/watch.ts
@@ -11,15 +11,15 @@ export function watchProject(options: WatchOptions): WatchHandle {
   const outDir = resolve(options.outDir);
   const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let closed = false;
-  let compiling = false;
-  let pending = false;
+  let closed: boolean = false;
+  let compiling: boolean = false;
+  let pending: boolean = false;
   const pendingPaths = new Set<string>();
   let watcher: ReturnType<typeof watch> | undefined;
   const incremental = createIncrementalCompiler();
   let initialEvent: WatchEvent | undefined;
-  let resolveReady!: (event: WatchEvent) => void;
-  let rejectReady!: (error: unknown) => void;
+  let resolveReady: (event: WatchEvent) => void = () => undefined;
+  let rejectReady: (error: unknown) => void = () => undefined;
 
   const ready = new Promise<WatchEvent>((resolvePromise, rejectPromise) => {
     resolveReady = resolvePromise;

--- a/packages/db/src/access.ts
+++ b/packages/db/src/access.ts
@@ -95,7 +95,7 @@ export function createDatabaseAccessBoundary<UserClient, ServiceClient = never>(
           "Service-role database access is not configured",
         );
       }
-      serviceClient ??= Promise.resolve(options.createServiceClient()).catch((error) => {
+      serviceClient ??= Promise.resolve(options.createServiceClient()).catch((error: unknown) => {
         serviceClient = undefined;
         throw error;
       });

--- a/packages/db/src/lint.ts
+++ b/packages/db/src/lint.ts
@@ -21,8 +21,8 @@ const CREATE_POLICY_RE = /\bcreate\s+policy\b/i;
 const DROP_POLICY_IF_EXISTS_RE = /\bdrop\s+policy\s+if\s+exists\b/i;
 
 function lineOf(sql: string, index: number): number {
-  let line = 1;
-  for (let i = 0; i < index; i += 1) {
+  let line: number = 1;
+  for (let i: number = 0; i < index; i += 1) {
     if (sql.charCodeAt(i) === 10) line += 1;
   }
   return line;

--- a/packages/edge-runtime/bun.lock
+++ b/packages/edge-runtime/bun.lock
@@ -7,10 +7,10 @@
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@sinclair/typebox": "^0.34.52",
-        "@supabase/supabase-js": "^2.114.0",
+        "@supabase/supabase-js": "^2.115.0",
         "elysia": "^1.4.30",
         "es-module-lexer": "2.3.2",
-        "jose": "^6.2.10",
+        "jose": "^6.2.11",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -26,19 +26,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.115.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.115.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.115.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.115.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.115.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.115.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.115.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.115.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.115.0.tgz", { "dependencies": { "@supabase/auth-js": "2.115.0", "@supabase/functions-js": "2.115.0", "@supabase/postgrest-js": "2.115.0", "@supabase/realtime-js": "2.115.0", "@supabase/storage-js": "2.115.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-PYJSxtCo37R7tTZW6pAqsxUeSx/dlhA7zn8RzKEUSCqyTxCUhG+iHrDTb04UyVBYbttaUbhwkNTvb8h5HW+uZA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -108,7 +108,7 @@
 
     "ieee754": ["ieee754@1.2.1", "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "jose": ["jose@6.2.10", "https://registry.npmmirror.com/jose/-/jose-6.2.10.tgz", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
+    "jose": ["jose@6.2.11", "https://registry.npmmirror.com/jose/-/jose-6.2.11.tgz", {}, "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg=="],
 
     "memoirist": ["memoirist@0.4.0", "https://registry.npmmirror.com/memoirist/-/memoirist-0.4.0.tgz", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
 

--- a/packages/edge-runtime/deno-compat.ts
+++ b/packages/edge-runtime/deno-compat.ts
@@ -107,7 +107,7 @@ const DISABLED_BUN_HOST_CAPABILITIES = [
   "udpSocket",
 ];
 
-let projectRootControlInitialized = false;
+let projectRootControlInitialized: boolean = false;
 
 export function initializeProjectRootControl(): (root: string | null) => void {
   if (projectRootControlInitialized) {

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.2",
     "@sinclair/typebox": "^0.34.52",
-    "@supabase/supabase-js": "^2.114.0",
+    "@supabase/supabase-js": "^2.115.0",
     "elysia": "^1.4.30",
     "es-module-lexer": "2.3.2",
-    "jose": "^6.2.10"
+    "jose": "^6.2.11"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -310,8 +310,8 @@ if (!process.env.EDGE_RUNTIME_VERSION) {
   process.env.EDGE_RUNTIME_VERSION = "1.58.3";
 }
 
-let shuttingDown = false;
-let workerRecycleScheduled = false;
+let shuttingDown: boolean = false;
+let workerRecycleScheduled: boolean = false;
 
 function requestRuntimeRecycle(): void {
   if (workerRecycleScheduled || shuttingDown) return;
@@ -682,7 +682,7 @@ async function appendFunctionRuntimeLog(
         execution_id: context.executionId,
         background: context.background,
       },
-    };
+    } as const;
     await fs.appendFile(logFile, `${JSON.stringify(payload)}\n`, "utf8");
   } catch (error) {
     console.warn(

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -116,7 +116,7 @@ const moduleCache = new Map<string, ModuleCacheEntry>();
 
 function evictOldestModule() {
   while (moduleCache.size >= MAX_MODULE_CACHE) {
-    let oldestKey = "";
+    let oldestKey: string = "";
     let oldestTime = Infinity;
     for (const [key, entry] of moduleCache) {
       if (entry.lastUsed < oldestTime) {
@@ -160,7 +160,7 @@ function buildModuleImportUrl(identity: ModuleIdentity): string {
 }
 
 function invalidateCachedModules(predicate: (entry: ModuleCacheEntry) => boolean): number {
-  let invalidated = 0;
+  let invalidated: number = 0;
   for (const [key, entry] of moduleCache) {
     if (predicate(entry)) {
       moduleCache.delete(key);
@@ -252,7 +252,7 @@ function isDynamicImportLiteral(source: string, start: number, end: number): boo
     return false;
   }
 
-  for (let index = 1; index < expression.length; index++) {
+  for (let index: number = 1; index < expression.length; index++) {
     const character = expression[index];
     if (character === "\\") {
       index++;
@@ -341,11 +341,11 @@ async function assertTenantModuleGraphSafe(
 const originalProcessEnv = process.env;
 const bunRuntime = (globalThis as unknown as { Bun?: { env: Record<string, string | undefined> } }).Bun;
 const originalBunEnv = bunRuntime ? { ...bunRuntime.env } : null;
-let envSnapshotActive = false;
+let envSnapshotActive: boolean = false;
 let currentAbortController: AbortController | null = null;
 let currentInjectedEnv: Record<string, string> = {};
 let currentWaitUntilTasks: Promise<unknown>[] = [];
-let retiring = false;
+let retiring: boolean = false;
 
 async function resolveMessageTlsPolicy(
   tlsPolicy: EdgeFetchTlsPolicy | undefined,
@@ -819,7 +819,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
 
           try {
             const reader = response.body.getReader();
-            let responseBytes = 0;
+            let responseBytes: number = 0;
             while (true) {
               const { done, value } = await reader.read();
               if (done) {

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -355,7 +355,7 @@ export class WorkerPool {
     this.maxWorkerReplacementsBeforeRecycle = config.maxWorkerReplacementsBeforeRecycle
       ?? DEFAULT_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE;
     this.onWorkerRecycleRequired = config.onWorkerRecycleRequired ?? (() => process.exit(1));
-    for (let i = 0; i < config.size; i++) {
+    for (let i: number = 0; i < config.size; i++) {
       const w = this.createWorker();
       this.idle.push(w);
       this.activeWorkers.add(w);
@@ -552,9 +552,9 @@ export class WorkerPool {
     this.totalQueueWaitMs += queueWaitMs;
     const cancelGraceMs = 3_000;
 
-    let resolved = false;
-    let executionStarted = false;
-    let cancellationRequested = false;
+    let resolved: boolean = false;
+    let executionStarted: boolean = false;
+    let cancellationRequested: boolean = false;
     const resolveOnce = (response: Response) => {
       if (resolved) return;
       resolved = true;
@@ -790,7 +790,7 @@ export class WorkerPool {
       }
       if (msg.type === "stream_start" && msg.streamId) {
         const streamId = msg.streamId;
-        let streamFinished = false;
+        let streamFinished: boolean = false;
         let streamListener: ((streamMsg: any) => void) | undefined;
         const clearStreamState = () => {
           streamFinished = true;

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -10,6 +10,8 @@ Runtime adapter that turns `@supacloud/compiler` output into a production-ready
   passing exported services downstream via Elysia plugins.
 - **Request-scoped providers**: creates a fresh scope per HTTP request via
   `createRequestScope`, mapping request-scoped controllers and services.
+- **Request-scope teardown**: invokes the compiler-generated
+  `destroyRequestScope` after the response, including when the handler fails.
 - **TypeBox schema binding**: attaches compiled parameter, query, body, and
   response TypeBox schemas directly to Elysia route definitions.
 - **Unified Command Pipeline**: runs `@Command`-decorated handlers through a

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -425,6 +425,10 @@ describe("SupaCloud request context", () => {
     expect(context.identity.accessToken).toBe("signed-token");
     expect(context.idempotencyKey).toBe("idem-1");
     expect(JSON.stringify(context.identity)).not.toContain("signed-token");
+
+    const identity = requireTrustedIdentity(context);
+    expect(identity.subject).toBe("user-42");
+    expect(Object.keys(identity)).not.toContain("accessToken");
   });
 
   test("requires both verified identity and bearer credentials", async () => {

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -32,6 +32,7 @@ interface Captured {
   auditService?: AuditService;
   caseImported?: Record<string, Record<string, unknown>>;
   caseDeps?: Record<string, unknown>;
+  requestScopeDestroyed?: number;
 }
 
 function createAuditModule(captured: Captured): CompiledModule {
@@ -96,6 +97,9 @@ function createCaseModule(captured: Captured): CompiledModule {
           requestId,
         ),
       };
+    },
+    destroyRequestScope: async () => {
+      captured.requestScopeDestroyed = (captured.requestScopeDestroyed ?? 0) + 1;
     },
     controllers: [
       {
@@ -494,6 +498,8 @@ describe("createModulePlugin", () => {
       requestId: "req-standalone",
     });
     expect(captured.auditService?.entries).toEqual(["case.get:9"]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(captured.requestScopeDestroyed).toBe(1);
   });
 });
 

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -423,7 +423,7 @@ export function createModulePlugin(
   ctxFactory: RequestContextFactory = defaultRequestContext,
   options: Pick<ApplicationOptions, "commandGovernance" | "commandExecutor" | "errorMapper"> = {},
   imported: Record<string, Record<string, unknown>> = {},
-) {
+): Elysia {
   const hasCommandRoutes = compiled.controllers.some((controller) =>
     controller.routes.some((route) => route.command !== undefined),
   );
@@ -572,7 +572,7 @@ export function createModulePlugin(
     return mapped ?? defaultErrorResponse(error, code);
   });
 
-  return plugin;
+  return plugin as unknown as Elysia;
 }
 
 export function defaultErrorResponse(

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -211,6 +211,33 @@ function safeHeaderValue(value: string | null, maxLength: number): string | unde
   return value;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isTrustedIdentity(value: unknown): value is TrustedRequestIdentity {
+  return isRecord(value)
+    && typeof value.authenticated === "boolean"
+    && (value.subject === undefined || typeof value.subject === "string")
+    && (value.accessToken === undefined || typeof value.accessToken === "string");
+}
+
+type AuthenticatedTrustedIdentity = TrustedRequestIdentity & {
+  authenticated: true;
+  subject: string;
+  accessToken: string;
+};
+
+function isAuthenticatedTrustedIdentity(
+  value: TrustedRequestIdentity | undefined,
+): value is AuthenticatedTrustedIdentity {
+  return value?.authenticated === true
+    && typeof value.subject === "string"
+    && value.subject.length > 0
+    && typeof value.accessToken === "string"
+    && value.accessToken.length > 0;
+}
+
 function bearerToken(request: Request): string | undefined {
   const authorization = request.headers.get("authorization");
   const match = authorization?.match(/^Bearer\s+(.+)$/i);
@@ -290,14 +317,21 @@ export function createCommandExecutor(
 ): CommandExecutor {
   return async (invocation, next) => {
     const { command } = invocation;
+    const audit = command.audit ? governance.audit : undefined;
+    const transaction = command.transaction === "required"
+      ? governance.transaction
+      : undefined;
+    const idempotency = command.idempotency === "required"
+      ? governance.idempotency
+      : undefined;
 
-    if (command.audit && !governance.audit) {
+    if (command.audit && !audit) {
       throw missingGovernanceAdapter(command, "audit");
     }
-    if (command.transaction === "required" && !governance.transaction) {
+    if (command.transaction === "required" && !transaction) {
       throw missingGovernanceAdapter(command, "transaction");
     }
-    if (command.idempotency === "required" && !governance.idempotency) {
+    if (command.idempotency === "required" && !idempotency) {
       throw missingGovernanceAdapter(command, "idempotency");
     }
 
@@ -305,20 +339,22 @@ export function createCommandExecutor(
       await governance.authorize(invocation);
       let execute = async () => {
         const result = await next();
-        if (command.audit) await governance.audit!.succeeded(invocation, result);
+        if (audit) await audit.succeeded.call(audit, invocation, result);
         return result;
       };
       if (command.transaction === "required") {
+        if (!transaction) throw missingGovernanceAdapter(command, "transaction");
         const inner = execute;
-        execute = () => Promise.resolve(governance.transaction!(invocation, inner));
+        execute = () => Promise.resolve(transaction.call(governance, invocation, inner));
       }
       if (command.idempotency === "required") {
+        if (!idempotency) throw missingGovernanceAdapter(command, "idempotency");
         const inner = execute;
-        execute = () => Promise.resolve(governance.idempotency!(invocation, inner));
+        execute = () => Promise.resolve(idempotency.call(governance, invocation, inner));
       }
       return await execute();
     } catch (error) {
-      if (command.audit) await governance.audit!.failed(invocation, error);
+      if (audit) await audit.failed.call(audit, invocation, error);
       throw error;
     }
   };
@@ -328,21 +364,20 @@ export function requireTrustedIdentity(
   requestContext: unknown,
 ): Required<Pick<TrustedRequestIdentity, "subject" | "accessToken">>
   & TrustedRequestIdentity {
-  const context = requestContext as Partial<SupaCloudRequestContext> | null;
-  const identity = context?.identity;
-  if (!identity?.authenticated || !identity.subject || !identity.accessToken) {
+  const context = isRecord(requestContext) ? requestContext : {};
+  const identity = isTrustedIdentity(context.identity) ? context.identity : undefined;
+  if (!isAuthenticatedTrustedIdentity(identity)) {
     throw new ApplicationError("Authenticated user context is required", {
       status: 401,
       code: "AUTHENTICATION_REQUIRED",
     });
   }
-  return identity as Required<Pick<TrustedRequestIdentity, "subject" | "accessToken">>
-    & TrustedRequestIdentity;
+  return identity;
 }
 
 export function requireIdempotencyKey(invocation: CommandInvocation): string {
-  const context = invocation.requestContext as Partial<SupaCloudRequestContext> | null;
-  const key = context?.idempotencyKey
+  const context = isRecord(invocation.requestContext) ? invocation.requestContext : {};
+  const key = (typeof context.idempotencyKey === "string" ? context.idempotencyKey : undefined)
     ?? safeHeaderValue(invocation.request.headers.get(IDEMPOTENCY_KEY_HEADER), 512);
   if (!key) {
     throw new ApplicationError("Idempotency-Key header is required", {
@@ -368,16 +403,11 @@ interface HttpContext {
   requestContext?: unknown;
 }
 
-type ControllerInstance = Record<
-  string,
-  (input: {
-    body: unknown;
-    params: Record<string, string>;
-    query: Record<string, unknown>;
-    request: Request;
-    scope?: Record<string, unknown>;
-  }) => unknown
->;
+type ControllerInstance = Record<string, unknown>;
+
+function controllerInstance(value: unknown): ControllerInstance | undefined {
+  return isRecord(value) ? value : undefined;
+}
 
 /**
  * Adapt a single compiled module into an Elysia plugin.
@@ -393,7 +423,7 @@ export function createModulePlugin(
   ctxFactory: RequestContextFactory = defaultRequestContext,
   options: Pick<ApplicationOptions, "commandGovernance" | "commandExecutor" | "errorMapper"> = {},
   imported: Record<string, Record<string, unknown>> = {},
-): Elysia {
+) {
   const hasCommandRoutes = compiled.controllers.some((controller) =>
     controller.routes.some((route) => route.command !== undefined),
   );
@@ -466,9 +496,7 @@ export function createModulePlugin(
         if (requestScope && compiled.destroyRequestScope) requestScopes.set(ctx.request, requestScope);
         const source =
           controller.scope === "request" ? requestScope : services;
-        const instance = source?.[controller.serviceKey] as
-          | ControllerInstance
-          | undefined;
+        const instance = controllerInstance(source?.[controller.serviceKey]);
         const method = instance?.[route.handler];
         if (typeof method !== "function") {
           throw new Error(
@@ -483,10 +511,15 @@ export function createModulePlugin(
           scope: requestScope,
           requestContext,
         };
-        const invoke = () => method.call(instance, input);
+        const invoke = () => Reflect.apply(method, instance, [input]);
         if (!route.command) return invoke();
 
-        const command = commandsByClassName.get(route.command)!;
+        const command = commandsByClassName.get(route.command);
+        if (!command) {
+          throw new ApplicationError(`Command "${route.command}" is not registered`, {
+            code: "COMMAND_NOT_REGISTERED",
+          });
+        }
         if (!commandExecutor) {
           throw new ApplicationError(`Command "${command.name}" has no executor`, {
             status: 501,
@@ -539,7 +572,7 @@ export function createModulePlugin(
     return mapped ?? defaultErrorResponse(error, code);
   });
 
-  return plugin as unknown as Elysia;
+  return plugin;
 }
 
 export function defaultErrorResponse(
@@ -569,15 +602,14 @@ export function defaultErrorResponse(
 }
 
 function isPublicApplicationError(error: unknown): error is PublicApplicationError {
-  if (!(error instanceof Error)) return false;
-  const candidate = error as Partial<PublicApplicationError>;
-  return candidate.expose === true
-    && typeof candidate.status === "number"
-    && Number.isInteger(candidate.status)
-    && candidate.status >= 400
-    && candidate.status <= 599
-    && typeof candidate.code === "string"
-    && candidate.code.length > 0;
+  if (!(error instanceof Error) || !isRecord(error)) return false;
+  return error.expose === true
+    && typeof error.status === "number"
+    && Number.isInteger(error.status)
+    && error.status >= 400
+    && error.status <= 599
+    && typeof error.code === "string"
+    && error.code.length > 0;
 }
 
 /**
@@ -610,7 +642,7 @@ export function createApplication(options: ApplicationOptions): Elysia {
     }, imported));
   }
 
-  return app as unknown as Elysia;
+  return app;
 }
 
 /** Semantic alias of createApplication for readable tests. */

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -47,6 +47,7 @@ export interface CompiledModule {
     ctx: unknown,
     imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
+  destroyRequestScope?(scope: Record<string, unknown>): Promise<void>;
   controllers: CompiledController[];
   commands?: CompiledCommand[];
 }
@@ -428,6 +429,20 @@ export function createModulePlugin(
   );
 
   const createRequestScope = compiled.createRequestScope;
+  const requestScopes = new WeakMap<Request, Record<string, unknown>>();
+  if (compiled.destroyRequestScope) {
+    const destroyRequestScope = compiled.destroyRequestScope;
+    plugin.onAfterResponse(async ({ request }) => {
+      const scope = requestScopes.get(request);
+      if (!scope) return;
+      requestScopes.delete(request);
+      try {
+        await destroyRequestScope(scope);
+      } catch (error) {
+        console.error(`supacloud: request scope cleanup failed for "${compiled.name}"`, error);
+      }
+    });
+  }
   plugin.resolve(async ({ request }) => {
     const requestContext = await ctxFactory(request);
     requestContexts.set(request, requestContext);
@@ -448,6 +463,7 @@ export function createModulePlugin(
         const requestScope = createRequestScope
           ? createRequestScope(services, requestContext, imported)
           : undefined;
+        if (requestScope && compiled.destroyRequestScope) requestScopes.set(ctx.request, requestScope);
         const source =
           controller.scope === "request" ? requestScope : services;
         const instance = source?.[controller.serviceKey] as

--- a/packages/management-api/bun.lock
+++ b/packages/management-api/bun.lock
@@ -12,11 +12,11 @@
         "acorn": "^8.18.0",
         "aws4fetch": "^1.0.20",
         "elysia": "^1.4.30",
-        "jose": "^6.2.10",
+        "jose": "^6.2.11",
         "nanoid": "^6.0.1",
       },
       "devDependencies": {
-        "@supabase/supabase-js": "^2.114.0",
+        "@supabase/supabase-js": "^2.115.0",
         "@types/bun": "^1.4.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -49,19 +49,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.115.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.115.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.115.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.115.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.115.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.115.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.115.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.115.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.115.0.tgz", { "dependencies": { "@supabase/auth-js": "2.115.0", "@supabase/functions-js": "2.115.0", "@supabase/postgrest-js": "2.115.0", "@supabase/realtime-js": "2.115.0", "@supabase/storage-js": "2.115.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-PYJSxtCo37R7tTZW6pAqsxUeSx/dlhA7zn8RzKEUSCqyTxCUhG+iHrDTb04UyVBYbttaUbhwkNTvb8h5HW+uZA=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -151,7 +151,7 @@
 
     "ieee754": ["ieee754@1.2.1", "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "jose": ["jose@6.2.10", "https://registry.npmmirror.com/jose/-/jose-6.2.10.tgz", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
+    "jose": ["jose@6.2.11", "https://registry.npmmirror.com/jose/-/jose-6.2.11.tgz", {}, "sha512-A5NPn7g8EAzGU3IzRs+Yiq8K5n3ypYS75M5+KKiVHdUexfpWK1kP4ZMq7QnTGDoMj6TJ1dtcEJjW60yZDXS4hg=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -39,11 +39,11 @@
     "acorn": "^8.18.0",
     "aws4fetch": "^1.0.20",
     "elysia": "^1.4.30",
-    "jose": "^6.2.10",
+    "jose": "^6.2.11",
     "nanoid": "^6.0.1"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "^2.114.0",
+    "@supabase/supabase-js": "^2.115.0",
     "@types/bun": "^1.4.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/management-api/src/routes/frontend.ts
+++ b/packages/management-api/src/routes/frontend.ts
@@ -14,6 +14,7 @@ import {
 import type { FrontendFramework } from "../types/frontend";
 import { FRAMEWORK_DEFAULTS } from "../types/frontend";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { maskFrontendBuildLog, toFrontendDeploymentResponse } from "../utils/frontend-security";
 
 const FRONTEND_UPLOAD_MAX_BYTES = Number(process.env.FRONTEND_UPLOAD_MAX_BYTES || 100 * 1024 * 1024);
 const FRONTEND_UPLOAD_MAX_FILES = Number(process.env.FRONTEND_UPLOAD_MAX_FILES || 10_000);
@@ -217,7 +218,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
     "/deployments",
     async ({ params }) => {
       const deployments = await frontendService.listDeployments(params.ref);
-      return { deployments };
+      return { deployments: deployments.map(toFrontendDeploymentResponse) };
     },
     {
       params: t.Object({
@@ -234,7 +235,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!deployment) {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -354,7 +355,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       });
 
       set.status = 201;
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -395,7 +396,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
                 return status(404, { message: "Deployment not found", code: "404" });
       }
 
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -613,7 +614,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!deployment) {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -634,7 +635,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!deployment) {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -659,7 +660,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!deployment) {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -752,7 +753,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!deployment) {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
-      return deployment;
+      return toFrontendDeploymentResponse(deployment);
     },
     {
       params: t.Object({
@@ -789,7 +790,14 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
     "/deployments/:id/deployment-records",
     async ({ params, set }) => {
       const records = await frontendService.listDeploymentRecords(params.ref, params.id);
-      return { records };
+      const deployment = await frontendService.getDeployment(params.ref, params.id);
+      const secrets = Object.values(deployment?.env_vars || {});
+      return {
+        records: records.map((record) => ({
+          ...record,
+          build_log: maskFrontendBuildLog(record.build_log, secrets),
+        })),
+      };
     },
     {
       params: t.Object({
@@ -807,7 +815,14 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
       if (!record) {
                 return status(404, { message: "Record not found", code: "404" });
       }
-      return record;
+      const deployment = await frontendService.getDeployment(params.ref, params.id);
+      return {
+        ...record,
+        build_log: maskFrontendBuildLog(
+          record.build_log,
+          Object.values(deployment?.env_vars || {}),
+        ),
+      };
     },
     {
       params: t.Object({

--- a/packages/management-api/src/routes/webhook.ts
+++ b/packages/management-api/src/routes/webhook.ts
@@ -2,15 +2,8 @@ import { Elysia, t, type Static, status } from "elysia";
 import { logger } from "../utils/logger";
 import { frontendService } from "../services/frontend.service";
 import type { FrontendDeployment } from "../types/frontend";
-import { timingSafeEqual } from "crypto";
+import { timingSafeEqual } from "node:crypto";
 import { processAutoBranchingFromPush } from "../services/auto-branching.service";
-
-function safeTokenEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, "utf8");
-  const bufB = Buffer.from(b, "utf8");
-  if (bufA.length !== bufB.length) return false;
-  return timingSafeEqual(bufA, bufB);
-}
 
 // Shared TypeBox schema for Git webhook payloads (GitHub/GitLab/Gitee/GitCode)
 const WebhookBodySchema = t.Object({
@@ -174,8 +167,12 @@ export const webhookRoutes = new Elysia({ prefix: "/v1/webhooks" })
           } else {
             const payloadStr = JSON.stringify(body);
             const safeSignature = signature || "";
-            for (const t of tokens) {
-              if (await verifyGitHubSignature(payloadStr, safeSignature, t.token)) {
+            const tokenSecrets = await frontendService.getDeployTokenSecrets(
+              deployment.project_ref,
+              deployment.id,
+            );
+            for (const token of tokenSecrets) {
+              if (await verifyGitHubSignature(payloadStr, safeSignature, token)) {
                 isValidSignature = true;
                 break;
               }
@@ -485,7 +482,11 @@ async function triggerDeployForGit(
         results.push({ deployment_id: deployment.id, project_ref: deployment.project_ref, success: false, error: "Missing webhook token" });
         continue;
       }
-      const isValid = deployment.deploy_tokens.some(t => safeTokenEqual(t.token, token!));
+      const isValid = await frontendService.verifyDeployToken(
+        deployment.project_ref,
+        deployment.id,
+        token,
+      );
       if (!isValid) {
         results.push({ deployment_id: deployment.id, project_ref: deployment.project_ref, success: false, error: "Invalid webhook token" });
         continue;

--- a/packages/management-api/src/services/certificate.service.ts
+++ b/packages/management-api/src/services/certificate.service.ts
@@ -9,6 +9,7 @@ import {
   resolveProjectApiHosts,
   resolveProjectStudioHost,
 } from "../utils/project-routing";
+import { normalizeFrontendCertificateDomain } from "../utils/frontend-security";
 import { gatewayService } from "./gateway.service";
 
 export type CertificateMode = "lego" | "manual";
@@ -44,13 +45,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function normalizeDomain(value: string): string {
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed) return "";
   try {
-    const parsed = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
-    return parsed.hostname.toLowerCase();
+    return normalizeFrontendCertificateDomain(value);
   } catch {
-    return trimmed.replace(/:\d+$/, "");
+    return "";
   }
 }
 

--- a/packages/management-api/src/services/frontend-domain.service.ts
+++ b/packages/management-api/src/services/frontend-domain.service.ts
@@ -9,6 +9,13 @@ import type {
   FrontendDeployment,
 } from "../types/frontend";
 import type { FrontendDeploymentLock } from "./frontend-deployment-lock";
+import { decryptSecretIfNeeded, encryptSecretIfNeeded } from "../utils/secret-crypto";
+import { timingSafeEqual } from "node:crypto";
+import {
+  MASKED_FRONTEND_VALUE,
+  normalizeFrontendCustomDomain,
+  normalizeFrontendEnvVars,
+} from "../utils/frontend-security";
 
 interface FrontendDomainServiceOptions {
   deploymentLock: FrontendDeploymentLock;
@@ -29,6 +36,33 @@ function newDeployToken(name: string): DeployToken {
   };
 }
 
+function readToken(candidate: DeployToken): string | null {
+  if (candidate.token_encrypted) return decryptSecretIfNeeded(candidate.token_encrypted);
+  return candidate.token || null;
+}
+
+function safeTokenEqual(expected: string, actual: string): boolean {
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const actualBytes = Buffer.from(actual, "utf8");
+  return expectedBytes.length === actualBytes.length
+    && timingSafeEqual(expectedBytes, actualBytes);
+}
+
+function sameGitTarget(left: string, right: string): boolean {
+  try {
+    const a = new URL(left);
+    const b = new URL(right);
+    if (b.username || b.password) return false;
+    a.username = "";
+    a.password = "";
+    b.username = "";
+    b.password = "";
+    return a.toString() === b.toString();
+  } catch {
+    return left === right;
+  }
+}
+
 export class FrontendDomainService {
   constructor(private readonly options: FrontendDomainServiceOptions) {}
 
@@ -40,9 +74,16 @@ export class FrontendDomainService {
     return this.options.deploymentLock(projectRef, deploymentId, async () => {
       const deployment = await this.options.getDeployment(projectRef, deploymentId);
       if (!deployment) return null;
+      const nextEnvVars = { ...deployment.env_vars };
+      for (const [name, value] of Object.entries(envVars)) {
+        if (value === MASKED_FRONTEND_VALUE && Object.prototype.hasOwnProperty.call(nextEnvVars, name)) {
+          continue;
+        }
+        nextEnvVars[name] = value;
+      }
       const updated = {
         ...deployment,
-        env_vars: { ...deployment.env_vars, ...envVars },
+        env_vars: normalizeFrontendEnvVars(nextEnvVars),
         updated_at: new Date().toISOString(),
       };
       await this.options.writeDeployment(updated);
@@ -56,8 +97,9 @@ export class FrontendDomainService {
     domain: string,
   ): Promise<FrontendDeployment | null> {
     return this.mutateCustomDomains(projectRef, deploymentId, (deployment) => {
-      if (deployment.custom_domains.includes(domain)) return null;
-      return [...deployment.custom_domains, domain];
+      const normalized = normalizeFrontendCustomDomain(domain);
+      if (deployment.custom_domains.includes(normalized)) return null;
+      return [...deployment.custom_domains, normalized];
     });
   }
 
@@ -67,8 +109,9 @@ export class FrontendDomainService {
     domain: string,
   ): Promise<FrontendDeployment | null> {
     return this.mutateCustomDomains(projectRef, deploymentId, (deployment) => {
-      if (!deployment.custom_domains.includes(domain)) return null;
-      return deployment.custom_domains.filter((candidate) => candidate !== domain);
+      const normalized = normalizeFrontendCustomDomain(domain);
+      if (!deployment.custom_domains.includes(normalized)) return null;
+      return deployment.custom_domains.filter((candidate) => candidate !== normalized);
     });
   }
 
@@ -101,13 +144,33 @@ export class FrontendDomainService {
       const deployment = await this.options.getDeployment(projectRef, deploymentId);
       if (!deployment) return null;
       const deployToken = newDeployToken(name);
+      const token = readToken(deployToken)!;
       await this.options.writeDeployment({
         ...deployment,
-        deploy_tokens: [...(deployment.deploy_tokens || []), deployToken],
+        deploy_tokens: [
+          ...(deployment.deploy_tokens || []),
+          {
+            id: deployToken.id,
+            name: deployToken.name,
+            token_encrypted: encryptSecretIfNeeded(token),
+            created_at: deployToken.created_at,
+          },
+        ],
         updated_at: new Date().toISOString(),
       });
-      return { id: deployToken.id, token: deployToken.token };
+      return { id: deployToken.id, token };
     });
+  }
+
+  async getDeployTokenSecrets(
+    projectRef: string,
+    deploymentId: string,
+  ): Promise<string[]> {
+    const deployment = await this.options.getDeployment(projectRef, deploymentId);
+    if (!deployment) return [];
+    return (deployment.deploy_tokens || [])
+      .map(readToken)
+      .filter((token): token is string => Boolean(token));
   }
 
   async listDeployTokens(
@@ -149,7 +212,10 @@ export class FrontendDomainService {
     return this.options.deploymentLock(projectRef, deploymentId, async () => {
       const deployment = await this.options.getDeployment(projectRef, deploymentId);
       if (!deployment) return false;
-      const foundToken = (deployment.deploy_tokens || []).find((candidate) => candidate.token === token);
+      const foundToken = (deployment.deploy_tokens || []).find((candidate) => {
+        const candidateToken = readToken(candidate);
+        return candidateToken ? safeTokenEqual(candidateToken, token) : false;
+      });
       if (!foundToken) return false;
       const lastUsedAt = new Date().toISOString();
       await this.options.writeDeployment({
@@ -174,7 +240,9 @@ export class FrontendDomainService {
       if (!deployment) return null;
       const updated = {
         ...deployment,
-        git_url: gitUrl,
+        git_url: deployment.git_url && sameGitTarget(deployment.git_url, gitUrl)
+          ? deployment.git_url
+          : gitUrl,
         git_branch: branch,
         updated_at: new Date().toISOString(),
       };

--- a/packages/management-api/src/services/frontend-record.service.ts
+++ b/packages/management-api/src/services/frontend-record.service.ts
@@ -6,6 +6,7 @@
  */
 import { $ } from "bun";
 import { logger } from "../utils/logger";
+import { maskFrontendBuildLog } from "../utils/frontend-security";
 import type { DeploymentRecord } from "../types/frontend";
 
 export class FrontendRecordService {
@@ -40,7 +41,7 @@ export class FrontendRecordService {
       commit_message: record.commit_message,
       branch: record.branch,
       triggered_by: record.triggered_by || "manual",
-      build_log: record.build_log,
+      build_log: maskFrontendBuildLog(record.build_log),
       started_at: new Date().toISOString(),
     };
 
@@ -68,6 +69,9 @@ export class FrontendRecordService {
       const updated = {
         ...record,
         ...updates,
+        ...(updates.build_log !== undefined
+          ? { build_log: maskFrontendBuildLog(updates.build_log) }
+          : {}),
         finished_at: updates.status === "success" || updates.status === "failed" 
           ? new Date().toISOString() 
           : undefined,

--- a/packages/management-api/src/services/frontend-runtime.ts
+++ b/packages/management-api/src/services/frontend-runtime.ts
@@ -71,6 +71,14 @@ User=${runtimeUser}
 Group=${runtimeUser}
 WorkingDirectory=${buildDir}
 NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+LockPersonality=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+CapabilityBoundingSet=
+AmbientCapabilities=
 Environment="PORT=${input.port}"
 Environment="NODE_ENV=production"
 Environment="PROTOCOL_HEADER=x-forwarded-proto"

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -12,7 +12,9 @@
  *   SSR: build -> start process -> readiness -> switch proxy route
  */
 import { $ } from "bun";
-import { chmod, mkdtemp, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 import { logger } from "../utils/logger";
 import { config } from "../config";
@@ -40,11 +42,34 @@ import {
   withFrontendDeploymentLock,
   type FrontendDeploymentLock,
 } from "./frontend-deployment-lock";
+import {
+  maskFrontendBuildLog,
+  normalizeFrontendCustomDomain,
+  normalizeFrontendCustomDomains,
+  normalizeFrontendEnvVars,
+  normalizeFrontendOutputDir,
+  sanitizeFrontendGitUrl,
+} from "../utils/frontend-security";
 
 const FRONTEND_BASE_DIR = "/var/supacloud/frontends";
 const READINESS_TIMEOUT_MS = 30_000;
 const READINESS_INTERVAL_MS = 500;
-const UNSAFE_COMMAND_PATTERN = /[\n\r;&|`$<>]/;
+const MAX_BUILD_COMMAND_LENGTH = 4096;
+const MAX_BUILD_LOG_BYTES = 256 * 1024;
+const SAFE_BUILD_ENV_KEYS = ["PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TZ", "CI", "NODE_ENV"] as const;
+const SAFE_GIT_ENV_KEYS = [
+  "SSH_AUTH_SOCK",
+  "SSH_AGENT_PID",
+  "GIT_SSH_COMMAND",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_CONFIG_NOSYSTEM",
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITLAB_TOKEN",
+  "BITBUCKET_TOKEN",
+] as const;
+const RESTRICTED_BUILD_SHELL_PATTERN = /[\r\n;&|`<>]|\$\(|\$\{/;
 const SAFE_GIT_SSH_PATTERN = /^git@[A-Za-z0-9.-]+:[A-Za-z0-9._~/-]+\.git$/;
 const STATIC_PRECOMPRESS_MIN_BYTES = 1024;
 const STATIC_PRECOMPRESS_EXTENSIONS = new Set([
@@ -93,11 +118,92 @@ function normalizeHealthCheckPath(value: string | undefined): string {
   return `${url.pathname}${url.search}`;
 }
 
-function assertSafeBuildCommand(command: string): void {
-  if (process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS !== "true") return;
-  if (command.length > 200 || UNSAFE_COMMAND_PATTERN.test(command)) {
+function assertBuildCommandPolicy(command: string): void {
+  if (command.length > MAX_BUILD_COMMAND_LENGTH) {
+    throw new Error(`Build command exceeds ${MAX_BUILD_COMMAND_LENGTH} characters`);
+  }
+  if (process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS === "true" && RESTRICTED_BUILD_SHELL_PATTERN.test(command)) {
     throw new Error("Build command contains unsupported shell syntax");
   }
+}
+
+function buildCommandEnvironment(
+  deploymentEnv: Record<string, string>,
+  nodeVersion: string,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of SAFE_BUILD_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  Object.assign(env, normalizeFrontendEnvVars(deploymentEnv));
+  env.NODE_VERSION = nodeVersion;
+  return env;
+}
+
+function buildGitEnvironment(): Record<string, string> {
+  const env = buildCommandEnvironment({}, "20");
+  for (const key of SAFE_GIT_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+function gitUrlForLog(gitUrl: string): string {
+  return sanitizeFrontendGitUrl(gitUrl);
+}
+
+function appendBuildLog(log: string, chunk: string): string {
+  const next = `${log}${chunk}`;
+  if (Buffer.byteLength(next, "utf8") <= MAX_BUILD_LOG_BYTES) return next;
+  const suffix = "\n[build log truncated]\n";
+  const available = Math.max(0, MAX_BUILD_LOG_BYTES - Buffer.byteLength(suffix, "utf8"));
+  return `${Buffer.from(next, "utf8").subarray(0, available).toString("utf8")}${suffix}`;
+}
+
+async function runBuildCommand(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  runtimeUser?: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  assertBuildCommandPolicy(command);
+  // Preserve the existing build-command UX while keeping management-api
+  // credentials out of the child environment.
+  const commandArgs = ["/bin/sh", "-c", command];
+  const setprivPath = ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync);
+  const spawnArgs = runtimeUser && process.getuid?.() === 0
+    ? setprivPath
+      ? [setprivPath, "--reuid", runtimeUser, "--regid", runtimeUser, "--clear-groups", "--", ...commandArgs]
+      : (() => { throw new Error("Frontend builds require setpriv when Management API runs as root"); })()
+    : commandArgs;
+  const proc = Bun.spawn(spawnArgs, {
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+async function resolveContainedOutputDir(sourceDir: string, outputDir: string): Promise<string> {
+  const requested = outputDir.trim();
+  if (!requested || isAbsolute(requested) || requested.split(/[\\/]/).includes("..")) {
+    throw new Error("Frontend output_dir must be a relative path without parent traversal");
+  }
+  const canonicalRoot = await realpath(sourceDir);
+  const canonicalCandidate = await realpath(resolve(canonicalRoot, requested));
+  const escaped = relative(canonicalRoot, canonicalCandidate);
+  if (escaped === ".." || escaped.startsWith(`..${"/"}`) || isAbsolute(escaped)) {
+    throw new Error("Frontend output_dir escapes the source directory");
+  }
+  return canonicalCandidate;
 }
 
 function assertSafeGitUrl(gitUrl: string): void {
@@ -376,7 +482,9 @@ export class FrontendService {
   async createDeployment(projectRef: string, deploymentConfig: FrontendDeploymentConfig): Promise<FrontendDeployment> {
     const deploymentId = this.generateId();
     const defaults = FRAMEWORK_DEFAULTS[deploymentConfig.framework];
-    const domain = deploymentConfig.domain || defaultFrontendDomain(projectRef, deploymentId);
+    const domain = deploymentConfig.domain
+      ? normalizeFrontendCustomDomain(deploymentConfig.domain)
+      : defaultFrontendDomain(projectRef, deploymentId);
 
     const deployment: FrontendDeployment = {
       id: deploymentId,
@@ -384,15 +492,15 @@ export class FrontendService {
       name: deploymentConfig.name,
       framework: deploymentConfig.framework,
       domain,
-      custom_domains: deploymentConfig.custom_domains || [],
+      custom_domains: normalizeFrontendCustomDomains(deploymentConfig.custom_domains),
       build_command: deploymentConfig.build_command || defaults.build_command,
-      output_dir: deploymentConfig.output_dir || defaults.output_dir,
+      output_dir: normalizeFrontendOutputDir(deploymentConfig.output_dir || defaults.output_dir),
       install_command: deploymentConfig.install_command || defaults.install_command,
       node_version: deploymentConfig.node_version || defaults.node_version,
       health_check_path: normalizeHealthCheckPath(
         deploymentConfig.health_check_path || defaults.health_check_path,
       ),
-      env_vars: deploymentConfig.env_vars || {},
+      env_vars: normalizeFrontendEnvVars(deploymentConfig.env_vars),
       status: "pending",
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -422,12 +530,22 @@ export class FrontendService {
       const definedUpdates = Object.fromEntries(
         Object.entries(updates).filter(([, value]) => value !== undefined),
       ) as Partial<FrontendDeploymentConfig>;
-      const normalizedUpdates = definedUpdates.health_check_path === undefined
-        ? definedUpdates
-        : {
-            ...definedUpdates,
-            health_check_path: normalizeHealthCheckPath(definedUpdates.health_check_path),
-          };
+      const normalizedUpdates: Partial<FrontendDeploymentConfig> = { ...definedUpdates };
+      if (definedUpdates.domain !== undefined) {
+        normalizedUpdates.domain = normalizeFrontendCustomDomain(definedUpdates.domain);
+      }
+      if (definedUpdates.custom_domains !== undefined) {
+        normalizedUpdates.custom_domains = normalizeFrontendCustomDomains(definedUpdates.custom_domains);
+      }
+      if (definedUpdates.env_vars !== undefined) {
+        normalizedUpdates.env_vars = normalizeFrontendEnvVars(definedUpdates.env_vars);
+      }
+      if (definedUpdates.output_dir !== undefined) {
+        normalizedUpdates.output_dir = normalizeFrontendOutputDir(definedUpdates.output_dir);
+      }
+      if (definedUpdates.health_check_path !== undefined) {
+        normalizedUpdates.health_check_path = normalizeHealthCheckPath(definedUpdates.health_check_path);
+      }
       const updated = {
         ...deployment,
         ...normalizedUpdates,
@@ -519,7 +637,8 @@ export class FrontendService {
     deploymentId: string,
     sourcePath: string,
   ): Promise<FrontendBuildResult> {
-    if (!await this.getDeployment(projectRef, deploymentId)) {
+    const deployment = await this.getDeployment(projectRef, deploymentId);
+    if (!deployment) {
       return { success: false, deployment_id: deploymentId, url: "", build_log: "", error: "Deployment not found" };
     }
 
@@ -540,12 +659,19 @@ export class FrontendService {
       return await this.buildDeployment(projectRef, deploymentId, sourceDir);
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error);
+      const safeError = maskFrontendBuildLog(errorMsg, Object.values(deployment.env_vars));
       await this.updateDeployment(projectRef, deploymentId, {
         status: "failed",
-        build_log: `Error copying source: ${errorMsg}`,
+        build_log: `Error copying source: ${safeError}`,
       } as Partial<FrontendDeployment>);
 
-      return { success: false, deployment_id: deploymentId, url: "", build_log: `Error: ${errorMsg}`, error: errorMsg };
+      return {
+        success: false,
+        deployment_id: deploymentId,
+        url: "",
+        build_log: `Error: ${safeError}`,
+        error: safeError,
+      };
     }
   }
 
@@ -567,7 +693,8 @@ export class FrontendService {
     gitUrl: string,
     branch: string,
   ): Promise<FrontendBuildResult> {
-    if (!await this.getDeployment(projectRef, deploymentId)) {
+    const deployment = await this.getDeployment(projectRef, deploymentId);
+    if (!deployment) {
       return { success: false, deployment_id: deploymentId, url: "", build_log: "", error: "Deployment not found" };
     }
 
@@ -590,17 +717,18 @@ export class FrontendService {
 
       await $`rm -rf ${sourceDir}`.quiet();
 
-      buildLog += `$ git clone --branch ${branch} ${gitUrl}\n`;
+      buildLog += `$ git clone --branch ${branch} ${gitUrlForLog(gitUrl)}\n`;
       const cloneResult = await $`git clone --branch ${branch} --depth 1 ${gitUrl} ${sourceDir}`
         .env({
-          ...process.env,
+          ...buildGitEnvironment(),
           GIT_TERMINAL_PROMPT: "0",
           GIT_ASKPASS: "echo",
         })
         .quiet();
-      buildLog += cloneResult.stdout.toString();
-      buildLog += cloneResult.stderr.toString();
-      buildLog += "\n";
+      buildLog = appendBuildLog(
+        buildLog,
+        `${cloneResult.stdout.toString()}${cloneResult.stderr.toString()}\n`,
+      );
 
       if (cloneResult.exitCode !== 0) {
         throw new Error(`Git clone failed: ${cloneResult.stderr.toString()}`);
@@ -608,18 +736,28 @@ export class FrontendService {
 
       return await this.buildDeployment(projectRef, deploymentId, sourceDir);
     } catch (error: unknown) {
-      buildLog += `\nError: ${error instanceof Error ? error.message : String(error)}\n`;
+      buildLog = appendBuildLog(
+        buildLog,
+        `\nError: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      const safeBuildLog = maskFrontendBuildLog(
+        buildLog,
+        [...Object.values(deployment.env_vars), gitUrl],
+      );
       await this.updateDeployment(projectRef, deploymentId, {
         status: "failed",
-        build_log: buildLog,
+        build_log: safeBuildLog,
       } as Partial<FrontendDeployment>);
 
       return {
         success: false,
         deployment_id: deploymentId,
         url: "",
-        build_log: buildLog,
-        error: (error instanceof Error ? error.message : String(error)),
+        build_log: safeBuildLog,
+        error: maskFrontendBuildLog(
+          error instanceof Error ? error.message : String(error),
+          [gitUrl],
+        ),
       };
     }
   }
@@ -643,29 +781,37 @@ export class FrontendService {
     await this.updateDeployment(projectRef, deploymentId, { status: "building" } as Partial<FrontendDeployment>);
 
     try {
+      const buildUser = process.getuid?.() === 0
+        ? await tenantRuntimeService.ensureTenantRuntimeUser(projectRef)
+        : undefined;
+      if (buildUser) {
+        await $`chown -R ${buildUser}:${buildUser} ${sourceDir}`.quiet();
+      }
       if (deployment.install_command) {
-        assertSafeBuildCommand(deployment.install_command);
         buildLog += `$ ${deployment.install_command}\n`;
-        const installResult = await $`${deployment.install_command}`
-          .cwd(sourceDir)
-          .env({ ...process.env, ...deployment.env_vars, NODE_VERSION: deployment.node_version })
-          .quiet();
-        buildLog += installResult.stdout.toString() + "\n";
+        const installResult = await runBuildCommand(
+          deployment.install_command,
+          sourceDir,
+          buildCommandEnvironment(deployment.env_vars, deployment.node_version),
+          buildUser,
+        );
+        buildLog = appendBuildLog(buildLog, installResult.stdout + installResult.stderr + "\n");
         if (installResult.exitCode !== 0) {
-          throw new Error(`Install failed: ${installResult.stderr.toString()}`);
+          throw new Error(`Install failed: ${installResult.stderr}`);
         }
       }
 
       if (deployment.build_command) {
-        assertSafeBuildCommand(deployment.build_command);
         buildLog += `$ ${deployment.build_command}\n`;
-        const buildResult = await $`${deployment.build_command}`
-          .cwd(sourceDir)
-          .env({ ...process.env, ...deployment.env_vars, NODE_VERSION: deployment.node_version })
-          .quiet();
-        buildLog += buildResult.stdout.toString() + "\n";
+        const buildResult = await runBuildCommand(
+          deployment.build_command,
+          sourceDir,
+          buildCommandEnvironment(deployment.env_vars, deployment.node_version),
+          buildUser,
+        );
+        buildLog = appendBuildLog(buildLog, buildResult.stdout + buildResult.stderr + "\n");
         if (buildResult.exitCode !== 0) {
-          throw new Error(`Build failed: ${buildResult.stderr.toString()}`);
+          throw new Error(`Build failed: ${buildResult.stderr}`);
         }
       }
 
@@ -677,18 +823,28 @@ export class FrontendService {
       const prepared = await this.prepareLegacyBuild(deployment, sourceDir, buildLog);
       return await this.publishLegacyBuild(projectRef, deploymentId, prepared);
     } catch (error: unknown) {
-      buildLog += `\nError: ${error instanceof Error ? error.message : String(error)}\n`;
+      buildLog = appendBuildLog(
+        buildLog,
+        `\nError: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      const safeBuildLog = maskFrontendBuildLog(
+        buildLog,
+        Object.values(deployment.env_vars),
+      );
       await this.updateDeployment(projectRef, deploymentId, {
         status: "failed",
-        build_log: buildLog,
+        build_log: safeBuildLog,
       } as Partial<FrontendDeployment>);
 
       return {
         success: false,
         deployment_id: deploymentId,
         url: "",
-        build_log: buildLog,
-        error: (error instanceof Error ? error.message : String(error)),
+        build_log: safeBuildLog,
+        error: maskFrontendBuildLog(
+          error instanceof Error ? error.message : String(error),
+          Object.values(deployment.env_vars),
+        ),
       };
     }
   }
@@ -700,7 +856,7 @@ export class FrontendService {
   ): Promise<PreparedLegacyBuild> {
     const deploymentDir = this.joinPath(this.baseDir, deployment.project_ref, deployment.id);
     const stagingDir = await mkdtemp(this.joinPath(deploymentDir, ".legacy-build-"));
-    const outputDir = this.joinPath(sourceDir, deployment.output_dir);
+    const outputDir = await resolveContainedOutputDir(sourceDir, deployment.output_dir);
     try {
       await $`cp -r ${outputDir}/. ${stagingDir}`.quiet();
       await this.precompressStaticAssets(stagingDir);
@@ -730,7 +886,7 @@ export class FrontendService {
             ...deployment,
             status: "success" as const,
             last_deployed_at: new Date().toISOString(),
-            build_log: prepared.buildLog,
+            build_log: maskFrontendBuildLog(prepared.buildLog, Object.values(deployment.env_vars)),
             updated_at: new Date().toISOString(),
           });
         } catch (error: unknown) {
@@ -742,7 +898,7 @@ export class FrontendService {
           success: true,
           deployment_id: deploymentId,
           url: deployment.deployment_url,
-          build_log: prepared.buildLog,
+          build_log: maskFrontendBuildLog(prepared.buildLog, Object.values(deployment.env_vars)),
         };
       });
     } finally {
@@ -826,7 +982,7 @@ export class FrontendService {
       ...deployment,
       status: "success" as const,
       last_deployed_at: new Date().toISOString(),
-      build_log: buildLog,
+      build_log: maskFrontendBuildLog(buildLog, Object.values(deployment.env_vars)),
       updated_at: new Date().toISOString(),
     });
   }
@@ -839,7 +995,7 @@ export class FrontendService {
       success: true,
       deployment_id: deployment.id,
       url: deployment.deployment_url,
-      build_log: buildLog,
+      build_log: maskFrontendBuildLog(buildLog, Object.values(deployment.env_vars)),
     };
   }
 
@@ -861,7 +1017,8 @@ export class FrontendService {
     const deploymentDir = this.joinPath(this.baseDir, deployment.project_ref, deployment.id);
     const stagingDir = await mkdtemp(this.joinPath(deploymentDir, ".legacy-ssr-build-"));
     try {
-      await $`cp -r ${this.joinPath(sourceDir, deployment.output_dir)}/. ${stagingDir}`.quiet();
+      const outputDir = await resolveContainedOutputDir(sourceDir, deployment.output_dir);
+      await $`cp -r ${outputDir}/. ${stagingDir}`.quiet();
       if (deployment.framework === "sveltekit") {
         await prepareSvelteKitRuntime(sourceDir, stagingDir);
       }
@@ -1023,6 +1180,14 @@ User=${runtimeUser}
 Group=${runtimeUser}
 WorkingDirectory=${buildDir}
 NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+LockPersonality=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+CapabilityBoundingSet=
+AmbientCapabilities=
 Environment="PORT=${port}"
 Environment="NODE_ENV=production"
 EnvironmentFile=${envFile}
@@ -1128,7 +1293,12 @@ WantedBy=multi-user.target
 
   async getBuildLog(projectRef: string, deploymentId: string): Promise<string> {
     const deployment = await this.getDeployment(projectRef, deploymentId);
-    return deployment?.build_log || "";
+    return deployment
+      ? maskFrontendBuildLog(
+          deployment.build_log,
+          [...Object.values(deployment.env_vars || {}), deployment.git_url || ""],
+        )
+      : "";
   }
 
   // ── Delegated to domain service ───────────────────────────────────
@@ -1140,6 +1310,7 @@ WantedBy=multi-user.target
   listDeployTokens = (...args: Parameters<FrontendDomainService["listDeployTokens"]>) => this.domainService.listDeployTokens(...args);
   deleteDeployToken = (...args: Parameters<FrontendDomainService["deleteDeployToken"]>) => this.domainService.deleteDeployToken(...args);
   verifyDeployToken = (...args: Parameters<FrontendDomainService["verifyDeployToken"]>) => this.domainService.verifyDeployToken(...args);
+  getDeployTokenSecrets = (...args: Parameters<FrontendDomainService["getDeployTokenSecrets"]>) => this.domainService.getDeployTokenSecrets(...args);
   setGitConfig = (...args: Parameters<FrontendDomainService["setGitConfig"]>) => this.domainService.setGitConfig(...args);
 
   // ── Delegated to record service ───────────────────────────────────

--- a/packages/management-api/src/services/project-ops.service.ts
+++ b/packages/management-api/src/services/project-ops.service.ts
@@ -10,6 +10,7 @@ import { routerService } from "./router.service";
 import { logger } from "../utils/logger";
 import type { BackupResponse } from "./project.service";
 import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
+import { normalizeFrontendCustomDomain } from "../utils/frontend-security";
 
 export class ProjectOpsService {
   // --- Backup Management ---
@@ -64,11 +65,12 @@ export class ProjectOpsService {
     const project = await projectRepository.findByRef(ref);
     if (!project) return false;
 
-    const result = await routerService.bindCustomDomain(ref, domain);
+    const normalizedDomain = normalizeFrontendCustomDomain(domain);
+    const result = await routerService.bindCustomDomain(ref, normalizedDomain);
     if (result.success) {
       await projectRepository.updateConfig(
         ref,
-        mergeProjectConfig(project.config, { custom_domain: domain }),
+        mergeProjectConfig(project.config, { custom_domain: normalizedDomain }),
       );
       try {
         const { tenantRuntimeService } = await import("./tenant-runtime.service");

--- a/packages/management-api/src/services/router.service.ts
+++ b/packages/management-api/src/services/router.service.ts
@@ -7,6 +7,7 @@ import {
   resolveProjectStudioHost,
   resolveProjectStudioUrl,
 } from "../utils/project-routing";
+import { normalizeFrontendCustomDomain } from "../utils/frontend-security";
 
 export interface ProjectDomains {
   apiDomain: string;
@@ -53,8 +54,9 @@ export class RouterService {
 
   async bindCustomDomain(projectRef: string, customDomain: string): Promise<{ success: boolean; error?: string }> {
     try {
-      const apiDomain = resolveProjectApiHost(projectRef, { custom_domain: customDomain });
-      const studioDomain = resolveProjectStudioHost(projectRef, { custom_domain: customDomain });
+      const normalizedDomain = normalizeFrontendCustomDomain(customDomain);
+      const apiDomain = resolveProjectApiHost(projectRef, { custom_domain: normalizedDomain });
+      const studioDomain = resolveProjectStudioHost(projectRef, { custom_domain: normalizedDomain });
       await gatewayService.addProjectDomains(projectRef, [apiDomain], [studioDomain]);
       return { success: true };
     } catch (error: unknown) {
@@ -64,8 +66,9 @@ export class RouterService {
 
   async removeCustomDomain(projectRef: string, customDomain: string): Promise<{ success: boolean; error?: string }> {
     try {
-      const apiDomain = resolveProjectApiHost(projectRef, { custom_domain: customDomain });
-      const studioDomain = resolveProjectStudioHost(projectRef, { custom_domain: customDomain });
+      const normalizedDomain = normalizeFrontendCustomDomain(customDomain);
+      const apiDomain = resolveProjectApiHost(projectRef, { custom_domain: normalizedDomain });
+      const studioDomain = resolveProjectStudioHost(projectRef, { custom_domain: normalizedDomain });
       await gatewayService.removeProjectDomains(projectRef, [apiDomain], [studioDomain]);
       return { success: true };
     } catch (error: unknown) {

--- a/packages/management-api/src/services/systemd-unit-broker.ts
+++ b/packages/management-api/src/services/systemd-unit-broker.ts
@@ -10,8 +10,9 @@ const UNIT_DIRECTIVES = new Set([
 ]);
 const SERVICE_DIRECTIVES = new Set([
   "CPUWeight", "Environment", "EnvironmentFile", "ExecReload", "ExecStart",
-  "Group", "LimitNOFILE", "MemoryMax", "NoNewPrivileges", "ProtectHome",
-  "ProtectSystem", "ReadOnlyPaths", "Restart", "RestartSec", "SyslogIdentifier",
+  "AmbientCapabilities", "CapabilityBoundingSet", "Group", "LimitNOFILE", "LockPersonality",
+  "MemoryMax", "NoNewPrivileges", "PrivateTmp", "ProtectHome", "ProtectSystem",
+  "ReadOnlyPaths", "RestrictRealtime", "RestrictSUIDSGID", "Restart", "RestartSec", "SyslogIdentifier",
   "Type", "User", "WorkingDirectory",
 ]);
 const INSTALL_DIRECTIVES = new Set(["WantedBy"]);

--- a/packages/management-api/src/sigstore-trusted-root.ts
+++ b/packages/management-api/src/sigstore-trusted-root.ts
@@ -100,7 +100,7 @@ export async function withSigstoreVerificationDirectory<T>(
 ): Promise<T> {
   const resources = createSigstoreVerificationDirectory();
   let operationOutput: T | undefined;
-  let operationFailed = false;
+  let operationFailed: boolean = false;
   let operationError: unknown;
   try {
     operationOutput = await operation(resources);
@@ -108,7 +108,7 @@ export async function withSigstoreVerificationDirectory<T>(
     operationFailed = true;
     operationError = error;
   }
-  let cleanupFailed = false;
+  let cleanupFailed: boolean = false;
   let cleanupError: unknown;
   try {
     rmSync(resources.directory, { recursive: true });

--- a/packages/management-api/src/types/frontend.ts
+++ b/packages/management-api/src/types/frontend.ts
@@ -29,7 +29,8 @@ export interface FrontendDeployment {
 export interface DeployToken {
   id: string;
   name: string;
-  token: string;
+  token?: string;
+  token_encrypted?: string;
   created_at: string;
   last_used_at?: string;
 }

--- a/packages/management-api/src/utils/frontend-security.ts
+++ b/packages/management-api/src/utils/frontend-security.ts
@@ -1,0 +1,142 @@
+import { isValidCaddyDomain, normalizeCaddyHost } from "./caddy-domains";
+import type { FrontendDeployment } from "../types/frontend";
+
+export const MASKED_FRONTEND_VALUE = "********";
+
+const RESERVED_FRONTEND_ENV_NAMES = new Set([
+  "PATH",
+  "PWD",
+  "OLDPWD",
+  "SHELL",
+  "BASH_ENV",
+  "ENV",
+  "NODE_OPTIONS",
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "NODE_VERSION",
+  "DATABASE_URL",
+  "MASTER_TOKEN",
+  "JWT_SECRET",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_SECRET_KEY",
+  "NPM_TOKEN",
+]);
+const RESERVED_FRONTEND_ENV_PREFIXES = ["SUPACLOUD_", "SUPAOAUTH_", "AWS_SECRET"];
+
+function normalizeFrontendHost(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)) {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return "";
+    if (parsed.pathname !== "/" || parsed.search || parsed.hash) return "";
+    return normalizeCaddyHost(parsed.hostname);
+  }
+  if (/[/?#]/.test(trimmed)) return "";
+  return normalizeCaddyHost(trimmed);
+}
+
+function assertSafeFrontendEnvName(name: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid frontend environment variable name: ${name}`);
+  }
+  const normalized = name.toUpperCase();
+  if (
+    RESERVED_FRONTEND_ENV_NAMES.has(normalized)
+    || RESERVED_FRONTEND_ENV_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  ) {
+    throw new Error(`Reserved frontend environment variable name: ${name}`);
+  }
+}
+
+export function normalizeFrontendEnvVars(
+  envVars: Record<string, string> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(envVars || {})) {
+    assertSafeFrontendEnvName(name);
+    if (typeof value !== "string" || value.length > 24_576 || /[\u0000\r\n]/.test(value)) {
+      throw new Error(`Frontend environment variable is too large: ${name}`);
+    }
+    normalized[name] = value;
+  }
+  if (Object.keys(normalized).length > 256) {
+    throw new Error("Frontend environment variable count exceeds 256");
+  }
+  return normalized;
+}
+
+export function normalizeFrontendCustomDomain(domain: string): string {
+  const normalized = normalizeFrontendHost(domain);
+  if (!isValidCaddyDomain(normalized)) throw new Error("Invalid custom domain");
+  return normalized;
+}
+
+export function normalizeFrontendCustomDomains(domains: string[] | undefined): string[] {
+  return [...new Set((domains || []).map(normalizeFrontendCustomDomain))];
+}
+
+export function normalizeFrontendCertificateDomain(domain: string): string {
+  const normalized = normalizeFrontendHost(domain);
+  const candidate = normalized.startsWith("*.") ? normalized.slice(2) : normalized;
+  if (!isValidCaddyDomain(candidate)) throw new Error("Invalid certificate domain");
+  return normalized;
+}
+
+export function maskFrontendBuildLog(
+  log: string | undefined,
+  secretValues: Iterable<string> = [],
+): string {
+  let masked = log || "";
+  for (const secret of secretValues) {
+    if (secret.length >= 4) masked = masked.split(secret).join("********");
+  }
+  return masked
+    .replace(/([a-z][a-z\d+.-]*:\/\/)[^/@\s]+@/gi, "$1********@")
+    .replace(
+      /((?:token|secret|password|passwd|api[_-]?key|authorization)\s*[=:]\s*)([^\s,;]+)/gi,
+      "$1********",
+    );
+}
+
+export function sanitizeFrontendGitUrl(gitUrl: string): string {
+  try {
+    const parsed = new URL(gitUrl);
+    parsed.username = "";
+    parsed.password = "";
+    return parsed.toString();
+  } catch {
+    return gitUrl.replace(/:\/\/[^/@\s]+@/g, "://********@");
+  }
+}
+
+export function normalizeFrontendOutputDir(outputDir: string | undefined): string {
+  const requested = (outputDir ?? "").trim();
+  if (!requested || requested.startsWith("/") || requested.startsWith("\\")
+    || requested.split(/[\\/]/).includes("..")) {
+    throw new Error("Frontend output_dir must be a relative path without parent traversal");
+  }
+  return requested;
+}
+
+export function toFrontendDeploymentResponse(deployment: FrontendDeployment): Omit<FrontendDeployment, "deploy_tokens" | "env_vars" | "build_log"> & {
+  env_vars: Record<string, string>;
+  deploy_tokens: Array<{ id: string; name: string; created_at: string; last_used_at?: string }>;
+} {
+  const { deploy_tokens, env_vars, build_log: _buildLog, ...safeDeployment } = deployment;
+  if (safeDeployment.git_url) {
+    safeDeployment.git_url = sanitizeFrontendGitUrl(safeDeployment.git_url);
+  }
+  return {
+    ...safeDeployment,
+    env_vars: Object.fromEntries(
+      Object.keys(env_vars || {}).map((name) => [name, MASKED_FRONTEND_VALUE]),
+    ),
+    deploy_tokens: (deploy_tokens || []).map(({ id, name, created_at, last_used_at }) => ({
+      id,
+      name,
+      created_at,
+      last_used_at,
+    })),
+  };
+}

--- a/packages/management-api/tests/unit/frontend-security.test.ts
+++ b/packages/management-api/tests/unit/frontend-security.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeFrontendCertificateDomain,
+  normalizeFrontendCustomDomain,
+  normalizeFrontendEnvVars,
+  sanitizeFrontendGitUrl,
+  toFrontendDeploymentResponse,
+} from "../../src/utils/frontend-security";
+
+describe("frontend security boundaries", () => {
+  test("keeps normal project build variables available while reserving host controls", () => {
+    expect(normalizeFrontendEnvVars({
+      SUPABASE_URL: "https://project.example.com",
+      SUPABASE_ANON_KEY: "public-key",
+      VITE_API_BASE: "/api",
+    })).toEqual({
+      SUPABASE_URL: "https://project.example.com",
+      SUPABASE_ANON_KEY: "public-key",
+      VITE_API_BASE: "/api",
+    });
+
+    expect(() => normalizeFrontendEnvVars({ SUPACLOUD_MASTER_TOKEN: "secret" })).toThrow(
+      "Reserved frontend environment variable",
+    );
+    expect(() => normalizeFrontendEnvVars({ NODE_OPTIONS: "--require ./hook.js" })).toThrow(
+      "Reserved frontend environment variable",
+    );
+  });
+
+  test("normalizes domains at the management boundary and preserves certificate wildcards", () => {
+    expect(normalizeFrontendCustomDomain(" HTTPS://WWW.Example.COM./ ")).toBe("www.example.com");
+    expect(normalizeFrontendCertificateDomain("*.Example.COM.")).toBe("*.example.com");
+    expect(() => normalizeFrontendCustomDomain("example.com/path")).toThrow("Invalid custom domain");
+    expect(() => normalizeFrontendCertificateDomain("https://example.com/path")).toThrow(
+      "Invalid certificate domain",
+    );
+  });
+
+  test("does not expose deployment logs or secret values in deployment responses", () => {
+    const response = toFrontendDeploymentResponse({
+      id: "deploy123",
+      project_ref: "project123",
+      name: "site",
+      framework: "static",
+      domain: "site.example.com",
+      custom_domains: [],
+      build_command: "npm run build",
+      output_dir: "dist",
+      install_command: "npm install",
+      node_version: "20",
+      env_vars: { NPM_TOKEN_VALUE: "secret-value" },
+      status: "success",
+      created_at: "2026-09-04T00:00:00.000Z",
+      updated_at: "2026-09-04T00:00:00.000Z",
+      deployment_url: "https://site.example.com",
+      build_log: "token=secret-value",
+      deploy_tokens: [{
+        id: "token123",
+        name: "ci",
+        token: "raw-token",
+        created_at: "2026-09-04T00:00:00.000Z",
+      }],
+    });
+
+    expect(response).not.toHaveProperty("build_log");
+    expect(response.env_vars).toEqual({ NPM_TOKEN_VALUE: "********" });
+    expect(response.deploy_tokens).toEqual([{
+      id: "token123",
+      name: "ci",
+      created_at: "2026-09-04T00:00:00.000Z",
+      last_used_at: undefined,
+    }]);
+  });
+
+  test("preserves repository usability without exposing embedded Git credentials", () => {
+    expect(sanitizeFrontendGitUrl("https://build-user:build-secret@git.example.com/org/repo.git"))
+      .toBe("https://git.example.com/org/repo.git");
+    const response = toFrontendDeploymentResponse({
+      id: "deploy123",
+      project_ref: "project123",
+      name: "site",
+      framework: "static",
+      domain: "site.example.com",
+      custom_domains: [],
+      build_command: "",
+      output_dir: ".",
+      install_command: "",
+      node_version: "20",
+      env_vars: {},
+      status: "pending",
+      created_at: "2026-09-04T00:00:00.000Z",
+      updated_at: "2026-09-04T00:00:00.000Z",
+      deployment_url: "https://site.example.com",
+      git_url: "https://build-user:build-secret@git.example.com/org/repo.git",
+    });
+    expect(response.git_url).toBe("https://git.example.com/org/repo.git");
+  });
+});

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -138,6 +138,64 @@ describe("FrontendService DNS records", () => {
 });
 
 describe("FrontendService SvelteKit defaults", () => {
+  test("keeps shell-compatible build commands working by default", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-shell-build-"));
+    const sourceDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-shell-source-"));
+    const previousPolicy = process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS;
+    delete process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS;
+
+    try {
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      (service as any).applyGatewayRoute = async () => undefined;
+      const deployment = await service.createDeployment("proj123", {
+        name: "shell-site",
+        framework: "static",
+        install_command: "",
+        build_command: "mkdir -p dist && printf '<h1>ok</h1>' > dist/index.html",
+        output_dir: "dist",
+      });
+
+      const result = await service.deployFromSource("proj123", deployment.id, sourceDir);
+
+      expect(result.success).toBe(true);
+      expect(await readFile(join(baseDir, "proj123", deployment.id, "build", "index.html"), "utf8"))
+        .toBe("<h1>ok</h1>");
+    } finally {
+      if (previousPolicy === undefined) delete process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS;
+      else process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS = previousPolicy;
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("supports an explicit restricted build-command policy", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-shell-policy-"));
+    const sourceDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-shell-policy-source-"));
+    const previousPolicy = process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS;
+    process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS = "true";
+
+    try {
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const deployment = await service.createDeployment("proj123", {
+        name: "restricted-site",
+        framework: "static",
+        install_command: "",
+        build_command: "printf ok > index.html && printf blocked > blocked.html",
+        output_dir: ".",
+      });
+
+      const result = await service.deployFromSource("proj123", deployment.id, sourceDir);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("unsupported shell syntax");
+    } finally {
+      if (previousPolicy === undefined) delete process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS;
+      else process.env.SUPACLOUD_RESTRICT_BUILD_COMMANDS = previousPolicy;
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
   test("uses an adapter-node output and a root readiness probe", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-sveltekit-defaults-"));
     const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
@@ -597,6 +655,56 @@ describe("FrontendService deployment serialization", () => {
         git_url: "https://git.example.com/org/repo.git",
         git_branch: "main",
         deploy_tokens: [],
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves private Git credentials when the UI saves a redacted repository URL", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-git-redaction-"));
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+
+    try {
+      const deployment = await service.createDeployment("proj123", { name: "site", framework: "static" });
+      await service.setGitConfig(
+        "proj123",
+        deployment.id,
+        "https://build-user:build-secret@git.example.com/org/repo.git",
+        "main",
+      );
+      await service.setGitConfig(
+        "proj123",
+        deployment.id,
+        "https://git.example.com/org/repo.git",
+        "main",
+      );
+
+      expect((await service.getDeployment("proj123", deployment.id))?.git_url)
+        .toBe("https://build-user:build-secret@git.example.com/org/repo.git");
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not overwrite an environment secret when the masked value is submitted back", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-env-mask-"));
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+
+    try {
+      const deployment = await service.createDeployment("proj123", {
+        name: "site",
+        framework: "static",
+        env_vars: { VITE_API_TOKEN: "real-secret-value" },
+      });
+      await service.setEnvVars("proj123", deployment.id, {
+        VITE_API_TOKEN: "********",
+        FEATURE_FLAG: "enabled",
+      });
+
+      expect((await service.getDeployment("proj123", deployment.id))?.env_vars).toEqual({
+        VITE_API_TOKEN: "real-secret-value",
+        FEATURE_FLAG: "enabled",
       });
     } finally {
       await rm(baseDir, { recursive: true, force: true });

--- a/packages/pgredis-runtime/server.ts
+++ b/packages/pgredis-runtime/server.ts
@@ -29,7 +29,7 @@ app.listen({
 console.log(`[pgredis-runtime] listening on ${config.host}:${config.port}`);
 
 const cleanupTimer = setInterval(() => {
-  void registry.sweepExpired().catch((error) => {
+  void registry.sweepExpired().catch((error: unknown) => {
     console.error("[pgredis-runtime] expired cache cleanup failed", {
       error: error instanceof Error ? error.message : String(error),
     });
@@ -37,7 +37,7 @@ const cleanupTimer = setInterval(() => {
 }, config.cleanupIntervalMs);
 cleanupTimer.unref?.();
 
-let shuttingDown = false;
+let shuttingDown: boolean = false;
 async function shutdown() {
   if (shuttingDown) return;
   shuttingDown = true;

--- a/packages/pgredis-runtime/src/app.test.ts
+++ b/packages/pgredis-runtime/src/app.test.ts
@@ -46,7 +46,7 @@ describe("pgredis-runtime internal API", () => {
       async set(key, value, options) { calls.push(["set", key, value, options]); return true; },
       async delete(key) { calls.push(["delete", key]); return true; },
       async ttl(key) { calls.push(["ttl", key]); return 500; },
-      async getset<T>(key: string, value: T) { calls.push(["getset", key, value]); return "old" as T; },
+      async getset<T>(key: string, value: T, _decode: (value: unknown) => T) { calls.push(["getset", key, value]); return "old" as T; },
       async getdel<T>(key: string) { calls.push(["getdel", key]); return "deleted" as T; },
       async flush() { calls.push(["flush"]); return 2; },
     };

--- a/packages/pgredis-runtime/src/app.ts
+++ b/packages/pgredis-runtime/src/app.ts
@@ -1,24 +1,11 @@
 import { timingSafeEqual } from "node:crypto";
-import { Elysia, t } from "elysia";
+import { Elysia, t, type Static } from "elysia";
 import { TenantCapacityError, type TenantCache, type TenantCacheRegistry } from "./cache-registry";
 import { InvalidCapabilityError, verifyPgredisCapability } from "./capability";
 import { pgredisExtensionPolicy } from "./extension-policy";
 import { PROJECT_REF_PATTERN, TenantConfigError } from "./tenant-config";
 
 type CacheOperation = "get" | "set" | "delete" | "ttl" | "getset" | "getdel";
-
-interface CacheRequest {
-  op: CacheOperation;
-  key: string;
-  value?: unknown;
-  ttlMs?: number | null;
-}
-
-type AdminCacheRequest =
-  | { projectRef: string; op: "get" | "delete" | "ttl" | "getdel"; key: string }
-  | { projectRef: string; op: "set"; key: string; value: unknown; ttlMs?: number | null }
-  | { projectRef: string; op: "getset"; key: string; value: unknown }
-  | { projectRef: string; op: "flush"; confirmProjectRef: string };
 
 export interface PgredisRuntimeAppOptions {
   signingSecret: string;
@@ -63,7 +50,7 @@ async function executeCacheOperation(
       if (!("value" in body) || jsonSize(body.value) > maxValueBytes) {
         throw new ClientRequestError("Cache value is missing or too large");
       }
-      return { value: await cache.getset(body.key, body.value) };
+      return { value: await cache.getset(body.key, body.value, (value) => value) };
     }
     case "getdel":
       return { value: await cache.getdel(body.key) };
@@ -109,6 +96,7 @@ const cacheRequestSchema = t.Object({
     t.Null(),
   ])),
 }, { additionalProperties: false });
+type CacheRequest = Static<typeof cacheRequestSchema>;
 
 const projectRefSchema = t.String({
   minLength: 1,
@@ -141,6 +129,7 @@ const adminCacheRequestSchema = t.Union([
     confirmProjectRef: projectRefSchema,
   }, { additionalProperties: false }),
 ]);
+type AdminCacheRequest = Static<typeof adminCacheRequestSchema>;
 
 export function createPgredisRuntimeApp(options: PgredisRuntimeAppOptions) {
   const adminToken = options.adminToken ?? options.signingSecret;
@@ -223,7 +212,7 @@ export function createPgredisRuntimeApp(options: PgredisRuntimeAppOptions) {
       "/internal/v1/admin/cache",
       async ({ body, request }) => {
         requireInternalToken(request, adminToken);
-        const adminRequest = body as AdminCacheRequest;
+        const adminRequest: AdminCacheRequest = body;
         if (
           adminRequest.op === "flush"
           && adminRequest.confirmProjectRef !== adminRequest.projectRef
@@ -264,7 +253,7 @@ export function createPgredisRuntimeApp(options: PgredisRuntimeAppOptions) {
         try {
           return await executeCacheOperation(
             lease.cache,
-            body as CacheRequest,
+            body,
             options.maxValueBytes,
             options.maxTtlMs,
           );

--- a/packages/pgredis-runtime/src/cache-registry.postgres.test.ts
+++ b/packages/pgredis-runtime/src/cache-registry.postgres.test.ts
@@ -65,7 +65,7 @@ test.skipIf(!databaseUrl)("PostgreSQL commits notifications atomically and clear
     try {
       await first.cache.set("atomic:set", { version: 1 });
       await first.cache.delete("atomic:set");
-      expect(await first.cache.getset<{ version: number }>("atomic:swap", { version: 2 })).toBeNull();
+    expect(await first.cache.getset<{ version: number }>("atomic:swap", { version: 2 }, (value) => value as { version: number })).toBeNull();
       expect(await first.cache.getdel<{ version: number }>("atomic:swap")).toEqual({ version: 2 });
       await waitFor(() => notifications.filter(({ key }) => key?.startsWith("atomic:")).length === 4);
       expect(notifications.filter(({ key }) => key?.startsWith("atomic:"))).toEqual([

--- a/packages/pgredis-runtime/src/cache-registry.test.ts
+++ b/packages/pgredis-runtime/src/cache-registry.test.ts
@@ -418,7 +418,7 @@ describe("createTransactionalTenantCache", () => {
       () => fakeCache(),
     );
 
-    expect(await cache.getset<{ previous?: boolean; next?: boolean }>("shared", { next: true }))
+    expect(await cache.getset<{ previous?: boolean; next?: boolean }>("shared", { next: true }, (value) => value as { previous?: boolean; next?: boolean }))
       .toEqual({ previous: true });
     expect(calls[0]).toBe("BEGIN");
     expect(calls[1]).toBe("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE");
@@ -451,7 +451,7 @@ describe("createTransactionalTenantCache", () => {
       () => fakeCache(),
     );
 
-    await expect(cache.getset("shared", "next")).rejects.toThrow("notify failed");
+    await expect(cache.getset("shared", "next", (value) => value as string)).rejects.toThrow("notify failed");
     expect(invalidated).toBeFalse();
   });
 

--- a/packages/pgredis-runtime/src/cache-registry.ts
+++ b/packages/pgredis-runtime/src/cache-registry.ts
@@ -18,7 +18,11 @@ export interface TenantCache {
   ): Promise<boolean>;
   delete(key: string): Promise<boolean>;
   ttl(key: string): Promise<number | null>;
-  getset<T = unknown>(key: string, value: T): Promise<T | null>;
+  getset<T>(
+    key: string,
+    value: T,
+    decode: (value: unknown) => T,
+  ): Promise<T | null>;
   getdel<T = unknown>(key: string): Promise<T | null>;
   flush(): Promise<number>;
   cleanupExpired?(limit?: number): Promise<number>;
@@ -118,12 +122,12 @@ function notification(op: "set" | "delete", key: string): string {
   return JSON.stringify({ namespace: CACHE_NAMESPACE, op, key });
 }
 
-function deserializeJsonValue<T>(value: unknown): T {
-  if (typeof value !== "string") return value as T;
+function deserializeJsonValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
   try {
-    return JSON.parse(value) as T;
+    return JSON.parse(value);
   } catch {
-    return value as T;
+    return value;
   }
 }
 
@@ -152,7 +156,7 @@ export function createTransactionalTenantCache(
     serializable = false,
   ): Promise<T> => {
     if (!adapter.begin) throw new Error("pgredis runtime requires transaction-capable PostgreSQL adapter");
-    for (let attempt = 0; attempt < 3; attempt += 1) {
+    for (let attempt: number = 0; attempt < 3; attempt += 1) {
       try {
         return await adapter.begin(async (tx) => {
           if (serializable) await tx.unsafe("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE");
@@ -178,9 +182,9 @@ export function createTransactionalTenantCache(
       cache.invalidate(key);
       return deleted;
     },
-    async getset<T = unknown>(key: string, value: T) {
+    async getset<T>(key: string, value: T, decode: (value: unknown) => T) {
       const serialized = JSON.stringify(value);
-      const previousValue = await transaction<T | null>(async (tx) => {
+      const previousValue = await transaction<unknown | null>(async (tx) => {
         const rows = await tx.unsafe<{ value: unknown }>(
           `SELECT value
            FROM ${CACHE_TABLE}
@@ -203,10 +207,10 @@ export function createTransactionalTenantCache(
           NOTIFY_CHANNEL,
           notification("set", key),
         ]);
-        return rows[0] ? deserializeJsonValue<T>(rows[0].value) : null;
+        return rows[0] ? deserializeJsonValue(rows[0].value) : null;
       }, true);
       cache.invalidate(key);
-      return previousValue;
+      return previousValue === null ? null : decode(previousValue);
     },
     async getdel<T = unknown>(key: string) {
       const deletedValue = await transaction((_tx, txCache) => txCache.getdel<T>(key));
@@ -228,7 +232,7 @@ function waitForListener(listener: PgListenerHandle, timeoutMs = 5_000): Promise
   const health = listener.getHealth();
   if (health.connected) return Promise.resolve();
   return new Promise((resolve, reject) => {
-    let settled = false;
+    let settled: boolean = false;
     const timer = setTimeout(() => finish(new Error("pgredis LISTEN connection timed out")), timeoutMs);
     const offConnected = listener.on("connected", () => finish());
     const offError = listener.on("error", (error) => finish(error));
@@ -343,7 +347,7 @@ export class TenantCacheRegistry {
       this.releaseEntry(entry);
       throw new Error("pgredis runtime is shutting down");
     }
-    let released = false;
+    let released: boolean = false;
     return {
       cache: entry.cache,
       release: () => {
@@ -365,7 +369,7 @@ export class TenantCacheRegistry {
 
   async sweepExpired(): Promise<number> {
     const limit = this.options.cleanupBatchSize ?? 500;
-    let deleted = 0;
+    let deleted: number = 0;
     for (const entry of this.entries.values()) {
       if (entry.retiring || !entry.cache.cleanupExpired) continue;
       entry.leases += 1;
@@ -464,7 +468,7 @@ export class TenantCacheRegistry {
       if (existing.leases === 0) await existing.closePromise;
     }
     this.creating += 1;
-    let reservationActive = true;
+    let reservationActive: boolean = true;
     try {
       await this.evictForCapacity();
       const backend = await this.createBackend(

--- a/packages/pgredis-runtime/src/capability.ts
+++ b/packages/pgredis-runtime/src/capability.ts
@@ -22,6 +22,11 @@ function invalid(): never {
   throw new InvalidCapabilityError();
 }
 
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return invalid();
+  return Object.fromEntries(Object.entries(value));
+}
+
 export function verifyPgredisCapability(
   token: string,
   signingSecret: string,
@@ -45,8 +50,7 @@ export function verifyPgredisCapability(
   } catch {
     invalid();
   }
-  if (!claims || typeof claims !== "object" || Array.isArray(claims)) invalid();
-  const value = claims as Record<string, unknown>;
+  const value = record(claims);
   const now = options.now ?? Date.now();
   if (
     value.v !== 1
@@ -65,5 +69,13 @@ export function verifyPgredisCapability(
     || value.exp <= now
     || value.exp - value.iat > options.maxTtlMs
   ) invalid();
-  return value as unknown as CapabilityClaims;
+  return {
+    v: 1,
+    aud: "pgredis-runtime",
+    scope: "cache",
+    projectRef: value.projectRef,
+    sub: value.sub,
+    iat: value.iat,
+    exp: value.exp,
+  };
 }

--- a/packages/pgredis-runtime/src/tenant-config.ts
+++ b/packages/pgredis-runtime/src/tenant-config.ts
@@ -30,7 +30,11 @@ function parseEnvironmentFile(content: string): Record<string, string> {
     const value = rawValue.trim();
     if (value.startsWith('"')) {
       try {
-        values[key] = JSON.parse(value) as string;
+        const parsed: unknown = JSON.parse(value);
+        if (typeof parsed !== "string") {
+          throw new TenantConfigError("Tenant pgredis configuration is invalid", 503);
+        }
+        values[key] = parsed;
       } catch {
         throw new TenantConfigError("Tenant pgredis configuration is invalid", 503);
       }

--- a/packages/supacloud-js/bun.lock
+++ b/packages/supacloud-js/bun.lock
@@ -5,29 +5,29 @@
     "": {
       "name": "@supacloud/js",
       "devDependencies": {
-        "@supabase/supabase-js": "^2.114.0",
+        "@supabase/supabase-js": "^2.115.0",
         "@types/bun": "^1.4.0",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.114.0",
+        "@supabase/supabase-js": "^2.115.0",
       },
     },
   },
   "packages": {
-    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.115.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.115.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.115.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.115.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.115.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.115.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.115.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.115.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.115.0.tgz", { "dependencies": { "@supabase/auth-js": "2.115.0", "@supabase/functions-js": "2.115.0", "@supabase/postgrest-js": "2.115.0", "@supabase/realtime-js": "2.115.0", "@supabase/storage-js": "2.115.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-PYJSxtCo37R7tTZW6pAqsxUeSx/dlhA7zn8RzKEUSCqyTxCUhG+iHrDTb04UyVBYbttaUbhwkNTvb8h5HW+uZA=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 

--- a/packages/supacloud-js/package.json
+++ b/packages/supacloud-js/package.json
@@ -42,11 +42,11 @@
     "directory": "packages/supacloud-js"
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^2.114.0"
+    "@supabase/supabase-js": "^2.115.0"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@supabase/supabase-js": "^2.114.0",
+    "@supabase/supabase-js": "^2.115.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/supacloud-js/src/auth-fetch.ts
+++ b/packages/supacloud-js/src/auth-fetch.ts
@@ -30,7 +30,7 @@ function parseRefreshBody(body: string, contentType: string): URLSearchParams | 
     let value: unknown;
     try { value = JSON.parse(body); } catch { return null; }
     if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-    const record = value as Record<string, unknown>;
+    const record = valueRecord(value);
     const refreshToken = typeof record.refresh_token === "string" ? record.refresh_token.trim() : "";
     if (!refreshToken) return null;
     const params = new URLSearchParams();
@@ -41,6 +41,13 @@ function parseRefreshBody(body: string, contentType: string): URLSearchParams | 
   }
   const params = new URLSearchParams(body);
   return params.get("refresh_token")?.trim() ? params : null;
+}
+
+function valueRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const record: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) record[key] = item;
+  return record;
 }
 
 function replacementRequest(

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -114,8 +114,12 @@ describe("@supacloud/js", () => {
             ? input.toString()
             : input.url;
       calls.push({ url, init });
+      const task = { id: "tsk_123", status: "running" };
+      const payload = url.includes("/tasks?") || url.includes("/tasks/dlq")
+        ? [task]
+        : task;
       return Promise.resolve(
-        new Response(JSON.stringify({ id: "tsk_123", status: "running" }), {
+        new Response(JSON.stringify(payload), {
           headers: { "content-type": "application/json" },
         }),
       );
@@ -236,8 +240,41 @@ describe("@supacloud/js", () => {
             ? input.toString()
             : input.url;
       calls.push({ url, init });
+      let payload: unknown;
+      if (url.endsWith("/tasks/queues")) {
+        payload = (init?.method ?? "GET") === "POST"
+          ? { queue_name: "emails" }
+          : [{ queue_name: "emails" }];
+      } else if (url.endsWith("/tasks/queues/emails")) {
+        payload = undefined;
+      } else if (url.endsWith("/messages?archived=true&limit=10")) {
+        payload = [{ id: "msg_123", msg_id: 123, payload: { hello: "world" } }];
+      } else if (url.endsWith("/stats")) {
+        payload = {
+          queue_name: "emails",
+          queue_length: 1,
+          newest_msg_age_sec: null,
+          oldest_msg_age_sec: null,
+          total_messages: 1,
+          scrape_time: "now",
+        };
+      } else if (url.endsWith("/settings")) {
+        payload = {
+          max_in_flight: 20,
+          default_visibility_timeout_sec: 60,
+          max_attempts: 3,
+          rate_limit_per_minute: 100,
+        };
+      } else if (url.endsWith("/purge")) {
+        payload = { queue_name: "emails", purged: 1 };
+      } else {
+        payload = { id: "msg_123", msg_id: 123, status: "leased", payload: { hello: "world" } };
+      }
+      if (url.endsWith("/tasks/queues/emails") && init?.method === "DELETE") {
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
       return Promise.resolve(
-        new Response(JSON.stringify({ id: "msg_123", status: "leased", payload: { hello: "world" } }), {
+        new Response(JSON.stringify(payload), {
           headers: { "content-type": "application/json" },
         }),
       );

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -443,6 +443,7 @@ export class SupaCloudApiError extends Error {
 }
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+type ResponseDecoder<T> = (value: unknown) => T;
 
 const TERMINAL_STATUSES = new Set<string>([
   "succeeded",
@@ -529,15 +530,273 @@ function normalizeMessageId(value: unknown): number {
 }
 
 function firstRpcValue(value: unknown): unknown {
-  return Array.isArray(value) ? value[0] : value;
+  return isUnknownArray(value) ? value[0] : value;
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function valueRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const record: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) record[key] = item;
+  return record;
+}
+
+function responseRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid ${label} response`);
+  }
+  return valueRecord(value);
+}
+
+function responseString(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Invalid ${label} response: ${key} is required`);
+  }
+  return value;
+}
+
+function responseNumber(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Invalid ${label} response: ${key} is required`);
+  }
+  return value;
+}
+
+function responseBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+): boolean {
+  const value = record[key];
+  if (typeof value !== "boolean") {
+    throw new Error(`Invalid ${label} response: ${key} is required`);
+  }
+  return value;
+}
+
+function decodeVoid(value: unknown): void {
+  if (value !== undefined) throw new Error("Expected an empty response");
+}
+
+function decodeTaskDetail(value: unknown): SupaCloudTaskDetail {
+  const record = responseRecord(value, "task");
+  return {
+    ...record,
+    id: responseString(record, "id", "task"),
+    status: responseString(record, "status", "task"),
+  };
+}
+
+function decodeTaskDetails(value: unknown): SupaCloudTaskDetail[] {
+  if (!Array.isArray(value)) throw new Error("Invalid task list response");
+  return value.map(decodeTaskDetail);
+}
+
+function decodeQueueMessage(value: unknown): SupaCloudQueueMessage {
+  const record = responseRecord(value, "queue message");
+  const messageValue = record.message ?? record.payload;
+  const message = valueRecord(messageValue);
+  return {
+    ...record,
+    id: responseString(record, "id", "queue message"),
+    msg_id: responseNumber(record, "msg_id", "queue message"),
+    message,
+    payload: message,
+  };
+}
+
+function decodeQueueMessages(value: unknown): SupaCloudQueueMessage[] {
+  if (!Array.isArray(value)) throw new Error("Invalid queue message list response");
+  return value.map(decodeQueueMessage);
+}
+
+function decodeQueueStats(value: unknown): SupaCloudQueueStats {
+  const record = responseRecord(value, "queue stats");
+  return {
+    ...record,
+    queue_name: responseString(record, "queue_name", "queue stats"),
+    queue_length: responseNumber(record, "queue_length", "queue stats"),
+    newest_msg_age_sec: record.newest_msg_age_sec === null
+      ? null
+      : responseNumber(record, "newest_msg_age_sec", "queue stats"),
+    oldest_msg_age_sec: record.oldest_msg_age_sec === null
+      ? null
+      : responseNumber(record, "oldest_msg_age_sec", "queue stats"),
+    total_messages: responseNumber(record, "total_messages", "queue stats"),
+    scrape_time: responseString(record, "scrape_time", "queue stats"),
+  };
+}
+
+function decodeQueueSettings(value: unknown): SupaCloudQueueSettings {
+  const record = responseRecord(value, "queue settings");
+  return {
+    max_in_flight: responseNumber(record, "max_in_flight", "queue settings"),
+    default_visibility_timeout_sec: responseNumber(
+      record,
+      "default_visibility_timeout_sec",
+      "queue settings",
+    ),
+    max_attempts: responseNumber(record, "max_attempts", "queue settings"),
+    rate_limit_per_minute: responseNumber(record, "rate_limit_per_minute", "queue settings"),
+  };
+}
+
+function decodeQueueInfo(value: unknown): SupaCloudQueueInfo {
+  const record = responseRecord(value, "queue info");
+  return {
+    ...record,
+    queue_name: responseString(record, "queue_name", "queue info"),
+  };
+}
+
+function decodeQueueInfos(value: unknown): SupaCloudQueueInfo[] {
+  if (!Array.isArray(value)) throw new Error("Invalid queue info list response");
+  return value.map(decodeQueueInfo);
+}
+
+function decodeOAuthServerStatus(value: unknown): SupaCloudOAuthServerStatus {
+  const record = responseRecord(value, "OAuth Server");
+  return {
+    ...record,
+    project_ref: responseString(record, "project_ref", "OAuth Server"),
+    account_isolated: responseBoolean(record, "account_isolated", "OAuth Server"),
+    enabled: responseBoolean(record, "enabled", "OAuth Server"),
+    allow_dynamic_registration: responseBoolean(record, "allow_dynamic_registration", "OAuth Server"),
+    issuer: responseString(record, "issuer", "OAuth Server"),
+    discovery_url: responseString(record, "discovery_url", "OAuth Server"),
+    jwks_url: responseString(record, "jwks_url", "OAuth Server"),
+    authorization_endpoint: responseString(record, "authorization_endpoint", "OAuth Server"),
+    token_endpoint: responseString(record, "token_endpoint", "OAuth Server"),
+  };
+}
+
+function decodeOAuthClient(value: unknown): SupaCloudOAuthClient {
+  const record = responseRecord(value, "OAuth client");
+  return {
+    ...record,
+    client_id: responseString(record, "client_id", "OAuth client"),
+  };
+}
+
+function decodeOAuthClientList(value: unknown): SupaCloudOAuthClientList {
+  const record = responseRecord(value, "OAuth client list");
+  const clients = record.clients;
+  if (clients === undefined) return record;
+  if (!Array.isArray(clients)) throw new Error("Invalid OAuth client list response");
+  return { ...record, clients: clients.map(decodeOAuthClient) };
+}
+
+function decodeSupAuthStepResult(value: unknown): SupaCloudSupAuthStepResult {
+  const record = responseRecord(value, "SupAuth step");
+  return {
+    ...record,
+    step: responseString(record, "step", "SupAuth step"),
+    status: responseString(record, "status", "SupAuth step"),
+  };
+}
+
+function decodeSupAuthProvisionResult(value: unknown): SupaCloudSupAuthProvisionResult {
+  const record = responseRecord(value, "SupAuth provision");
+  const steps = record.steps;
+  if (steps !== undefined && !Array.isArray(steps)) {
+    throw new Error("Invalid SupAuth provision response");
+  }
+  return {
+    ...record,
+    projectRef: responseString(record, "projectRef", "SupAuth provision"),
+    status: responseString(record, "status", "SupAuth provision"),
+    ...(steps === undefined ? {} : { steps: steps.map(decodeSupAuthStepResult) }),
+  };
+}
+
+function decodeSupAuthReconcileResult(value: unknown): SupaCloudSupAuthReconcileResult {
+  const record = responseRecord(value, "SupAuth reconcile");
+  const steps = record.steps;
+  if (steps !== undefined && !Array.isArray(steps)) {
+    throw new Error("Invalid SupAuth reconcile response");
+  }
+  return {
+    ...record,
+    projectRef: responseString(record, "projectRef", "SupAuth reconcile"),
+    changed: responseBoolean(record, "changed", "SupAuth reconcile"),
+    ...(steps === undefined ? {} : { steps: steps.map(decodeSupAuthStepResult) }),
+  };
+}
+
+function decodeSupAuthRollbackResult(value: unknown): SupaCloudSupAuthRollbackResult {
+  const record = responseRecord(value, "SupAuth rollback");
+  const steps = record.steps;
+  if (steps !== undefined && !Array.isArray(steps)) {
+    throw new Error("Invalid SupAuth rollback response");
+  }
+  return {
+    ...record,
+    projectRef: responseString(record, "projectRef", "SupAuth rollback"),
+    status: responseString(record, "status", "SupAuth rollback"),
+    ...(steps === undefined ? {} : { steps: steps.map(decodeSupAuthStepResult) }),
+  };
+}
+
+function decodeSupAuthClientConfig(value: unknown): SupaCloudSupAuthClientConfig {
+  const record = responseRecord(value, "SupAuth client config");
+  return {
+    ...record,
+    projectRef: responseString(record, "projectRef", "SupAuth client config"),
+    supabaseUrl: responseString(record, "supabaseUrl", "SupAuth client config"),
+    authUrl: responseString(record, "authUrl", "SupAuth client config"),
+    restUrl: responseString(record, "restUrl", "SupAuth client config"),
+    storageUrl: responseString(record, "storageUrl", "SupAuth client config"),
+    realtimeUrl: responseString(record, "realtimeUrl", "SupAuth client config"),
+    functionsUrl: responseString(record, "functionsUrl", "SupAuth client config"),
+  };
+}
+
+function decodeSupAuthVerification(value: unknown): SupaCloudSupAuthVerification {
+  const record = responseRecord(value, "SupAuth verification");
+  const checks = record.checks;
+  if (!isUnknownArray(checks)) throw new Error("Invalid SupAuth verification response");
+  return {
+    ...record,
+    projectRef: responseString(record, "projectRef", "SupAuth verification"),
+    healthy: responseBoolean(record, "healthy", "SupAuth verification"),
+    checks: checks.map((check) => {
+      const record = responseRecord(check, "SupAuth check");
+      return {
+        ...record,
+        name: responseString(record, "name", "SupAuth check"),
+        status: responseString(record, "status", "SupAuth check"),
+      };
+    }),
+  };
+}
+
+function decodePurgeResult(value: unknown): { queue_name: string; purged: number } {
+  const record = responseRecord(value, "queue purge");
+  return {
+    queue_name: responseString(record, "queue_name", "queue purge"),
+    purged: responseNumber(record, "purged", "queue purge"),
+  };
 }
 
 function normalizeRpcMessage(queueName: string, value: unknown, status?: string): SupaCloudQueueMessage | null {
   const row = firstRpcValue(value);
   if (!row || typeof row !== "object") return null;
-  const record = row as Record<string, unknown>;
+  const record = valueRecord(row);
   const message = record.message && typeof record.message === "object" && !Array.isArray(record.message)
-    ? record.message as Record<string, unknown>
+    ? valueRecord(record.message)
     : {};
   const msgId = normalizeMessageId(record.msg_id ?? record.id);
   return {
@@ -553,7 +812,7 @@ function normalizeRpcMessage(queueName: string, value: unknown, status?: string)
 }
 
 function normalizeRpcMessages(queueName: string, value: unknown, status?: string): SupaCloudQueueMessage[] {
-  const rows = Array.isArray(value) ? value : value == null ? [] : [value];
+  const rows = isUnknownArray(value) ? value : value == null ? [] : [value];
   return rows
     .map((row) => normalizeRpcMessage(queueName, row, status))
     .filter((row): row is SupaCloudQueueMessage => Boolean(row));
@@ -562,20 +821,20 @@ function normalizeRpcMessages(queueName: string, value: unknown, status?: string
 function normalizeRpcMessageId(value: unknown): number {
   const row = firstRpcValue(value);
   if (row && typeof row === "object") {
-    const record = row as Record<string, unknown>;
+    const record = valueRecord(row);
     return normalizeMessageId(record.msg_id ?? record.send ?? record.send_batch ?? record.id);
   }
   return normalizeMessageId(row);
 }
 
 function normalizeRpcMessageIds(value: unknown): number[] {
-  const rows = Array.isArray(value) ? value : value == null ? [] : [value];
+  const rows = isUnknownArray(value) ? value : value == null ? [] : [value];
   return rows.map((row) => normalizeRpcMessageId(row)).filter((id) => id > 0);
 }
 
 function extractErrorCode(body: unknown): string | null {
   if (!body || typeof body !== "object") return null;
-  const code = (body as Record<string, unknown>).code;
+  const code = valueRecord(body).code;
   return typeof code === "string" ? code : null;
 }
 
@@ -583,7 +842,8 @@ async function readResponseBody(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) return undefined;
   try {
-    return JSON.parse(text) as unknown;
+    const parsed: unknown = JSON.parse(text);
+    return parsed;
   } catch {
     return text;
   }
@@ -598,7 +858,7 @@ async function defaultAccessTokenResolver(
 }
 
 function normalizeTaskSnapshot(task: unknown): SupaCloudTaskSnapshot {
-  const value = (task ?? {}) as Record<string, unknown>;
+  const value = valueRecord(task ?? {});
   return {
     id: String(value.id ?? ""),
     status: String(value.status ?? "unknown"),
@@ -632,7 +892,12 @@ class SupaCloudManagementClient<TClient extends SupabaseClient = SupabaseClient>
     return token;
   }
 
-  protected async request<T>(path: string, method: HttpMethod, body?: unknown): Promise<T> {
+  protected async request<T>(
+    path: string,
+    method: HttpMethod,
+    body: unknown,
+    decode: ResponseDecoder<T>,
+  ): Promise<T> {
     const accessToken = await this.resolveAccessToken();
     const response = await fetch(`${this.options.managementApiUrl}${path}`, {
       method,
@@ -643,18 +908,19 @@ class SupaCloudManagementClient<TClient extends SupabaseClient = SupabaseClient>
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
 
-    if (response.status === 204) return undefined as T;
+    if (response.status === 204) return decode(undefined);
 
     const responseBody = await readResponseBody(response);
     if (!response.ok) {
+      const responseRecord = valueRecord(responseBody);
       const message =
-        responseBody && typeof responseBody === "object" && typeof (responseBody as Record<string, unknown>).message === "string"
-          ? String((responseBody as Record<string, unknown>).message)
+        typeof responseRecord.message === "string"
+          ? responseRecord.message
           : `SupaCloud request failed (${response.status})`;
       throw new SupaCloudApiError(message, response.status, responseBody);
     }
 
-    return responseBody as T;
+    return decode(responseBody);
   }
 }
 
@@ -687,15 +953,16 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
       ...(options.businessTaskId ? { "x-supacloud-business-task-id": options.businessTaskId } : {}),
       ...(options.metadata ? { "x-supacloud-task-metadata": JSON.stringify(options.metadata) } : {}),
     };
-    const { data, error } = await this.options.supabase.functions.invoke(functionName, {
+    const invocation: { data: unknown; error: unknown } = await this.options.supabase.functions.invoke(functionName, {
       body,
       method,
       headers: invokeHeaders,
     });
+    const { data, error } = invocation;
 
     if (error) throw error;
 
-    const payload = (data ?? {}) as Record<string, unknown>;
+    const payload = valueRecord(data ?? {});
     const taskId =
       typeof payload.task_id === "string"
         ? payload.task_id
@@ -717,6 +984,8 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudTaskDetail>(
       `/v1/projects/${this.options.projectRef}/tasks/${taskId}`,
       "GET",
+      undefined,
+      decodeTaskDetail,
     );
   }
 
@@ -724,6 +993,8 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudTaskDetail[]>(
       `/v1/projects/${this.options.projectRef}/tasks${createQueryString(filters)}`,
       "GET",
+      undefined,
+      decodeTaskDetails,
     );
   }
 
@@ -731,6 +1002,8 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudTaskDetail>(
       `/v1/projects/${this.options.projectRef}/tasks/${taskId}/cancel`,
       "POST",
+      undefined,
+      decodeTaskDetail,
     );
   }
 
@@ -738,6 +1011,8 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudTaskDetail>(
       `/v1/projects/${this.options.projectRef}/tasks/${taskId}/retry`,
       "POST",
+      undefined,
+      decodeTaskDetail,
     );
   }
 
@@ -745,6 +1020,8 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudTaskDetail[]>(
       `/v1/projects/${this.options.projectRef}/tasks/dlq?limit=${limit}`,
       "GET",
+      undefined,
+      decodeTaskDetails,
     );
   }
 
@@ -964,26 +1241,27 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return encodeURIComponent(this.name);
   }
 
-  private async rpc<T>(fn: string, params: Record<string, unknown>): Promise<T> {
-    const scopedClient = (this.options.supabase as unknown as {
-      schema: (name: string) => {
-        rpc: (fn: string, params: Record<string, unknown>) => Promise<{ data: unknown; error: unknown }>;
-      };
-    }).schema("pgmq_public");
-    const { data, error } = await scopedClient.rpc(fn, params);
+  private async rpc<T>(
+    fn: string,
+    params: Record<string, unknown>,
+    decode: ResponseDecoder<T>,
+  ): Promise<T> {
+    const scopedClient = this.options.supabase.schema("pgmq_public");
+    const rpcResult: { data: unknown; error: unknown } = await scopedClient.rpc(fn, params);
+    const { data, error } = rpcResult;
     if (error) throw error;
-    return data as T;
+    return decode(data);
   }
 
   async send(
     payload: Record<string, unknown> = {},
     options: SupaCloudQueueSendOptions = {},
   ): Promise<SupaCloudQueueSendResult> {
-    const msgId = normalizeRpcMessageId(await this.rpc("send", {
+    const msgId = await this.rpc("send", {
       queue_name: this.name,
       message: payload,
       sleep_seconds: normalizeSecondsFromOptions(options),
-    }));
+    }, normalizeRpcMessageId);
     return {
       id: String(msgId),
       msg_id: msgId,
@@ -997,11 +1275,11 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     messages: Record<string, unknown>[],
     options: SupaCloudQueueSendOptions = {},
   ): Promise<SupaCloudQueueSendResult[]> {
-    const ids = normalizeRpcMessageIds(await this.rpc("send_batch", {
+    const ids = await this.rpc("send_batch", {
       queue_name: this.name,
       messages,
       sleep_seconds: normalizeSecondsFromOptions(options),
-    }));
+    }, normalizeRpcMessageIds);
     return ids.map((msgId, index) => ({
       id: String(msgId),
       msg_id: msgId,
@@ -1014,15 +1292,11 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
   async read(
     options: SupaCloudQueueReceiveOptions = {},
   ): Promise<SupaCloudQueueMessage[]> {
-    return normalizeRpcMessages(
-      this.name,
-      await this.rpc("read", {
-        queue_name: this.name,
-        sleep_seconds: normalizeSecondsFromOptions(options),
-        n: Math.max(1, Math.floor(options.n ?? options.count ?? 1)),
-      }),
-      "leased",
-    );
+    return this.rpc("read", {
+      queue_name: this.name,
+      sleep_seconds: normalizeSecondsFromOptions(options),
+      n: Math.max(1, Math.floor(options.n ?? options.count ?? 1)),
+    }, (value) => normalizeRpcMessages(this.name, value, "leased"));
   }
 
   async receive(
@@ -1033,17 +1307,16 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
   }
 
   async pop(): Promise<SupaCloudQueueMessage | null> {
-    return normalizeRpcMessage(
-      this.name,
-      await this.rpc("pop", { queue_name: this.name }),
-      "deleted",
-    );
+    return this.rpc("pop", { queue_name: this.name }, (value) =>
+      normalizeRpcMessage(this.name, value, "deleted"));
   }
 
   async list(filters: SupaCloudQueueListFilters = {}): Promise<SupaCloudQueueMessage[]> {
     return this.request<SupaCloudQueueMessage[]>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages${createQueueQueryString(filters)}`,
       "GET",
+      undefined,
+      decodeQueueMessages,
     );
   }
 
@@ -1059,6 +1332,8 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudQueueStats>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/stats`,
       "GET",
+      undefined,
+      decodeQueueStats,
     );
   }
 
@@ -1066,6 +1341,8 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudQueueSettings>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/settings`,
       "GET",
+      undefined,
+      decodeQueueSettings,
     );
   }
 
@@ -1074,15 +1351,16 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/settings`,
       "PATCH",
       settings,
+      decodeQueueSettings,
     );
   }
 
   async archive(messageId: string | number): Promise<SupaCloudQueueMutationResult> {
     const msgId = normalizeMessageId(messageId);
-    const success = Boolean(firstRpcValue(await this.rpc("archive", {
+    const success = await this.rpc("archive", {
       queue_name: this.name,
       message_id: msgId,
-    })));
+    }, (value) => Boolean(firstRpcValue(value)));
     return { id: String(msgId), msg_id: msgId, queue_name: this.name, status: "archived", success };
   }
 
@@ -1092,10 +1370,10 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
 
   async delete(messageId: string | number): Promise<SupaCloudQueueMutationResult> {
     const msgId = normalizeMessageId(messageId);
-    const success = Boolean(firstRpcValue(await this.rpc("delete", {
+    const success = await this.rpc("delete", {
       queue_name: this.name,
       message_id: msgId,
-    })));
+    }, (value) => Boolean(firstRpcValue(value)));
     return { id: String(msgId), msg_id: msgId, queue_name: this.name, status: "deleted", success };
   }
 
@@ -1110,6 +1388,7 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
         sleep_seconds: normalizeSecondsFromOptions(options),
         ...(options.error ? { error: options.error } : {}),
       },
+      decodeQueueMessage,
     );
   }
 
@@ -1117,6 +1396,8 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<{ queue_name: string; purged: number }>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/purge`,
       "POST",
+      undefined,
+      decodePurgeResult,
     );
   }
 
@@ -1138,6 +1419,8 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudQueueMessage>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}`,
       "GET",
+      undefined,
+      decodeQueueMessage,
     );
   }
 
@@ -1148,6 +1431,8 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return this.request<SupaCloudQueueMessage>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/retry`,
       "POST",
+      undefined,
+      decodeQueueMessage,
     );
   }
 }
@@ -1157,6 +1442,8 @@ class SupaCloudQueuesClient<TClient extends SupabaseClient = SupabaseClient> ext
     return this.request<SupaCloudQueueInfo[]>(
       `/v1/projects/${this.options.projectRef}/tasks/queues`,
       "GET",
+      undefined,
+      decodeQueueInfos,
     );
   }
 
@@ -1165,6 +1452,7 @@ class SupaCloudQueuesClient<TClient extends SupabaseClient = SupabaseClient> ext
       `/v1/projects/${this.options.projectRef}/tasks/queues`,
       "POST",
       { queue_name: queueName, unlogged: options.unlogged },
+      decodeQueueInfo,
     );
   }
 
@@ -1172,6 +1460,8 @@ class SupaCloudQueuesClient<TClient extends SupabaseClient = SupabaseClient> ext
     await this.request<void>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${encodeURIComponent(queueName)}`,
       "DELETE",
+      undefined,
+      decodeVoid,
     );
   }
 }
@@ -1181,6 +1471,8 @@ class SupaCloudOAuthServerClient<TClient extends SupabaseClient = SupabaseClient
     return this.request<SupaCloudOAuthServerStatus>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-server`,
       "GET",
+      undefined,
+      decodeOAuthServerStatus,
     );
   }
 
@@ -1197,6 +1489,7 @@ class SupaCloudOAuthServerClient<TClient extends SupabaseClient = SupabaseClient
           ? {}
           : { authorization_path: options.authorizationPath }),
       },
+      decodeOAuthServerStatus,
     );
   }
 
@@ -1204,14 +1497,16 @@ class SupaCloudOAuthServerClient<TClient extends SupabaseClient = SupabaseClient
     const status = await this.getStatus();
     const response = await fetch(status.discovery_url);
     if (!response.ok) throw new Error(`SupaCloud OIDC discovery failed (${response.status})`);
-    return await response.json() as Record<string, unknown>;
+    const payload: unknown = await response.json();
+    return valueRecord(payload);
   }
 
   async getJwks(): Promise<Record<string, unknown>> {
     const status = await this.getStatus();
     const response = await fetch(status.jwks_url);
     if (!response.ok) throw new Error(`SupaCloud JWKS fetch failed (${response.status})`);
-    return await response.json() as Record<string, unknown>;
+    const payload: unknown = await response.json();
+    return valueRecord(payload);
   }
 
   async buildAuthorizeUrl(options: SupaCloudAuthorizeUrlOptions): Promise<string> {
@@ -1236,6 +1531,8 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
     return this.request<SupaCloudOAuthClientList>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients`,
       "GET",
+      undefined,
+      decodeOAuthClientList,
     );
   }
 
@@ -1244,6 +1541,7 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients`,
       "POST",
       input,
+      decodeOAuthClient,
     );
   }
 
@@ -1251,6 +1549,8 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
     return this.request<SupaCloudOAuthClient>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients/${encodeURIComponent(clientId)}`,
       "GET",
+      undefined,
+      decodeOAuthClient,
     );
   }
 
@@ -1259,6 +1559,7 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients/${encodeURIComponent(clientId)}`,
       "PUT",
       patch,
+      decodeOAuthClient,
     );
   }
 
@@ -1266,6 +1567,8 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
     await this.request<void>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients/${encodeURIComponent(clientId)}`,
       "DELETE",
+      undefined,
+      decodeVoid,
     );
   }
 
@@ -1273,6 +1576,8 @@ class SupaCloudOAuthClientsClient<TClient extends SupabaseClient = SupabaseClien
     return this.request<SupaCloudOAuthClient>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-clients/${encodeURIComponent(clientId)}/regenerate-secret`,
       "POST",
+      undefined,
+      decodeOAuthClient,
     );
   }
 }
@@ -1289,6 +1594,7 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
       `${this.basePath}/provision`,
       "POST",
       options,
+      decodeSupAuthProvisionResult,
     );
   }
 
@@ -1299,6 +1605,7 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
       `${this.basePath}/reconcile`,
       "POST",
       options,
+      decodeSupAuthReconcileResult,
     );
   }
 
@@ -1306,6 +1613,8 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
     return this.request<SupaCloudSupAuthRollbackResult>(
       `${this.basePath}/rollback`,
       "POST",
+      undefined,
+      decodeSupAuthRollbackResult,
     );
   }
 
@@ -1313,6 +1622,8 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
     return this.request<SupaCloudSupAuthClientConfig>(
       `${this.basePath}/client-config`,
       "GET",
+      undefined,
+      decodeSupAuthClientConfig,
     );
   }
 
@@ -1320,6 +1631,8 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
     return this.request<SupaCloudSupAuthVerification>(
       `${this.basePath}/verify`,
       "GET",
+      undefined,
+      decodeSupAuthVerification,
     );
   }
 }

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -457,7 +457,7 @@ function waitForPollingInterval(
   signal?: AbortSignal,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    let settled = false;
+    let settled: boolean = false;
     const finish = (settle: () => void) => {
       if (settled) return;
       settled = true;
@@ -767,7 +767,7 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
   }
 
   subscribe(taskId: string, options: SupaCloudTaskSubscribeOptions) {
-    let closed = false;
+    let closed: boolean = false;
     let channel: RealtimeChannel | null = null;
     let pollTimer: ReturnType<typeof setTimeout> | null = null;
     let realtimeTimeoutTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/supacloud-js/src/service-role-rpc.ts
+++ b/packages/supacloud-js/src/service-role-rpc.ts
@@ -1,22 +1,15 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-type ServiceRoleRpcClient = {
-  rpc(
-    rpcName: string,
-    params: { request: object },
-  ): Promise<{ data: unknown; error: unknown }>;
-};
-
 export async function invokeServiceRoleRpc<T>(
   supabase: SupabaseClient,
   functionName: string,
   request: object,
 ): Promise<T> {
-  const rpcClient = supabase as unknown as ServiceRoleRpcClient;
-  const { data: rpcResponse, error: rpcError } = await rpcClient.rpc(
+  const rpcResult: { data: unknown; error: unknown } = await supabase.rpc(
     functionName,
     { request },
   );
+  const { data: rpcResponse, error: rpcError } = rpcResult;
   if (rpcError) throw rpcError;
   return rpcResponse as T;
 }

--- a/packages/supacloud-lite/bun.lock
+++ b/packages/supacloud-lite/bun.lock
@@ -10,7 +10,7 @@
         "tar": "^7.5.22",
       },
       "devDependencies": {
-        "@supabase/supabase-js": "^2.114.0",
+        "@supabase/supabase-js": "^2.115.0",
         "@types/bun": "^1.4.0",
         "elysia": "^1.4.30",
         "typescript": "^7.0.2",
@@ -26,19 +26,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.115.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YNQlQWm1H0gsXHSY8Jd/xepBhjO0Zhwx04iW17A83/joQ5kFiUin6iPj9s9kZZvupnwLjXVP/diTFiLz2jUbwQ=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.115.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-p97V6/YFcdp+zblFDVJaE8f9rGKTNz0PRzyJ2d1w/EYIU5lwidKuc3l/wM+u27ACmAC62albvoGiUGzLPSg7Aw=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.115.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.115.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DdERcurLh5t84pgSywDg2LjLR5le7XAzl52/iQhC7FdboWDqGfDPMfaWJV3MHvhyxSlSNzbpSQG+RiQOBSn/4w=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.115.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.115.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-5HyBkvlA/IUV2v8jX3uLTdy15jmTPRVXwXKoxvH2SKw5jZMNURxCxt+VpCEukscXQlY7pUpH8Cy4NH6io4iaRw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.115.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.115.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-dLyIxzbO+MCcKHhcce8rVUCQX1iyqXqQ8ytgkOVYJ7D+Zp0qKylPtQH3hamgxrGSxtDjaw47Urpzw2iK9PsKdA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.115.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.115.0.tgz", { "dependencies": { "@supabase/auth-js": "2.115.0", "@supabase/functions-js": "2.115.0", "@supabase/postgrest-js": "2.115.0", "@supabase/realtime-js": "2.115.0", "@supabase/storage-js": "2.115.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-PYJSxtCo37R7tTZW6pAqsxUeSx/dlhA7zn8RzKEUSCqyTxCUhG+iHrDTb04UyVBYbttaUbhwkNTvb8h5HW+uZA=="],
 
     "@supacloud/db": ["@supacloud/db@0.2.0", "https://registry.npmmirror.com/@supacloud/db/-/db-0.2.0.tgz", {}, "sha512-rJKMCJqMZf4oQ+x9bOnCoYO6REQqwIcSEwugPjvMfoiCbBo7vhkpytKWfj60UJJl0IJIUjmIZMu4xI2U2Okigg=="],
 

--- a/packages/supacloud-lite/package.json
+++ b/packages/supacloud-lite/package.json
@@ -54,7 +54,7 @@
     "tar": "^7.5.22"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "^2.114.0",
+    "@supabase/supabase-js": "^2.115.0",
     "@types/bun": "^1.4.0",
     "elysia": "^1.4.30",
     "typescript": "^7.0.2"

--- a/packages/supacloud-lite/scripts/standalone-native-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-native-smoke.ts
@@ -241,7 +241,7 @@ async function expectWorkflowLeaseRecovery(workflows: WorkflowClient): Promise<v
   ], 'reclaimed lease claim')
   assert(reclaimed.runId === runId && reclaimed.attempt === 2, 'workflow lease was not reclaimed at attempt two')
   assert(await rejectedCode(() => workflows.complete({ ...attemptRequest(expired), runOutput: { stale: true } })) === '40001', 'stale worker completion was accepted')
-  const retryRequest = { ...attemptRequest(reclaimed), errorMessage: 'retry once', delaySeconds: 0 }
+  const retryRequest = { ...attemptRequest(reclaimed), errorMessage: 'retry once', delaySeconds: 0 } satisfies Parameters<WorkflowClient['retry']>[0]
   const retried = await workflows.retry(retryRequest)
   const repeated = await workflows.retry(retryRequest)
   assert(retried.steps[0]?.status === 'queued' && repeated.idempotent, 'workflow retry was not idempotent')
@@ -407,7 +407,7 @@ async function withServer<T>(
 ): Promise<T> {
   const port = await findEphemeralPort()
   const server = startNativeServer(environment, port)
-  let checkCompleted = false
+  let checkCompleted: boolean = false
   try {
     const url = `http://127.0.0.1:${port}`
     await waitForHealth(url, server.processHandle)
@@ -455,7 +455,7 @@ function isRequestedShutdown(exitCode: number): boolean {
 }
 
 async function waitForHealth(url: string, processHandle: Bun.Subprocess): Promise<void> {
-  for (let attempt = 0; attempt < 600; attempt++) {
+  for (let attempt: number = 0; attempt < 600; attempt++) {
     if (processHandle.exitCode !== null) throw new Error(`standalone native server exited before health (${processHandle.exitCode})`)
     try {
       if ((await fetch(`${url}/health`)).ok) return

--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -238,7 +238,7 @@ async function withServer(options: ServerOptions, check: (url: string) => Promis
   const stdout = new Response(processHandle.stdout).text()
   const stderr = new Response(processHandle.stderr).text()
   const url = `http://127.0.0.1:${port}`
-  let checkCompleted = false
+  let checkCompleted: boolean = false
   try {
     await waitForHealth(url, processHandle)
     console.log(`[standalone-smoke] ${options.phaseLabel}: healthy`)
@@ -269,7 +269,7 @@ function expectedStandaloneShutdownExitCode(): number {
 }
 
 async function waitForHealth(url: string, processHandle: Bun.Subprocess): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt++) {
+  for (let attempt: number = 0; attempt < 100; attempt++) {
     if (processHandle.exitCode !== null) throw new Error(`standalone server exited before becoming healthy (${processHandle.exitCode})`)
     try {
       if ((await fetch(`${url}/health`)).ok) return

--- a/packages/supacloud-lite/scripts/subprocess.ts
+++ b/packages/supacloud-lite/scripts/subprocess.ts
@@ -29,7 +29,7 @@ export interface BufferedCommandExecution {
 export async function executeBufferedCommand(options: BufferedCommandOptions): Promise<BufferedCommandExecution> {
   const timeoutController = new AbortController()
   const processHandle = spawnBufferedCommand(options, timeoutController.signal)
-  let timedOut = false
+  let timedOut: boolean = false
   const timeout = setTimeout(() => {
     timedOut = true
     timeoutController.abort()

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -52,7 +52,7 @@ function parseArgs(argv: string[]): CliOptions {
     json: false,
   }
 
-  for (let index = 0; index < args.length; index++) {
+  for (let index: number = 0; index < args.length; index++) {
     const argument = args[index]!
     const next = () => {
       const value = args[++index]
@@ -525,7 +525,7 @@ function formatDatabaseEngine(engine: NonNullable<ProjectRuntimeOptions['engine'
   return dataDir ? `${label} (${dataDir})` : `${label} (memory)`
 }
 
-let exitCode = 0
+let exitCode: number = 0
 try {
   await main()
 } catch (error) {

--- a/packages/supacloud-lite/src/runtime/auth/handler.ts
+++ b/packages/supacloud-lite/src/runtime/auth/handler.ts
@@ -127,7 +127,7 @@ function authError(status: number, errorCode: string, msg: string): Response {
 /** A cryptographically-random numeric OTP of `length` digits (6-10). */
 function randomOtp(length: number): string {
   const n = Math.max(6, Math.min(10, Math.floor(length)))
-  let code = ''
+  let code: string = ''
   // 250 is the largest multiple of 10 below 256. Rejecting bytes >=250 avoids
   // modulo bias while keeping the code cryptographically random.
   while (code.length < n) {

--- a/packages/supacloud-lite/src/runtime/auth/oauth.ts
+++ b/packages/supacloud-lite/src/runtime/auth/oauth.ts
@@ -332,7 +332,7 @@ function redirect(location: string): Response {
 }
 
 function base64url(bytes: Uint8Array): string {
-  let bin = ''
+  let bin: string = ''
   for (const b of bytes) bin += String.fromCharCode(b)
   return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }

--- a/packages/supacloud-lite/src/runtime/auth/password.ts
+++ b/packages/supacloud-lite/src/runtime/auth/password.ts
@@ -6,7 +6,7 @@ function toHex(bytes: Uint8Array): string {
 
 function fromHex(hex: string): Uint8Array {
   const out = new Uint8Array(hex.length / 2)
-  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  for (let i: number = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
   return out
 }
 
@@ -57,7 +57,7 @@ export async function verifyPassword(password: string, stored: string): Promise<
   if (actual.length !== expected.length) return false
   // SECURITY: constant-time compare over the full hash to avoid leaking a
   // match prefix via timing.
-  let diff = 0
-  for (let i = 0; i < actual.length; i++) diff |= actual.charCodeAt(i) ^ expected.charCodeAt(i)
+  let diff: number = 0
+  for (let i: number = 0; i < actual.length; i++) diff |= actual.charCodeAt(i) ^ expected.charCodeAt(i)
   return diff === 0
 }

--- a/packages/supacloud-lite/src/runtime/auth/qr.ts
+++ b/packages/supacloud-lite/src/runtime/auth/qr.ts
@@ -6,7 +6,7 @@
  */
 
 // Error-correction level → format bits. We use M (medium) like GoTrue.
-const ECC_M = { ordinal: 0, formatBits: 0 }
+const ECC_M = { ordinal: 0, formatBits: 0 } as const
 
 const ECC_CODEWORDS_PER_BLOCK = [
   // index by version (1..40); level M row
@@ -37,9 +37,9 @@ function getNumDataCodewords(ver: number): number {
 function reedSolomonComputeDivisor(degree: number): Uint8Array {
   const result = new Uint8Array(degree)
   result[degree - 1] = 1
-  let root = 1
-  for (let i = 0; i < degree; i++) {
-    for (let j = 0; j < result.length; j++) {
+  let root: number = 1
+  for (let i: number = 0; i < degree; i++) {
+    for (let j: number = 0; j < result.length; j++) {
       result[j] = reedSolomonMultiply(result[j], root)
       if (j + 1 < result.length) result[j] ^= result[j + 1]
     }
@@ -53,13 +53,13 @@ function reedSolomonComputeRemainder(data: Uint8Array, divisor: Uint8Array): Uin
     const factor = b ^ result[0]
     result.copyWithin(0, 1)
     result[result.length - 1] = 0
-    for (let i = 0; i < result.length; i++) result[i] ^= reedSolomonMultiply(divisor[i], factor)
+    for (let i: number = 0; i < result.length; i++) result[i] ^= reedSolomonMultiply(divisor[i], factor)
   }
   return result
 }
 function reedSolomonMultiply(x: number, y: number): number {
-  let z = 0
-  for (let i = 7; i >= 0; i--) {
+  let z: number = 0
+  for (let i: number = 7; i >= 0; i--) {
     z = (z << 1) ^ ((z >>> 7) * 0x11d)
     z ^= ((y >>> i) & 1) * x
   }
@@ -74,7 +74,7 @@ class QrCode {
   static encodeText(text: string): QrCode {
     const bytes = new TextEncoder().encode(text)
     // byte-mode segment bit length = 4 (mode) + charCountBits + 8*len
-    let version = 1
+    let version: number = 1
     for (; version <= 40; version++) {
       const dataCapacityBits = getNumDataCodewords(version) * 8
       const ccBits = version < 10 ? 8 : 16
@@ -94,10 +94,10 @@ class QrCode {
     const dataCapacityBits = getNumDataCodewords(version) * 8
     append(0, Math.min(4, dataCapacityBits - bb.length))
     while (bb.length % 8 !== 0) bb.push(0)
-    for (let pad = 0xec; bb.length < dataCapacityBits; pad ^= 0xec ^ 0x11) append(pad, 8)
+    for (let pad: number = 0xec; bb.length < dataCapacityBits; pad ^= 0xec ^ 0x11) append(pad, 8)
 
     const dataCodewords = new Uint8Array(bb.length / 8)
-    for (let i = 0; i < bb.length; i++) dataCodewords[i >>> 3] |= bb[i] << (7 - (i & 7))
+    for (let i: number = 0; i < bb.length; i++) dataCodewords[i >>> 3] |= bb[i] << (7 - (i & 7))
 
     return new QrCode(version, dataCodewords)
   }
@@ -114,8 +114,8 @@ class QrCode {
 
     // pick the mask with the lowest penalty (all masks are valid; this is polish)
     let minPenalty = Infinity
-    let bestMask = 0
-    for (let mask = 0; mask < 8; mask++) {
+    let bestMask: number = 0
+    for (let mask: number = 0; mask < 8; mask++) {
       this.applyMask(mask)
       this.drawFormatBits(mask)
       const penalty = this.getPenaltyScore()
@@ -138,7 +138,7 @@ class QrCode {
   }
 
   private drawFunctionPatterns(): void {
-    for (let i = 0; i < this.size; i++) {
+    for (let i: number = 0; i < this.size; i++) {
       this.setFunctionModule(6, i, i % 2 === 0)
       this.setFunctionModule(i, 6, i % 2 === 0)
     }
@@ -148,8 +148,8 @@ class QrCode {
 
     const alignPos = this.getAlignmentPatternPositions()
     const n = alignPos.length
-    for (let i = 0; i < n; i++) {
-      for (let j = 0; j < n; j++) {
+    for (let i: number = 0; i < n; i++) {
+      for (let j: number = 0; j < n; j++) {
         if (!((i === 0 && j === 0) || (i === 0 && j === n - 1) || (i === n - 1 && j === 0)))
           this.drawAlignmentPattern(alignPos[i], alignPos[j])
       }
@@ -161,24 +161,24 @@ class QrCode {
   private drawFormatBits(mask: number): void {
     const data = (ECC_M.formatBits << 3) | mask
     let rem = data
-    for (let i = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >>> 9) * 0x537)
+    for (let i: number = 0; i < 10; i++) rem = (rem << 1) ^ ((rem >>> 9) * 0x537)
     const bits = ((data << 10) | rem) ^ 0x5412
-    for (let i = 0; i <= 5; i++) this.setFunctionModule(8, i, ((bits >>> i) & 1) !== 0)
+    for (let i: number = 0; i <= 5; i++) this.setFunctionModule(8, i, ((bits >>> i) & 1) !== 0)
     this.setFunctionModule(8, 7, ((bits >>> 6) & 1) !== 0)
     this.setFunctionModule(8, 8, ((bits >>> 7) & 1) !== 0)
     this.setFunctionModule(7, 8, ((bits >>> 8) & 1) !== 0)
-    for (let i = 9; i < 15; i++) this.setFunctionModule(14 - i, 8, ((bits >>> i) & 1) !== 0)
-    for (let i = 0; i < 8; i++) this.setFunctionModule(this.size - 1 - i, 8, ((bits >>> i) & 1) !== 0)
-    for (let i = 8; i < 15; i++) this.setFunctionModule(8, this.size - 15 + i, ((bits >>> i) & 1) !== 0)
+    for (let i: number = 9; i < 15; i++) this.setFunctionModule(14 - i, 8, ((bits >>> i) & 1) !== 0)
+    for (let i: number = 0; i < 8; i++) this.setFunctionModule(this.size - 1 - i, 8, ((bits >>> i) & 1) !== 0)
+    for (let i: number = 8; i < 15; i++) this.setFunctionModule(8, this.size - 15 + i, ((bits >>> i) & 1) !== 0)
     this.setFunctionModule(8, this.size - 8, true)
   }
 
   private drawVersion(): void {
     if (this.version < 7) return
     let rem = this.version
-    for (let i = 0; i < 12; i++) rem = (rem << 1) ^ ((rem >>> 11) * 0x1f25)
+    for (let i: number = 0; i < 12; i++) rem = (rem << 1) ^ ((rem >>> 11) * 0x1f25)
     const bits = (this.version << 12) | rem
-    for (let i = 0; i < 18; i++) {
+    for (let i: number = 0; i < 18; i++) {
       const bit = ((bits >>> i) & 1) !== 0
       const a = this.size - 11 + (i % 3)
       const b = Math.floor(i / 3)
@@ -224,8 +224,8 @@ class QrCode {
 
     const blocks: Uint8Array[] = []
     const rsDiv = reedSolomonComputeDivisor(blockEccLen)
-    let k = 0
-    for (let i = 0; i < numBlocks; i++) {
+    let k: number = 0
+    for (let i: number = 0; i < numBlocks; i++) {
       const datLen = shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1)
       const dat = data.slice(k, k + datLen)
       k += datLen
@@ -237,9 +237,9 @@ class QrCode {
     }
 
     const result = new Uint8Array(rawCodewords)
-    let ri = 0
-    for (let i = 0; i < blocks[0].length; i++) {
-      for (let j = 0; j < blocks.length; j++) {
+    let ri: number = 0
+    for (let i: number = 0; i < blocks[0].length; i++) {
+      for (let j: number = 0; j < blocks.length; j++) {
         // skip the unused cell in short blocks' data region
         if (i !== shortBlockLen - blockEccLen || j >= numShortBlocks) {
           result[ri++] = blocks[j][i]
@@ -250,11 +250,11 @@ class QrCode {
   }
 
   private drawCodewords(data: Uint8Array): void {
-    let i = 0
+    let i: number = 0
     for (let right = this.size - 1; right >= 1; right -= 2) {
       if (right === 6) right = 5
-      for (let vert = 0; vert < this.size; vert++) {
-        for (let j = 0; j < 2; j++) {
+      for (let vert: number = 0; vert < this.size; vert++) {
+        for (let j: number = 0; j < 2; j++) {
           const x = right - j
           const upward = ((right + 1) & 2) === 0
           const y = upward ? this.size - 1 - vert : vert
@@ -268,9 +268,9 @@ class QrCode {
   }
 
   private applyMask(mask: number): void {
-    for (let y = 0; y < this.size; y++) {
-      for (let x = 0; x < this.size; x++) {
-        let invert = false
+    for (let y: number = 0; y < this.size; y++) {
+      for (let x: number = 0; x < this.size; x++) {
+        let invert: boolean = false
         switch (mask) {
           case 0: invert = (x + y) % 2 === 0; break
           case 1: invert = y % 2 === 0; break
@@ -287,13 +287,13 @@ class QrCode {
   }
 
   private getPenaltyScore(): number {
-    let result = 0
+    let result: number = 0
     const size = this.size
     // adjacent same-color runs in rows/columns
-    for (let y = 0; y < size; y++) {
-      let runColor = false
-      let runLen = 0
-      for (let x = 0; x < size; x++) {
+    for (let y: number = 0; y < size; y++) {
+      let runColor: boolean = false
+      let runLen: number = 0
+      for (let x: number = 0; x < size; x++) {
         if (this.modules[y][x] === runColor) {
           runLen++
           if (runLen === 5) result += 3
@@ -304,10 +304,10 @@ class QrCode {
         }
       }
     }
-    for (let x = 0; x < size; x++) {
-      let runColor = false
-      let runLen = 0
-      for (let y = 0; y < size; y++) {
+    for (let x: number = 0; x < size; x++) {
+      let runColor: boolean = false
+      let runLen: number = 0
+      for (let y: number = 0; y < size; y++) {
         if (this.modules[y][x] === runColor) {
           runLen++
           if (runLen === 5) result += 3
@@ -319,15 +319,15 @@ class QrCode {
       }
     }
     // 2x2 blocks
-    for (let y = 0; y < size - 1; y++) {
-      for (let x = 0; x < size - 1; x++) {
+    for (let y: number = 0; y < size - 1; y++) {
+      for (let x: number = 0; x < size - 1; x++) {
         const c = this.modules[y][x]
         if (c === this.modules[y][x + 1] && c === this.modules[y + 1][x] && c === this.modules[y + 1][x + 1])
           result += 3
       }
     }
     // proportion of dark modules
-    let dark = 0
+    let dark: number = 0
     for (const rowArr of this.modules) for (const v of rowArr) if (v) dark++
     const total = size * size
     const k = Math.ceil(Math.abs(dark * 20 - total * 10) / total) - 1
@@ -339,8 +339,8 @@ class QrCode {
   toSvgString(border: number): string {
     const dim = this.size + border * 2
     const parts: string[] = []
-    for (let y = 0; y < this.size; y++) {
-      for (let x = 0; x < this.size; x++) {
+    for (let y: number = 0; y < this.size; y++) {
+      for (let x: number = 0; x < this.size; x++) {
         if (this.modules[y][x]) parts.push(`M${x + border},${y + border}h1v1h-1z`)
       }
     }

--- a/packages/supacloud-lite/src/runtime/auth/redirect.ts
+++ b/packages/supacloud-lite/src/runtime/auth/redirect.ts
@@ -12,8 +12,8 @@
  * for URI_ALLOW_LIST entries.
  */
 function globToRegExp(pattern: string): RegExp {
-  let out = ''
-  for (let i = 0; i < pattern.length; i++) {
+  let out: string = ''
+  for (let i: number = 0; i < pattern.length; i++) {
     const c = pattern[i]
     if (c === '*') {
       if (pattern[i + 1] === '*') {

--- a/packages/supacloud-lite/src/runtime/auth/totp.ts
+++ b/packages/supacloud-lite/src/runtime/auth/totp.ts
@@ -8,9 +8,9 @@ const B32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
 
 /** Encode bytes as unpadded RFC 4648 base32 (the format authenticator apps expect). */
 export function base32Encode(bytes: Uint8Array): string {
-  let bits = 0
-  let value = 0
-  let out = ''
+  let bits: number = 0
+  let value: number = 0
+  let out: string = ''
   for (const b of bytes) {
     value = (value << 8) | b
     bits += 8
@@ -26,8 +26,8 @@ export function base32Encode(bytes: Uint8Array): string {
 /** Decode an unpadded/padded base32 string to bytes (case-insensitive). */
 export function base32Decode(input: string): Uint8Array {
   const clean = input.toUpperCase().replace(/=+$/, '').replace(/\s/g, '')
-  let bits = 0
-  let value = 0
+  let bits: number = 0
+  let value: number = 0
   const out: number[] = []
   for (const ch of clean) {
     const idx = B32_ALPHABET.indexOf(ch)
@@ -67,7 +67,7 @@ async function hotp(secret: Uint8Array, counter: number): Promise<string> {
   const msg = new Uint8Array(8)
   // 64-bit big-endian counter (safe integer range covers TOTP for millennia)
   let c = counter
-  for (let i = 7; i >= 0; i--) {
+  for (let i: number = 7; i >= 0; i--) {
     msg[i] = c & 0xff
     c = Math.floor(c / 256)
   }

--- a/packages/supacloud-lite/src/runtime/cron/service.ts
+++ b/packages/supacloud-lite/src/runtime/cron/service.ts
@@ -141,7 +141,7 @@ export function cronMatches(expr: string, date: Date): boolean {
     [1, 12],
     [0, 6],
   ]
-  for (let i = 0; i < 5; i++) {
+  for (let i: number = 0; i < 5; i++) {
     if (!fieldMatches(fields[i], parts[i], ranges[i][0], ranges[i][1])) return false
   }
   return true
@@ -156,7 +156,7 @@ function fieldMatches(field: string, value: number, min: number, max: number): b
 
 function matchPart(part: string, value: number, min: number, max: number): boolean {
   // step: */K or range/K
-  let step = 1
+  let step: number = 1
   let rangeStr = part
   const slash = part.indexOf('/')
   if (slash !== -1) {

--- a/packages/supacloud-lite/src/runtime/db/data-dir-lock.ts
+++ b/packages/supacloud-lite/src/runtime/db/data-dir-lock.ts
@@ -19,7 +19,7 @@ export async function acquireDataDirLock(dataDir?: string, engineName = 'databas
   await mkdir(dirname(absoluteDataDir), { recursive: true, mode: 0o700 })
   const nonce = crypto.randomUUID()
   const handle = await createDataDirLock(absoluteDataDir, lockPath, nonce, engineName)
-  let released = false
+  let released: boolean = false
   return async () => {
     if (released) return
     released = true
@@ -67,7 +67,7 @@ async function createDataDirLock(
   nonce: string,
   engineName: string
 ): Promise<FileHandle> {
-  for (let attempt = 0; attempt < 3; attempt++) {
+  for (let attempt: number = 0; attempt < 3; attempt++) {
     try {
       return await writeDataDirLock(lockPath, nonce)
     } catch (error) {

--- a/packages/supacloud-lite/src/runtime/db/database.ts
+++ b/packages/supacloud-lite/src/runtime/db/database.ts
@@ -594,8 +594,8 @@ export class Database {
 export function parseIdentityArgs(identity: string): FunctionArg[] {
   if (!identity.trim()) return []
   const parts: string[] = []
-  let depth = 0
-  let current = ''
+  let depth: number = 0
+  let current: string = ''
   for (const ch of identity) {
     if (ch === '(') depth++
     if (ch === ')') depth--

--- a/packages/supacloud-lite/src/runtime/db/pglite-engine.ts
+++ b/packages/supacloud-lite/src/runtime/db/pglite-engine.ts
@@ -107,7 +107,7 @@ export async function createPgliteEngine(dataDir?: string): Promise<DbEngine> {
   } finally {
     await removePreparedBundles(cleanupStandaloneBundles)
   }
-  let closed = false
+  let closed: boolean = false
 
   return {
     async query<T>(sql: string, params?: unknown[]): Promise<EngineResults<T>> {

--- a/packages/supacloud-lite/src/runtime/db/sql-compat.ts
+++ b/packages/supacloud-lite/src/runtime/db/sql-compat.ts
@@ -33,8 +33,8 @@
 export function rewriteMigrationSql(sql: string): string {
   const out: string[] = []
   const n = sql.length
-  let i = 0
-  let stmtStart = 0
+  let i: number = 0
+  let stmtStart: number = 0
 
   while (i < n) {
     const c = sql[i]
@@ -137,7 +137,7 @@ function rewriteStatement(stmt: string): string {
 /** A dollar-quote tag guaranteed not to occur in `text`. */
 function pickTag(text: string, base: string): string {
   let tag = `$${base}$`
-  let k = 0
+  let k: number = 0
   while (text.includes(tag)) tag = `$${base}_${k++}$`
   return tag
 }

--- a/packages/supacloud-lite/src/runtime/functions/fetch-policy.ts
+++ b/packages/supacloud-lite/src/runtime/functions/fetch-policy.ts
@@ -19,7 +19,7 @@ const policyStore = new AsyncLocalStorage<ReadonlySet<string>>()
 // functions legitimately call back into the Lite API / DB on loopback
 const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(['localhost', '127.0.0.1', '::1'])
 
-let installed = false
+let installed: boolean = false
 
 function installFetchPolicyShim(): void {
   if (installed) return

--- a/packages/supacloud-lite/src/runtime/functions/handler.ts
+++ b/packages/supacloud-lite/src/runtime/functions/handler.ts
@@ -329,7 +329,7 @@ function filterSecretsEnv(env: FunctionContext['env'], secrets: string[]): Funct
  * once the body is streaming in, there is no way to turn it into a clean 413.
  */
 function withCountedBody(req: Request, limit: number): Request {
-  let seen = 0
+  let seen: number = 0
   const counter = new TransformStream<Uint8Array, Uint8Array>({
     transform(chunk, controller) {
       seen += chunk.byteLength
@@ -359,7 +359,7 @@ function withResponseLimit(name: string, res: Response, limit: number): Response
     return json(502, { error: `function "${name}" response exceeded ${limit} bytes` })
   }
   if (!res.body) return res
-  let seen = 0
+  let seen: number = 0
   const counter = new TransformStream<Uint8Array, Uint8Array>({
     transform(chunk, controller) {
       seen += chunk.byteLength

--- a/packages/supacloud-lite/src/runtime/jwt.ts
+++ b/packages/supacloud-lite/src/runtime/jwt.ts
@@ -14,9 +14,9 @@ export interface ProjectApiKeys {
 }
 
 function bytesToBase64Url(bytes: Uint8Array): string {
-  let binary = ''
+  let binary: string = ''
   const chunk = 0x8000
-  for (let i = 0; i < bytes.length; i += chunk) {
+  for (let i: number = 0; i < bytes.length; i += chunk) {
     binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
   }
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
@@ -27,7 +27,7 @@ function base64UrlToBytes(str: string): Uint8Array {
   const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
   const binary = atob(padded)
   const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  for (let i: number = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
   return bytes
 }
 
@@ -74,7 +74,7 @@ export async function mintProjectApiKeys(jwtSecret: string): Promise<ProjectApiK
     ref: 'local',
     iat: PROJECT_API_KEY_ISSUED_AT,
     exp: PROJECT_API_KEY_EXPIRES_AT,
-  }
+  } satisfies JwtClaims
   return {
     anonKey: await signJwt({ ...commonClaims, role: 'anon' }, jwtSecret),
     serviceRoleKey: await signJwt({ ...commonClaims, role: 'service_role' }, jwtSecret),

--- a/packages/supacloud-lite/src/runtime/net/service.ts
+++ b/packages/supacloud-lite/src/runtime/net/service.ts
@@ -71,7 +71,7 @@ function isPrivateIp(host: string): boolean {
  */
 export async function guardedFetch(fetchImpl: typeof fetch, url: string, init: RequestInit = {}): Promise<Response> {
   let current = url
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+  for (let hop: number = 0; hop <= MAX_REDIRECTS; hop++) {
     const blocked = blockedNetTarget(current)
     if (blocked) throw new Error(blocked)
     const res = await fetchImpl(current, { ...init, redirect: 'manual' })
@@ -196,7 +196,7 @@ export class NetService {
     let contentType: string | null = null
     let content: string | null = null
     let respHeaders: Record<string, string> | null = null
-    let timedOut = false
+    let timedOut: boolean = false
     let errorMsg: string | null = null
 
     try {
@@ -259,7 +259,7 @@ async function readCapped(res: Response, maxBytes: number): Promise<string> {
   if (!res.body) return await res.text()
   const reader = res.body.getReader()
   const chunks: Uint8Array[] = []
-  let total = 0
+  let total: number = 0
   while (total < maxBytes) {
     const { done, value } = await reader.read()
     if (done) break
@@ -268,7 +268,7 @@ async function readCapped(res: Response, maxBytes: number): Promise<string> {
   }
   await reader.cancel().catch(() => {})
   let merged = new Uint8Array(Math.min(total, maxBytes))
-  let offset = 0
+  let offset: number = 0
   for (const c of chunks) {
     const take = Math.min(c.length, merged.length - offset)
     merged.set(c.subarray(0, take), offset)

--- a/packages/supacloud-lite/src/runtime/node/config-toml.ts
+++ b/packages/supacloud-lite/src/runtime/node/config-toml.ts
@@ -80,7 +80,7 @@ function descend(root: ConfigTable, path: string[]): ConfigTable {
 /** Remove a `#` comment that isn't inside a quoted string. */
 function stripComment(line: string): string {
   let quote: string | null = null
-  for (let i = 0; i < line.length; i++) {
+  for (let i: number = 0; i < line.length; i++) {
     const c = line[i]
     if (quote) {
       if (c === quote) quote = null

--- a/packages/supacloud-lite/src/runtime/node/db-diff.ts
+++ b/packages/supacloud-lite/src/runtime/node/db-diff.ts
@@ -35,7 +35,7 @@ export async function computeDbDiff(opts: DbDiffOptions): Promise<string[]> {
   let shadow: SupaCloudLiteBackend | undefined
   let live: SupaCloudLiteBackend | undefined
   let unclaimedLiveEngine = opts.liveEngine
-  let operationFailed = false
+  let operationFailed: boolean = false
 
   try {
     // shadow = migrations only, fresh
@@ -132,7 +132,7 @@ export async function pullSchema(opts: DbPullOptions): Promise<DbPullResult> {
   let shadow: SupaCloudLiteBackend | undefined
   let live: SupaCloudLiteBackend | undefined
   let unclaimedLiveEngine = opts.liveEngine
-  let operationFailed = false
+  let operationFailed: boolean = false
   try {
     shadow = await createBackend({
       engine: opts.makeShadowEngine ? await opts.makeShadowEngine() : undefined,

--- a/packages/supacloud-lite/src/runtime/node/native/engine.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/engine.ts
@@ -235,7 +235,7 @@ function postgresDownloadMirror(downloadMirror?: string): URL | undefined {
 
 async function fetchRelease(url: string): Promise<Response> {
   let lastError: unknown
-  for (let attempt = 1; attempt <= 3; attempt++) {
+  for (let attempt: number = 1; attempt <= 3; attempt++) {
     try {
       const response = await fetch(url)
       if (response.ok || response.status < 500) return response
@@ -310,8 +310,8 @@ export async function createNativeEngine(opts: NativeEngineOptions): Promise<DbE
         detached: false,
       }
     )
-    let postgresExited = false
-    let postgresStderr = ''
+    let postgresExited: boolean = false
+    let postgresStderr: string = ''
     postgres.stderr?.on('data', (chunk: Buffer) => {
       postgresStderr = (postgresStderr + chunk.toString()).slice(-4000)
     })

--- a/packages/supacloud-lite/src/runtime/node/native/wire.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/wire.ts
@@ -95,9 +95,9 @@ export class PgWireClient {
       })
 
       // SCRAM handshake state, carried across the SASL message exchange
-      let clientNonce = ''
-      let clientFirstBare = ''
-      let serverSignature = ''
+      let clientNonce: string = ''
+      let clientFirstBare: string = ''
+      let serverSignature: string = ''
       const needPassword = (): boolean => {
         if (opts.password == null) {
           reject(new Error('the server requested a password but none was provided'))
@@ -266,9 +266,9 @@ export class PgWireClient {
           // RowDescription
           if (!p) break
           const count = payload.readInt16BE(0)
-          let off = 2
+          let off: number = 2
           const columns: Column[] = []
-          for (let i = 0; i < count; i++) {
+          for (let i: number = 0; i < count; i++) {
             const end = payload.indexOf(0, off)
             const name = payload.toString('utf8', off, end)
             off = end + 1
@@ -283,9 +283,9 @@ export class PgWireClient {
           // DataRow
           if (!p) break
           const count = payload.readInt16BE(0)
-          let off = 2
+          let off: number = 2
           const row: Record<string, unknown> = {}
-          for (let i = 0; i < count; i++) {
+          for (let i: number = 0; i < count; i++) {
             const len = payload.readInt32BE(off)
             off += 4
             let value: unknown = null
@@ -355,7 +355,7 @@ const sha256 = (b: Buffer): Buffer => createHash('sha256').update(b).digest()
 const md5Hex = (b: Buffer): string => createHash('md5').update(b).digest('hex')
 function xorBuffers(a: Buffer, b: Buffer): Buffer {
   const out = Buffer.alloc(a.length)
-  for (let i = 0; i < a.length; i++) out[i] = a[i] ^ b[i]
+  for (let i: number = 0; i < a.length; i++) out[i] = a[i] ^ b[i]
   return out
 }
 /** Parse SCRAM attribute strings like `r=…,s=…,i=…` into a map. */
@@ -390,7 +390,7 @@ const int32 = (n: number) => {
 
 function parseErrorFields(payload: Buffer): Map<string, string> {
   const fields = new Map<string, string>()
-  let off = 0
+  let off: number = 0
   while (off < payload.length && payload[off] !== 0) {
     const key = String.fromCharCode(payload[off])
     const end = payload.indexOf(0, off + 1)
@@ -453,14 +453,14 @@ export function decodeValue(text: string, oid: number): unknown {
 export function parsePgArray(text: string): (string | null)[] {
   const out: (string | null)[] = []
   if (text.length < 2) return out
-  let i = 1
+  let i: number = 1
   while (i < text.length - 1) {
     if (text[i] === ',') {
       i++
       continue
     }
     if (text[i] === '"') {
-      let value = ''
+      let value: string = ''
       i++
       while (text[i] !== '"') {
         if (text[i] === '\\') i++
@@ -469,7 +469,7 @@ export function parsePgArray(text: string): (string | null)[] {
       i++
       out.push(value)
     } else {
-      let value = ''
+      let value: string = ''
       while (i < text.length - 1 && text[i] !== ',') value += text[i++]
       out.push(value === 'NULL' ? null : value)
     }

--- a/packages/supacloud-lite/src/runtime/realtime/engine.ts
+++ b/packages/supacloud-lite/src/runtime/realtime/engine.ts
@@ -136,7 +136,7 @@ export class RealtimeEngine {
         const read = ((rd.rows[0]?.n ?? 0) as number) > 0
         // write: does an INSERT policy let them broadcast? (last query - a
         // failure aborts the tx, which we roll back anyway)
-        let write = true
+        let write: boolean = true
         try {
           await tx.query(
             `insert into realtime.messages (topic, extension, event, payload, private) values ($1, 'broadcast', 'authz-w', '{}'::jsonb, true)`,
@@ -314,7 +314,7 @@ export class RealtimeEngine {
 
     const ctx = await this.contextFromToken(msg.payload?.access_token as string | undefined)
     const isPrivate = config.private === true
-    let canBroadcast = true
+    let canBroadcast: boolean = true
     // Private channels are RLS-authorized against realtime.messages (skipped on
     // subset engines with no RLS). No read policy → join is rejected.
     if (isPrivate && !this.db.engine.minimalBootstrap) {
@@ -434,7 +434,7 @@ export class RealtimeEngine {
   private handleBinary(conn: Connection, bytes: Uint8Array): void {
     if (bytes.length < 7 || bytes[0] !== 3) return
     const [, joinRefLen, refLen, topicLen, eventLen, metaLen, encoding] = bytes
-    let offset = 7
+    let offset: number = 7
     const decoder = new TextDecoder()
     const read = (len: number) => {
       const out = decoder.decode(bytes.subarray(offset, offset + len))

--- a/packages/supacloud-lite/src/runtime/rest/build.ts
+++ b/packages/supacloud-lite/src/runtime/rest/build.ts
@@ -192,7 +192,7 @@ export class QueryBuilder {
       })
       .join(', ')
 
-    let conflict = ''
+    let conflict: string = ''
     if (opts.upsert) {
       const target = this.q.onConflict ?? tinfo.primaryKey
       if (target.length === 0) {
@@ -505,7 +505,7 @@ export class QueryBuilder {
 
   /** Render `limit`/`offset` for the given path key (`''` = base); empty when neither is set. */
   renderLimitOffset(pathKey: string): string {
-    let s = ''
+    let s: string = ''
     const limit = this.q.limits.get(pathKey)
     const offset = this.q.offsets.get(pathKey)
     if (limit !== undefined) s += ` limit ${limit}`
@@ -593,7 +593,7 @@ export function renderColumnExpr(alias: string, raw: string): string {
   const base = unquote(tokens[0].trim())
   // empty alias → unqualified column (used for UPDATE/DELETE on subset engines)
   let expr = alias ? `${quoteIdent(alias)}.${quoteIdent(base)}` : quoteIdent(base)
-  for (let i = 1; i < tokens.length; i += 2) {
+  for (let i: number = 1; i < tokens.length; i += 2) {
     const op = tokens[i]
     const key = tokens[i + 1]?.trim() ?? ''
     expr += /^\d+$/.test(key) ? `${op}${key}` : `${op}${quoteLiteral(unquote(key))}`

--- a/packages/supacloud-lite/src/runtime/rest/parse.ts
+++ b/packages/supacloud-lite/src/runtime/rest/parse.ts
@@ -159,7 +159,7 @@ export function parseQuery(searchParams: URLSearchParams): ParsedQuery {
 }
 
 function parseFilterValue(column: string, raw: string, path: string[]): FilterCond {
-  let negated = false
+  let negated: boolean = false
   let rest = raw
   if (rest.startsWith('not.')) {
     negated = true
@@ -210,7 +210,7 @@ function parseLogicTree(op: 'and' | 'or', raw: string, path: string[], negated: 
 function parseOrderTerm(term: string, path: string[]): OrderTerm {
   const parts = term.split('.')
   const column = unquote(parts[0])
-  let asc = true
+  let asc: boolean = true
   let nullsFirst: boolean | undefined
   for (const p of parts.slice(1)) {
     if (p === 'asc') asc = true
@@ -225,10 +225,10 @@ function parseOrderTerm(term: string, path: string[]): OrderTerm {
 /** Split on a delimiter, ignoring delimiters inside parens and double quotes. */
 export function splitTopLevel(str: string, delim: string): string[] {
   const out: string[] = []
-  let depth = 0
-  let inQuote = false
-  let current = ''
-  for (let i = 0; i < str.length; i++) {
+  let depth: number = 0
+  let inQuote: boolean = false
+  let current: string = ''
+  for (let i: number = 0; i < str.length; i++) {
     const ch = str[i]
     if (inQuote) {
       current += ch
@@ -275,7 +275,7 @@ export function parseSelect(value: string): SelectItem[] {
 function parseSelectItem(item: string): SelectItem {
   if (item === '') throw new ParseError('empty select item')
 
-  let spread = false
+  let spread: boolean = false
   if (item.startsWith('...')) {
     spread = true
     item = item.slice(3)
@@ -312,7 +312,7 @@ function parseSelectItem(item: string): SelectItem {
     const headParts = head.split('!')
     const name = unquote(headParts[0])
     let hint: string | undefined
-    let inner = false
+    let inner: boolean = false
     for (const part of headParts.slice(1)) {
       if (part === 'inner') inner = true
       else if (part === 'left') { /* left is the default */ }
@@ -346,8 +346,8 @@ function parseSelectItem(item: string): SelectItem {
 
 /** Index of an alias ':' (not '::'), outside quotes/parens; -1 when absent. */
 function findAliasColon(item: string): number {
-  let inQuote = false
-  for (let i = 0; i < item.length; i++) {
+  let inQuote: boolean = false
+  for (let i: number = 0; i < item.length; i++) {
     const ch = item[i]
     if (ch === '"') inQuote = !inQuote
     if (inQuote) continue

--- a/packages/supacloud-lite/src/runtime/storage/handler.ts
+++ b/packages/supacloud-lite/src/runtime/storage/handler.ts
@@ -744,7 +744,7 @@ export class StorageHandler {
 
     try {
       const data = new Uint8Array(upload.length)
-      let cursor = 0
+      let cursor: number = 0
       for (const part of upload.chunks) {
         data.set(part, cursor)
         cursor += part.length
@@ -1324,7 +1324,7 @@ async function readLimitedBody(request: Request, maxBytes: number): Promise<Uint
   if (!request.body) return new Uint8Array()
   const reader = request.body.getReader()
   const chunks: Uint8Array[] = []
-  let total = 0
+  let total: number = 0
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
@@ -1336,7 +1336,7 @@ async function readLimitedBody(request: Request, maxBytes: number): Promise<Uint
     total += value.byteLength
   }
   const body = new Uint8Array(total)
-  let offset = 0
+  let offset: number = 0
   for (const chunk of chunks) {
     body.set(chunk, offset)
     offset += chunk.byteLength
@@ -1360,7 +1360,7 @@ export function parseMultipart(bytes: Uint8Array, boundary: string): MultipartPa
 
   const indexOf = (needle: Uint8Array, from: number): number => {
     outer: for (let i = from; i <= bytes.length - needle.length; i++) {
-      for (let j = 0; j < needle.length; j++) {
+      for (let j: number = 0; j < needle.length; j++) {
         if (bytes[i + j] !== needle[j]) continue outer
       }
       return i

--- a/packages/supacloud-lite/test/helpers/timezone-probe.ts
+++ b/packages/supacloud-lite/test/helpers/timezone-probe.ts
@@ -22,7 +22,7 @@ const TIMEZONE_PROBE_MIGRATION = {
     grant select on public.timezone_probes to service_role;
     grant execute on function public.timezone_probe() to service_role;
   `,
-}
+} as const
 const dataDir = process.env.SUPACLOUD_LITE_TIMEZONE_DATA_DIR
 const probeMode = process.env.SUPACLOUD_LITE_TIMEZONE_PROBE_MODE
 

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -14,24 +14,17 @@
       },
     },
   },
+  "overrides": {
+    "@supacloud/compiler": "file:../compiler",
+  },
   "packages": {
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/admin": ["@supacloud/admin@0.20.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-VK+5bdvm9FAF3LUHDA8SKaSRKTXrQzuUn9PNXlNkAcfrZTcKb3awks8opByLwhUMPKQHls53T8tfS62SyZ/Wqg=="],
+    "@supacloud/admin": ["@supacloud/admin@0.20.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.20.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-VK+5bdvm9FAF3LUHDA8SKaSRKTXrQzuUn9PNXlNkAcfrZTcKb3awks8opByLwhUMPKQHls53T8tfS62SyZ/Wqg=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.44.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.52", "@supacloud/compiler": "^0.2.0", "@supacloud/db": "^0.2.0", "fflate": "^0.8.3" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-RzSiqrs+Tnryk3VhZU2rTI2dWCU8JD9xH3z5jPfrg/NvF10FAubtS2H9Q/1KYzJbVNKWS3qeJwCDJwz4gregOg=="],
+    "@supacloud/cli": ["@supacloud/cli@0.44.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.44.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "@supacloud/compiler": "^0.2.0", "@supacloud/db": "^0.2.0", "fflate": "^0.8.3" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-RzSiqrs+Tnryk3VhZU2rTI2dWCU8JD9xH3z5jPfrg/NvF10FAubtS2H9Q/1KYzJbVNKWS3qeJwCDJwz4gregOg=="],
 
-    "@supacloud/compiler": ["@supacloud/compiler@0.2.0", "", { "dependencies": { "ts-morph": "^26.0.0" } }, "sha512-LJzWsSkNKmrd/mgXp7N83LEkagWDjbIS6R3i4uwszQ/Ouf1pPi22u9Db/5Qg0ET/n/0fV/FP8UxFvZ/zY4JxGQ=="],
-
-    "@supacloud/db": ["@supacloud/db@0.2.0", "", {}, "sha512-rJKMCJqMZf4oQ+x9bOnCoYO6REQqwIcSEwugPjvMfoiCbBo7vhkpytKWfj60UJJl0IJIUjmIZMu4xI2U2Okigg=="],
-
-    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+    "@supacloud/db": ["@supacloud/db@0.2.0", "https://registry.npmmirror.com/@supacloud/db/-/db-0.2.0.tgz", {}, "sha512-rJKMCJqMZf4oQ+x9bOnCoYO6REQqwIcSEwugPjvMfoiCbBo7vhkpytKWfj60UJJl0IJIUjmIZMu4xI2U2Okigg=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
@@ -79,68 +72,28 @@
 
     "asn1": ["asn1@0.2.6", "https://registry.npmmirror.com/asn1/-/asn1-0.2.6.tgz", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "https://registry.npmmirror.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
-
-    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
-
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "buildcheck": ["buildcheck@0.0.7", "https://registry.npmmirror.com/buildcheck/-/buildcheck-0.0.7.tgz", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
     "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
-    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
-
     "cpu-features": ["cpu-features@0.0.10", "https://registry.npmmirror.com/cpu-features/-/cpu-features-0.0.10.tgz", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fastq": ["fastq@1.20.3", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw=="],
-
-    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+    "fflate": ["fflate@0.8.3", "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "nan": ["nan@2.28.0", "https://registry.npmmirror.com/nan/-/nan-2.28.0.tgz", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
-
-    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
-    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "ssh2": ["ssh2@1.17.0", "https://registry.npmmirror.com/ssh2/-/ssh2-1.17.0.tgz", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "https://registry.npmmirror.com/tweetnacl/-/tweetnacl-0.14.5.tgz", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "@supacloud/cli/@supacloud/compiler": ["@supacloud/compiler@file:../compiler", {}],
   }
 }

--- a/packages/supacloud/package.json
+++ b/packages/supacloud/package.json
@@ -34,6 +34,9 @@
     "@supacloud/cli": "^0.44.1",
     "@supacloud/admin": "^0.20.1"
   },
+  "overrides": {
+    "@supacloud/compiler": "file:../compiler"
+  },
   "devDependencies": {
     "@types/bun": "^1.4.0",
     "typescript": "^7.0.2"

--- a/packages/supacloud/src/index.ts
+++ b/packages/supacloud/src/index.ts
@@ -199,7 +199,7 @@ export function compareSemver(left: string, right: string): number {
     const b = parseSemver(right);
     if (!a || !b) return left.localeCompare(right);
 
-    for (let i = 0; i < 3; i += 1) {
+    for (let i: number = 0; i < 3; i += 1) {
         if (a.main[i] !== b.main[i]) return a.main[i] > b.main[i] ? 1 : -1;
     }
 

--- a/packages/testing/src/db.ts
+++ b/packages/testing/src/db.ts
@@ -47,10 +47,20 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+interface BunFileApi {
+  file(path: string): { text(): Promise<string> };
+}
+
+function isBunFileApi(value: unknown): value is BunFileApi {
+  if (!value || typeof value !== "object") return false;
+  const file: unknown = Reflect.get(value, "file");
+  return typeof file === "function";
+}
+
 /** Default file reader: uses Bun.file without requiring bun types at compile time. */
 function defaultReadFile(path: string): Promise<string> {
-  const bun = (globalThis as { Bun?: { file(p: string): { text(): Promise<string> } } }).Bun;
-  if (!bun) {
+  const bun: unknown = Reflect.get(globalThis, "Bun");
+  if (!isBunFileApi(bun)) {
     throw new Error("runSqlTests: no readFile provided and Bun.file is not available");
   }
   return bun.file(path).text();

--- a/packages/testing/src/http.test.ts
+++ b/packages/testing/src/http.test.ts
@@ -39,6 +39,17 @@ describe("testJson", () => {
       echoApp(201),
       "/cases?page=1",
       { method: "PUT" },
+      (value) => {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          throw new Error("Expected JSON object");
+        }
+        const record: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(value)) record[key] = item;
+        if (typeof record.method !== "string" || typeof record.url !== "string") {
+          throw new Error("Expected method and url");
+        }
+        return { method: record.method, url: record.url };
+      },
     );
     expect(status).toBe(201);
     expect(body.method).toBe("PUT");

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -22,9 +22,10 @@ export async function testJson<T = unknown>(
   app: HandleLike,
   path: string,
   init: RequestInit = {},
+  decode: (value: unknown) => T,
 ): Promise<{ status: number; body: T }> {
   const response = await testRequest(app, path, init);
-  const body = (await response.json()) as T;
+  const body = decode(await response.json());
   return { status: response.status, body };
 }
 
@@ -52,12 +53,23 @@ export async function testJsonError(
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new Error("Expected JSON error response body to be an object");
   }
-  const error = body as Record<string, unknown>;
+  const error: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) error[key] = value;
   if (response.status !== expected.status) {
     throw new Error(`Expected status ${expected.status}, received ${response.status}`);
   }
   if (error.ok !== false || error.code !== expected.code || typeof error.message !== "string") {
     throw new Error(`Expected error code ${expected.code}, received ${String(error.code)}`);
   }
-  return error as unknown as JsonErrorBody;
+  const code = error.code;
+  const message = error.message;
+  if (code !== expected.code || typeof message !== "string") {
+    throw new Error(`Expected error code ${expected.code}, received ${String(code)}`);
+  }
+  return {
+    ok: false,
+    code,
+    message,
+    ...(error.details === undefined ? {} : { details: error.details }),
+  };
 }

--- a/packages/testing/src/mock-graph.ts
+++ b/packages/testing/src/mock-graph.ts
@@ -5,10 +5,10 @@ export interface MockModuleNode {
   file: string;
   line: number;
   imports: string[];
-  providers: any[];
-  controllers: any[];
-  commands: any[];
-  queries: any[];
+  providers: unknown[];
+  controllers: unknown[];
+  commands: unknown[];
+  queries: unknown[];
   exports: string[];
   [key: string]: unknown;
 }

--- a/packages/testing/src/test-module.ts
+++ b/packages/testing/src/test-module.ts
@@ -9,20 +9,21 @@
 const INJECTABLE_METADATA = "supacloud:injectable";
 const INJECT_PARAMS_METADATA = "supacloud:inject-params";
 const MODULE_METADATA = "supacloud:module";
+type Constructor = Function;
 
 export interface ProviderOverride {
   /** InjectionToken instance or class identifying the provider to replace. */
   token: unknown;
   useValue?: unknown;
-  useClass?: new (...args: any[]) => unknown;
-  useFactory?: (...deps: any[]) => unknown;
+  useClass?: Constructor;
+  useFactory?: (...deps: unknown[]) => unknown;
 }
 
 export interface ModuleMetaLike {
   name: string;
   /** Classes or { provide, useClass|useValue|useFactory|useExisting, deps?, scope? } records. */
   providers: unknown[];
-  imports?: Array<new (...args: any[]) => unknown> | ModuleMetaLike[];
+  imports?: Array<Constructor> | ModuleMetaLike[];
   [key: string]: unknown;
 }
 
@@ -36,7 +37,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isClass(value: unknown): value is new (...args: any[]) => unknown {
+function isClass(value: unknown): value is Constructor {
   return typeof value === "function";
 }
 
@@ -58,7 +59,7 @@ function camelCase(name: string): string {
  */
 export function tokenKey(token: unknown): string {
   if (isClass(token)) {
-    const name = (token as { name?: string }).name;
+    const name = token.name;
     if (!name) {
       throw new Error("tokenKey: anonymous class tokens are not supported");
     }
@@ -79,11 +80,14 @@ function describeToken(token: unknown): string {
 }
 
 /** Merge @Injectable deps with @Inject param tokens into a positional array. */
-function classDeps(cls: new (...args: any[]) => unknown): unknown[] {
-  const statics = cls as unknown as Record<string, unknown>;
-  const meta = statics[INJECTABLE_METADATA] as { deps?: unknown[] } | undefined;
-  const params = statics[INJECT_PARAMS_METADATA] as Record<number, unknown> | undefined;
-  const deps: unknown[] = [...(meta?.deps ?? [])];
+function classDeps(cls: Constructor): unknown[] {
+  const metaValue: unknown = Reflect.get(cls, INJECTABLE_METADATA);
+  const meta = isRecord(metaValue) && Array.isArray(metaValue.deps)
+    ? metaValue.deps
+    : [];
+  const paramsValue: unknown = Reflect.get(cls, INJECT_PARAMS_METADATA);
+  const params = isRecord(paramsValue) ? paramsValue : undefined;
+  const deps: unknown[] = [...meta];
   if (params) {
     for (const [index, token] of Object.entries(params)) {
       deps[Number(index)] = token;
@@ -101,7 +105,7 @@ function explicitDeps(provider: unknown): unknown[] | undefined {
 }
 
 /** Deps used to construct an override, falling back to the original declaration. */
-function overrideDeps(record: ProviderRecord, overrideClass?: new (...args: any[]) => unknown): unknown[] {
+function overrideDeps(record: ProviderRecord, overrideClass?: Constructor): unknown[] {
   if (overrideClass) {
     const own = classDeps(overrideClass);
     if (own.length > 0) return own;
@@ -118,12 +122,11 @@ function overrideDeps(record: ProviderRecord, overrideClass?: new (...args: any[
 function collectProviders(meta: ModuleMetaLike, records: ProviderRecord[]): void {
   for (const imported of meta.imports ?? []) {
     if (isClass(imported)) {
-      const importedMeta = (imported as unknown as Record<string, unknown>)[MODULE_METADATA] as
-        | ModuleMetaLike
-        | undefined;
+      const metadata: unknown = Reflect.get(imported, MODULE_METADATA);
+      const importedMeta = isModuleMetaLike(metadata) ? metadata : undefined;
       if (importedMeta) collectProviders(importedMeta, records);
     } else if (isRecord(imported)) {
-      collectProviders(imported as ModuleMetaLike, records);
+      if (isModuleMetaLike(imported)) collectProviders(imported, records);
     }
   }
   for (const provider of meta.providers ?? []) {
@@ -216,17 +219,17 @@ function instantiate(
     if ("useValue" in override) return override.useValue;
     if (override.useClass) {
       const deps = overrideDeps(record, override.useClass).map(resolve);
-      return new override.useClass(...deps);
+      return Reflect.construct(override.useClass, deps);
     }
     if (override.useFactory) {
-      return override.useFactory(...overrideDeps(record).map(resolve));
+      return Reflect.apply(override.useFactory, undefined, overrideDeps(record).map(resolve));
     }
     throw new Error(`createTestModule: override for "${describeToken(record.token)}" has no use* value`);
   }
 
   // Bare class provider: the class is its own token.
   if (isClass(provider)) {
-    return new provider(...classDeps(provider).map(resolve));
+    return Reflect.construct(provider, classDeps(provider).map(resolve));
   }
   if (!isRecord(provider)) {
     throw new Error(`createTestModule: invalid provider for "${describeToken(record.token)}"`);
@@ -234,14 +237,20 @@ function instantiate(
   if ("useValue" in provider) return provider.useValue;
   if (isClass(provider.useClass)) {
     const deps = (explicitDeps(provider) ?? classDeps(provider.useClass)).map(resolve);
-    return new provider.useClass(...deps);
+    return Reflect.construct(provider.useClass, deps);
   }
   if (typeof provider.useFactory === "function") {
     const deps = (explicitDeps(provider) ?? []).map(resolve);
-    return (provider.useFactory as (...deps: any[]) => unknown)(...deps);
+    return Reflect.apply(provider.useFactory, undefined, deps);
   }
   if ("useExisting" in provider) {
     return resolve(provider.useExisting);
   }
   throw new Error(`createTestModule: invalid provider for "${describeToken(record.token)}"`);
+}
+
+function isModuleMetaLike(value: unknown): value is ModuleMetaLike {
+  return isRecord(value)
+    && typeof value.name === "string"
+    && Array.isArray(value.providers);
 }

--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -28,7 +28,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
         "@typescript/native": "npm:typescript@^7.0.2",
-        "autoprefixer": "^10.5.4",
+        "autoprefixer": "^10.5.5",
         "bits-ui": "^2.19.0",
         "clsx": "^2.1.1",
         "jsdom": "30.0.1",
@@ -481,7 +481,7 @@
 
     "arktype": ["arktype@2.2.3", "", { "dependencies": { "@ark/schema": "0.56.2", "@ark/util": "0.56.2", "arkregex": "0.0.8" } }, "sha512-7W+0RLTUNJiBFIIZXwOQxSR8Z273IAd6IvqBeG9+gHnQKFsIx2C0iOtGTmMrPnlX4qLXyc5+ll7A0BIj9WrbTg=="],
 
-    "autoprefixer": ["autoprefixer@10.5.4", "", { "dependencies": { "browserslist": "^4.28.6", "caniuse-lite": "^1.0.30001806", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA=="],
+    "autoprefixer": ["autoprefixer@10.5.5", "", { "dependencies": { "browserslist": "^4.28.9", "caniuse-lite": "^1.0.30001810", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-uiRYvQYe/nNSzBJ7OUnd2/TZVsAdob3blml44teEpee9Cc1f4rGZFewO+JT3Wo8mgFOSzNqes4FHZn/Qz8WOuw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -493,7 +493,7 @@
 
     "bits-ui": ["bits-ui@2.19.0", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-dHDm5Jw2NZJgLRvHAwPeuR4BnZij+AqTIq33OqVfo+qiMXontoC/yIvGT5TZaviv7OuBdJ2QUy2JPQ2yKBvF6w=="],
 
-    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+    "browserslist": ["browserslist@4.28.9", "", { "dependencies": { "baseline-browser-mapping": "^2.11.20", "caniuse-lite": "^1.0.30001810", "electron-to-chromium": "^1.5.420", "node-releases": "^2.0.54", "update-browserslist-db": "^1.3.2" }, "bin": { "browserslist": "cli.js" } }, "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg=="],
 
     "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
@@ -629,7 +629,7 @@
 
     "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.418", "", {}, "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.422", "", {}, "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -20,7 +20,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "autoprefixer": "^10.5.4",
+    "autoprefixer": "^10.5.5",
     "bits-ui": "^2.19.0",
     "clsx": "^2.1.1",
     "jsdom": "30.0.1",

--- a/packages/web-console/src/lib/admin/auth.ts
+++ b/packages/web-console/src/lib/admin/auth.ts
@@ -58,7 +58,10 @@ export const authProvider: AuthProvider = {
   },
   
   onError: async (error: unknown) => {
-    const status = (error as { status?: number })?.status;
+    const status = error !== null && typeof error === "object" && "status" in error
+      && typeof error.status === "number"
+      ? error.status
+      : undefined;
     if (status === 401 || status === 403) {
       return { logout: true, redirectTo: '/login' };
     }

--- a/packages/web-console/src/lib/admin/provider.ts
+++ b/packages/web-console/src/lib/admin/provider.ts
@@ -133,7 +133,7 @@ export const chatProvider: ChatProvider = {
         throw new Error('No readable stream');
       }
 
-      let buffered = "";
+      let buffered: string = "";
 
       while (true) {
         const { done, value } = await reader.read();

--- a/packages/web-console/src/lib/admin/provider.ts
+++ b/packages/web-console/src/lib/admin/provider.ts
@@ -5,6 +5,26 @@ import {
 } from '@svadmin/elysia';
 import type { BaseRecord, ChatMessage, ChatProvider, GetListResult } from '@svadmin/core';
 
+function toRecord(value: object): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) result[key] = item;
+  return result;
+}
+
+function isBaseRecord(value: unknown): value is BaseRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function providerRecords<TData extends BaseRecord>(records: BaseRecord[]): TData[] {
+  // @svadmin/elysia exposes a generic response parser without a decoder
+  // parameter. The records have been structurally validated at this boundary.
+  return records as unknown as TData[];
+}
+
 const getApiUrl = () => {
     if (typeof window === 'undefined') return 'http://localhost:9090'; // SSR
     return window.location.origin;
@@ -19,7 +39,7 @@ function parseNamedListEnvelope<TData extends BaseRecord>(
     throw new Error(`Invalid list response for ${context.resource}. Expected an object containing ${recordKey}.`);
   }
 
-  const response = payload as Record<string, unknown>;
+  const response = toRecord(payload);
   const applicationError = typeof response.error === 'string'
     ? response.error
     : typeof response.message === 'string'
@@ -31,13 +51,16 @@ function parseNamedListEnvelope<TData extends BaseRecord>(
   if (!Array.isArray(records)) {
     throw new Error(`Invalid list response for ${context.resource}. Expected an object containing ${recordKey}.`);
   }
+  if (!records.every(isBaseRecord)) {
+    throw new Error(`Invalid list response for ${context.resource}. Expected object records.`);
+  }
 
   const metadata = Object.fromEntries(
     Object.entries(response).filter(([key]) => key !== recordKey),
   );
   return {
     ...metadata,
-    data: records as TData[],
+      data: providerRecords<TData>(records),
     total: typeof response.total === 'number' ? response.total : records.length,
   };
 }
@@ -48,8 +71,8 @@ function namedEnvelopeAdapter(
 ): ElysiaResourceAdapter {
   return {
     match,
-    parseListResponse: <TData extends BaseRecord>(payload: unknown, context: ElysiaListContext) =>
-      parseNamedListEnvelope<TData>(payload, context, recordKey),
+    parseListResponse: (payload, context) =>
+      parseNamedListEnvelope(payload, context, recordKey),
   };
 }
 
@@ -124,8 +147,20 @@ export const chatProvider: ChatProvider = {
       const decoder = new TextDecoder();
 
       if (!reader) {
-        const fallback = await res.json().catch(() => null);
-        const content = fallback?.choices?.[0]?.message?.content;
+        const fallback: unknown = await res.json().catch(() => null);
+        const fallbackRecord = fallback !== null && typeof fallback === "object" && !Array.isArray(fallback)
+          ? toRecord(fallback)
+          : {};
+        const choices = isUnknownArray(fallbackRecord.choices) ? fallbackRecord.choices : [];
+        const firstChoice = choices[0];
+        const choiceRecord = firstChoice !== null && typeof firstChoice === "object" && !Array.isArray(firstChoice)
+          ? toRecord(firstChoice)
+          : {};
+        const message = choiceRecord.message;
+        const messageRecord = message !== null && typeof message === "object" && !Array.isArray(message)
+          ? toRecord(message)
+          : {};
+        const content = typeof messageRecord.content === "string" ? messageRecord.content : undefined;
         if (content) {
           yield content;
           return;
@@ -149,9 +184,21 @@ export const chatProvider: ChatProvider = {
           const payload = trimmed.slice(5).trim();
           if (!payload || payload === '[DONE]') continue;
           try {
-            const data = JSON.parse(payload);
-            if (data.choices?.[0]?.delta?.content) {
-              yield data.choices[0].delta.content;
+            const data: unknown = JSON.parse(payload);
+            const dataRecord = data !== null && typeof data === "object" && !Array.isArray(data)
+              ? toRecord(data)
+              : {};
+            const dataChoices = isUnknownArray(dataRecord.choices) ? dataRecord.choices : [];
+            const delta = dataChoices[0];
+            const deltaRecord = delta !== null && typeof delta === "object" && !Array.isArray(delta)
+              ? toRecord(delta)
+              : {};
+            const contentRecord = deltaRecord.delta;
+            const content = contentRecord !== null && typeof contentRecord === "object" && !Array.isArray(contentRecord)
+              ? toRecord(contentRecord).content
+              : undefined;
+            if (typeof content === "string") {
+              yield content;
             }
           } catch {
             // Ignore malformed stream fragments.
@@ -165,9 +212,21 @@ export const chatProvider: ChatProvider = {
         const payload = tail.slice(5).trim();
         if (payload && payload !== '[DONE]') {
             try {
-              const data = JSON.parse(payload);
-              if (data.choices?.[0]?.delta?.content) {
-                yield data.choices[0].delta.content;
+              const data: unknown = JSON.parse(payload);
+              const dataRecord = data !== null && typeof data === "object" && !Array.isArray(data)
+                ? toRecord(data)
+                : {};
+              const dataChoices = isUnknownArray(dataRecord.choices) ? dataRecord.choices : [];
+              const delta = dataChoices[0];
+              const deltaRecord = delta !== null && typeof delta === "object" && !Array.isArray(delta)
+                ? toRecord(delta)
+                : {};
+              const contentRecord = deltaRecord.delta;
+              const content = contentRecord !== null && typeof contentRecord === "object" && !Array.isArray(contentRecord)
+                ? toRecord(contentRecord).content
+                : undefined;
+              if (typeof content === "string") {
+                yield content;
               }
             } catch {
               // Ignore malformed tail payload.

--- a/packages/web-console/src/lib/admin/resources.ts
+++ b/packages/web-console/src/lib/admin/resources.ts
@@ -43,6 +43,16 @@ export interface BuildTableRowsResourceInput {
 
 const TABLE_ROW_ID_PREFIX = '__svadmin_row_id';
 
+function toRecord(value: object): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) result[key] = item;
+  return result;
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
 const numericTypes = new Set([
   'smallint',
   'integer',
@@ -119,14 +129,14 @@ export function parseTableColumnsResponse(payload: unknown): TableColumnMetadata
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     throw new Error('Invalid table columns response');
   }
-  const data = (payload as Record<string, unknown>).data;
-  if (!Array.isArray(data)) throw new Error('Invalid table columns response');
+  const data = toRecord(payload).data;
+  if (!isUnknownArray(data)) throw new Error('Invalid table columns response');
 
   return data.map((candidate) => {
     if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
       throw new Error('Invalid table column metadata');
     }
-    const column = candidate as Record<string, unknown>;
+    const column = toRecord(candidate);
     if (
       typeof column.column_name !== 'string'
       || column.column_name.length === 0
@@ -161,7 +171,7 @@ export function buildTableRowsResource({
   const usesSyntheticIdentity = primaryKeyColumns.length !== 1;
   const identityKey = usesSyntheticIdentity
     ? syntheticTableRowIdentityKey(columns)
-    : primaryKeyColumns[0]!.column_name;
+    : primaryKeyColumns[0]?.column_name ?? syntheticTableRowIdentityKey(columns);
   const fields: FieldDefinition[] = columns.map((column) => ({
     key: column.column_name,
     label: column.column_name,

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -6,7 +6,7 @@
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
 const SESSION_REFRESH_WINDOW_MS = 2 * 60 * 1000;
-let studioSessionExpiresAtMs = 0;
+let studioSessionExpiresAtMs: number = 0;
 type StudioSessionRefresh = { promise: Promise<StudioSessionState> };
 let studioSessionRefresh: StudioSessionRefresh | null = null;
 

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -46,7 +46,7 @@ export async function ensureMutationSucceeded(response: Response, fallback: stri
 async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
   const value: unknown = await response.json().catch(() => ({}));
   return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
+    ? Object.fromEntries(Object.entries(value))
     : {};
 }
 
@@ -170,7 +170,7 @@ function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): {
   signal: AbortSignal | undefined;
   cleanup: () => void;
 } {
-  const validSignals = signals.filter(Boolean) as AbortSignal[];
+  const validSignals = signals.filter((signal): signal is AbortSignal => signal !== null && signal !== undefined);
   if (validSignals.length === 0) return { signal: undefined, cleanup: () => {} };
   if (validSignals.length === 1) return { signal: validSignals[0], cleanup: () => {} };
 

--- a/packages/web-console/src/lib/database-sql-response.ts
+++ b/packages/web-console/src/lib/database-sql-response.ts
@@ -13,6 +13,10 @@ type DatabaseSqlPayload = {
   statements?: unknown;
 };
 
+function isDatabaseSqlPayload(value: unknown): value is DatabaseSqlPayload {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 export type DatabaseSqlResponse = {
   rows: unknown[];
   rowCount: number;
@@ -49,8 +53,8 @@ async function responsePayload(response: Response): Promise<DatabaseSqlPayload> 
   if (!text) return {};
   try {
     const payload: unknown = JSON.parse(text);
-    return payload && typeof payload === "object" && !Array.isArray(payload)
-      ? payload as DatabaseSqlPayload
+    return isDatabaseSqlPayload(payload)
+      ? payload
       : { message: text };
   } catch {
     return { message: text };

--- a/packages/web-console/src/lib/edge-function-mutation-receipts.ts
+++ b/packages/web-console/src/lib/edge-function-mutation-receipts.ts
@@ -40,8 +40,14 @@ export type FunctionConfigMutationReceipt = {
 
 function record(candidate: unknown): Record<string, unknown> | null {
   return candidate !== null && typeof candidate === "object" && !Array.isArray(candidate)
-    ? candidate as Record<string, unknown>
+    ? toRecord(candidate)
     : null;
+}
+
+function toRecord(value: object): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) result[key] = item;
+  return result;
 }
 
 export function isObservedFunctionActivationId(candidate: unknown): candidate is string {
@@ -64,7 +70,7 @@ function positiveVersion(candidate: unknown): candidate is string {
 }
 
 function stringRoutes(candidate: unknown): candidate is string[] {
-  return Array.isArray(candidate) && candidate.every((route) => typeof route === "string");
+  return Array.isArray(candidate) && candidate.every((route: unknown) => typeof route === "string");
 }
 
 function invalidReceipt(): never {

--- a/packages/web-console/src/lib/physical-backup.ts
+++ b/packages/web-console/src/lib/physical-backup.ts
@@ -47,7 +47,7 @@ function formatSize(size: number): string {
   const units = ["KB", "MB", "GB", "TB"];
   let value = size / 1024;
   let unit = units[0];
-  for (let index = 1; index < units.length && value >= 1024; index += 1) {
+  for (let index: number = 1; index < units.length && value >= 1024; index += 1) {
     value /= 1024;
     unit = units[index];
   }

--- a/packages/web-console/src/lib/sql-tab-names.ts
+++ b/packages/web-console/src/lib/sql-tab-names.ts
@@ -11,7 +11,7 @@ export function nextSqlTabName(tabs: NamedSqlTab[], untitledName: string): strin
   const names = new Set(tabs.map((tab) => normalizedTabName(tab.name)));
 
   // Start at one and fill the first unused suffix so restored tabs remain easy to distinguish.
-  for (let suffix = 1; ; suffix += 1) {
+  for (let suffix: number = 1; ; suffix += 1) {
     const candidate = `${untitledName} ${suffix}`;
     if (!names.has(normalizedTabName(candidate))) return candidate;
   }

--- a/packages/web-console/src/routes/project/[ref]/auth/oauth-server/oauth-server-migration.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth/oauth-server/oauth-server-migration.test.ts
@@ -8,6 +8,23 @@ function oauthResponse(status: number, payload: Record<string, unknown>) {
   };
 }
 
+function enabledStatus(): Record<string, unknown> {
+  return {
+    enabled: true,
+    allow_dynamic_registration: false,
+    issuer: "https://auth.example.test",
+    discovery_url: "https://auth.example.test/.well-known/openid-configuration",
+    oauth_authorization_server_metadata_url: "https://auth.example.test/.well-known/oauth-authorization-server",
+    jwks_url: "https://auth.example.test/.well-known/jwks.json",
+    authorization_endpoint: "https://auth.example.test/authorize",
+    token_endpoint: "https://auth.example.test/token",
+    registration_endpoint: "https://auth.example.test/register",
+    signing_alg: "ES256",
+    oidc_id_token_ready: true,
+    migration_status: "oidc_es256_migrated",
+  };
+}
+
 describe("migrateOAuthServerWithReadback", () => {
   test("keeps an ordinary 503 as a migration failure without a readback", async () => {
     let migrationCalls = 0;
@@ -44,7 +61,7 @@ describe("migrateOAuthServerWithReadback", () => {
       },
       async () => {
         readbackCalls += 1;
-        return oauthResponse(200, { enabled: true, migration_status: "oidc_es256_migrated" });
+        return oauthResponse(200, enabledStatus());
       },
     );
 

--- a/packages/web-console/src/routes/project/[ref]/auth/oauth-server/oauth-server-migration.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth/oauth-server/oauth-server-migration.ts
@@ -39,8 +39,39 @@ function isAppliedDependentRefreshFailure({ response, payload }: OAuthApiRespons
 }
 
 function enabledOAuthServerStatus(payload: unknown): OAuthServerStatus | null {
-  if (!isRecord(payload) || payload.enabled !== true) return null;
-  return payload as OAuthServerStatus;
+  if (!isRecord(payload)
+    || payload.enabled !== true
+    || typeof payload.allow_dynamic_registration !== "boolean"
+    || typeof payload.issuer !== "string"
+    || typeof payload.discovery_url !== "string"
+    || typeof payload.oauth_authorization_server_metadata_url !== "string"
+    || typeof payload.jwks_url !== "string"
+    || typeof payload.authorization_endpoint !== "string"
+    || typeof payload.token_endpoint !== "string"
+    || typeof payload.registration_endpoint !== "string"
+    || typeof payload.signing_alg !== "string"
+    || typeof payload.oidc_id_token_ready !== "boolean"
+    || typeof payload.migration_status !== "string"
+    || (payload.warnings !== undefined
+      && (!Array.isArray(payload.warnings)
+        || !payload.warnings.every((warning: unknown) => typeof warning === "string")))) {
+    return null;
+  }
+  return {
+    enabled: payload.enabled,
+    allow_dynamic_registration: payload.allow_dynamic_registration,
+    issuer: payload.issuer,
+    discovery_url: payload.discovery_url,
+    oauth_authorization_server_metadata_url: payload.oauth_authorization_server_metadata_url,
+    jwks_url: payload.jwks_url,
+    authorization_endpoint: payload.authorization_endpoint,
+    token_endpoint: payload.token_endpoint,
+    registration_endpoint: payload.registration_endpoint,
+    signing_alg: payload.signing_alg,
+    oidc_id_token_ready: payload.oidc_id_token_ready,
+    migration_status: payload.migration_status,
+    ...(payload.warnings ? { warnings: payload.warnings.filter((warning): warning is string => typeof warning === "string") } : {}),
+  };
 }
 
 export async function migrateOAuthServerWithReadback(

--- a/packages/web-console/src/routes/project/[ref]/auth/sessions/session-policy.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth/sessions/session-policy.ts
@@ -143,9 +143,9 @@ function readNumber(field: ConfigField): string {
 }
 
 function parseTokenizedDuration(duration: string): number | null {
-  let cursor = 0;
-  let totalSeconds = 0;
-  let validSequence = true;
+  let cursor: number = 0;
+  let totalSeconds: number = 0;
+  let validSequence: boolean = true;
   DURATION_TOKEN.lastIndex = 0;
   for (let match = DURATION_TOKEN.exec(duration); match; match = DURATION_TOKEN.exec(duration)) {
     if (match.index !== cursor) {

--- a/scripts/check_business_invariants.ts
+++ b/scripts/check_business_invariants.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 
 export interface SqlTableDefinition {
@@ -19,6 +19,15 @@ export const DEFAULT_SQL_FILES = [
   "scripts/002_tasks_queue_schema_patch.sql",
   "scripts/004_background_task_mirror_migration.sql",
 ] as const;
+
+export async function discoverSqlFiles(root: string): Promise<string[]> {
+  const scriptsDir = join(root, "scripts");
+  const entries = await readdir(scriptsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && /^\d+[_-].+\.sql$/i.test(entry.name))
+    .map((entry) => join("scripts", entry.name))
+    .sort();
+}
 
 function normalizeIdentifier(value: string): string {
   return value
@@ -149,7 +158,8 @@ export function checkBusinessInvariants(
 
 async function main() {
   const root = resolve(import.meta.dir, "..");
-  const files = await Promise.all(DEFAULT_SQL_FILES.map(async (relativePath) => ({
+  const relativePaths = await discoverSqlFiles(root);
+  const files = await Promise.all(relativePaths.map(async (relativePath) => ({
     path: relativePath,
     sql: await readFile(join(root, relativePath), "utf8"),
   })));

--- a/scripts/check_workspace_boundaries.ts
+++ b/scripts/check_workspace_boundaries.ts
@@ -6,7 +6,6 @@ interface ProjectConfig {
   tags?: string[];
   path: string;
   dependencies: string[];
-  devDependencies: string[];
 }
 
 interface BoundaryRule {
@@ -54,7 +53,13 @@ async function loadProjects(packagesDir: string): Promise<Map<string, ProjectCon
     const pkgJsonPath = join(pkgDirPath, "package.json");
     const projectJsonPath = join(pkgDirPath, "project.json");
 
-    let pkgJson: { name?: string; dependencies?: Record<string, string>; devDependencies?: Record<string, string> } = {};
+    let pkgJson: {
+      name?: string;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    } = {};
     try {
       pkgJson = JSON.parse(await readFile(pkgJsonPath, "utf8"));
     } catch {
@@ -70,12 +75,17 @@ async function loadProjects(packagesDir: string): Promise<Map<string, ProjectCon
     }
 
     const name = pkgJson.name ?? entry.name;
+    const dependencies = Object.keys({
+      ...(pkgJson.dependencies ?? {}),
+      ...(pkgJson.devDependencies ?? {}),
+      ...(pkgJson.peerDependencies ?? {}),
+      ...(pkgJson.optionalDependencies ?? {}),
+    });
     projects.set(name, {
       name,
       tags,
       path: pkgDirPath,
-      dependencies: Object.keys(pkgJson.dependencies ?? {}),
-      devDependencies: Object.keys(pkgJson.devDependencies ?? {}),
+      dependencies,
     });
   }
 


### PR DESCRIPTION
## Summary
- align runtime DI with Angular public APIs and provider semantics
- preserve reflection-free static compiler factories and static type-safety checks
- add coverage for provider dependency descriptors

## Validation
- app: 128 pass
- compiler: 136 pass
- app/compiler typecheck, test typecheck, and build pass
- git diff --check pass