### PR TITLE
fix(ci): sync local compiler dependency for release

### DIFF
--- a/.github/scripts/sync-compiler-dependency.mjs
+++ b/.github/scripts/sync-compiler-dependency.mjs
@@ -29,7 +29,13 @@ function comparePrecedence(leftVersion, rightVersion) {
   return 0;
 }
 
-function caretLowerBound(range, dependencyName) {
+function caretLowerBound(range, dependencyName, localPackage) {
+  if (typeof range === 'string' && range.startsWith('file:')) {
+    // Local workspace references are valid for development, but never for a
+    // published package. Force release synchronization to emit a registry range.
+    packageVersion(localPackage, dependencyName);
+    return [0n, 0n, 0n];
+  }
   if (typeof range !== 'string' || !range.startsWith('^')) {
     throw new Error(`${dependencyName} has an unsupported dependency range`);
   }
@@ -48,7 +54,11 @@ export function syncCompilerDependency({ cliPackage, compilerPackage }) {
   const compilerVersion = packageVersion(compilerPackage, '@supacloud/compiler');
   const compilerPrecedence = stableVersionPrecedence(compilerVersion, '@supacloud/compiler');
   const currentRange = cliPackage.dependencies['@supacloud/compiler'];
-  const currentPrecedence = caretLowerBound(currentRange, '@supacloud/compiler');
+  const currentPrecedence = caretLowerBound(
+    currentRange,
+    '@supacloud/compiler',
+    compilerPackage,
+  );
   const nextPackage = structuredClone(cliPackage);
   const comparison = comparePrecedence(compilerPrecedence, currentPrecedence);
 

--- a/.github/scripts/sync-compiler-dependency.test.mjs
+++ b/.github/scripts/sync-compiler-dependency.test.mjs
@@ -37,6 +37,15 @@ describe('CLI compiler dependency sync', () => {
     );
   });
 
+  test('converts the local workspace dependency to a publishable range', () => {
+    const synchronization = syncCompilerDependency(packagesWithRange('file:../../packages/compiler', '0.6.0'));
+    assert.equal(synchronization.changed, true);
+    assert.equal(
+      synchronization.package.dependencies['@supacloud/compiler'],
+      '^0.6.0',
+    );
+  });
+
   test('fails closed for a compiler version regression', () => {
     assert.throws(
       () => syncCompilerDependency(packagesWithRange('^0.6.0', '0.5.0')),


### PR DESCRIPTION
## Summary
- accept local `file:` compiler dependencies during release synchronization
- always convert them to a publishable caret range
- add regression coverage

## Verification
- `node --test .github/scripts/sync-compiler-dependency.test.mjs`