### PR TITLE
fix(management-api): migrate legacy task authorities safely

### DIFF
--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -21,22 +21,10 @@ import {
 import { migrateAuditChainSequences } from "./audit-chain-migration";
 import { migrateProjectMutationJournal } from "./project-mutation-migration";
 import { migrateLegacyEncryptedSecretsInTransaction } from "./secret-key-migration";
-import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
 import { withExpectedControlPlaneDatabaseTransaction } from "./control-plane-database-identity";
 
 function sqlStringLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
-}
-
-function taskAuthAuthorityBackfillStatement(): string {
-  const authorityRef = config.authRuntimeOwnerRef.trim();
-  if (!authorityRef) {
-    return "UPDATE project_tasks SET auth_authority_ref = project_ref WHERE auth_authority_ref IS NULL";
-  }
-  if (!/^[A-Za-z0-9_-]{1,20}$/.test(authorityRef)) {
-    throw new Error("SUPACLOUD_AUTH_RUNTIME_OWNER_REF must be a valid project ref");
-  }
-  return `UPDATE project_tasks SET auth_authority_ref = ${sqlStringLiteral(authorityRef)} WHERE auth_authority_ref IS NULL`;
 }
 
 async function backfillOpaqueApiKeys(sql: SQL): Promise<number> {
@@ -548,25 +536,6 @@ export async function initDatabase() {
       { statement: 'UPDATE project_tasks SET next_run_at = COALESCE(next_run_at, created_at, NOW())', description: "project_tasks.next_run_at backfill" },
       { statement: 'UPDATE project_tasks SET max_attempts = COALESCE(max_attempts, 3)', description: "project_tasks.max_attempts backfill" },
       { statement: 'UPDATE project_tasks SET attempt = COALESCE(attempt, retries, 0)', description: "project_tasks.attempt backfill" },
-      { statement: "UPDATE project_tasks SET payload = COALESCE(payload, '{}'::jsonb)", description: "project_tasks.payload backfill" },
-      {
-        statement: `
-          UPDATE project_tasks
-          SET invoker_user_id = BTRIM(payload->'auth'->>'invoker_user_id')::uuid
-          WHERE invoker_user_id IS NULL
-            AND BTRIM(payload->'auth'->>'invoker_user_id')
-              ~* '${GOTRUE_USER_ID_POSTGRES_PATTERN}'
-        `,
-        description: "project_tasks.invoker_user_id backfill",
-      },
-      {
-        statement: taskAuthAuthorityBackfillStatement(),
-        description: "project_tasks.auth_authority_ref backfill",
-      },
-      {
-        statement: 'ALTER TABLE project_tasks ALTER COLUMN auth_authority_ref SET NOT NULL',
-        description: "project_tasks.auth_authority_ref not null",
-      },
       { statement: 'CREATE INDEX IF NOT EXISTS idx_project_tasks_project_status ON project_tasks(project_ref, status)', description: "idx_project_tasks_project_status" },
       { statement: 'CREATE INDEX IF NOT EXISTS idx_project_tasks_project_created_desc ON project_tasks(project_ref, created_at DESC)', description: "idx_project_tasks_project_created_desc" },
       { statement: 'CREATE INDEX IF NOT EXISTS idx_project_tasks_next_run ON project_tasks(next_run_at)', description: "idx_project_tasks_next_run" },

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -11,14 +11,28 @@ import { config } from "../config";
 import { migrateProjectMutationJournal } from "./project-mutation-migration";
 import { executeSqlStatements } from "./sql-statements";
 
-function configuredAuthAuthoritySql(): { backfill: string; constant: string } {
+function configuredAuthAuthoritySql(): { backfill: string; expected: string; constant: string } {
   const authorityRef = config.authRuntimeOwnerRef.trim();
-  if (!authorityRef) return { backfill: "project_ref", constant: "NULL" };
+  if (!authorityRef) {
+    return {
+      backfill: "project_ref",
+      expected: "project_ref",
+      constant: "NULL",
+    };
+  }
   if (!/^[A-Za-z0-9_-]{1,20}$/.test(authorityRef)) {
     throw new Error("SUPACLOUD_AUTH_RUNTIME_OWNER_REF must be a valid project ref");
   }
   const literal = `'${authorityRef.replaceAll("'", "''")}'`;
-  return { backfill: literal, constant: literal };
+  return {
+    backfill: `CASE
+      WHEN status IN ('pending', 'leased', 'running', 'retry_scheduled')
+        THEN ${literal}
+      ELSE project_ref
+    END`,
+    expected: literal,
+    constant: literal,
+  };
 }
 
 /**
@@ -269,22 +283,6 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
 
     ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS invoker_user_id UUID;
     ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS auth_authority_ref VARCHAR(20);
-    UPDATE project_tasks
-    SET invoker_user_id = BTRIM(payload->'auth'->>'invoker_user_id')::uuid
-    WHERE invoker_user_id IS NULL
-      AND BTRIM(payload->'auth'->>'invoker_user_id') ~* '${GOTRUE_USER_ID_POSTGRES_PATTERN}';
-    UPDATE project_tasks
-    SET auth_authority_ref = ${authAuthoritySql.backfill}
-    WHERE auth_authority_ref IS NULL;
-    ALTER TABLE project_tasks ALTER COLUMN auth_authority_ref SET NOT NULL;
-    CREATE INDEX IF NOT EXISTS idx_project_tasks_invoker_active
-      ON project_tasks(project_ref, invoker_user_id, status)
-      WHERE invoker_user_id IS NOT NULL
-        AND status IN ('pending', 'leased', 'running', 'retry_scheduled');
-    CREATE INDEX IF NOT EXISTS idx_project_tasks_authority_invoker_active
-      ON project_tasks(auth_authority_ref, invoker_user_id, status)
-      WHERE invoker_user_id IS NOT NULL
-        AND status IN ('pending', 'leased', 'running', 'retry_scheduled');
 
     CREATE OR REPLACE FUNCTION enforce_project_user_deletion_fence() RETURNS trigger AS $$
     DECLARE
@@ -292,6 +290,12 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       payload_invoker_user_id TEXT;
       normalized_payload_invoker_user_id UUID;
     BEGIN
+      -- Historical terminal rows may retain the authority that was valid for
+      -- their project. Only activation must match the current auth authority.
+      IF NEW.status NOT IN ('pending', 'leased', 'running', 'retry_scheduled') THEN
+        RETURN NEW;
+      END IF;
+
       IF NEW.auth_authority_ref IS NULL THEN
         NEW.auth_authority_ref := COALESCE(configured_authority_ref, NEW.project_ref);
       ELSIF NEW.auth_authority_ref IS DISTINCT FROM COALESCE(configured_authority_ref, NEW.project_ref) THEN
@@ -329,10 +333,6 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
           DETAIL = 'project_tasks.invoker_user_id must match payload.auth.invoker_user_id';
       END IF;
 
-      IF NEW.status NOT IN ('pending', 'leased', 'running', 'retry_scheduled') THEN
-        RETURN NEW;
-      END IF;
-
       PERFORM pg_advisory_xact_lock(hashtextextended(
         '${PROJECT_USER_LIFECYCLE_LOCK_NAMESPACE}:' || NEW.auth_authority_ref || ':' || NEW.invoker_user_id::text,
         0
@@ -354,6 +354,46 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       RETURN NEW;
     END;
     $$ LANGUAGE plpgsql;
+
+    UPDATE project_tasks
+    SET payload = COALESCE(payload, '{}'::jsonb)
+    WHERE payload IS NULL;
+
+    UPDATE project_tasks
+    SET invoker_user_id = BTRIM(payload->'auth'->>'invoker_user_id')::uuid
+    WHERE invoker_user_id IS NULL
+      AND BTRIM(payload->'auth'->>'invoker_user_id') ~* '${GOTRUE_USER_ID_POSTGRES_PATTERN}'
+      AND status IN ('pending', 'leased', 'running', 'retry_scheduled');
+    UPDATE project_tasks
+    SET auth_authority_ref = ${authAuthoritySql.backfill}
+    WHERE auth_authority_ref IS NULL;
+
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM project_tasks
+        WHERE status IN ('pending', 'leased', 'running', 'retry_scheduled')
+          AND auth_authority_ref IS DISTINCT FROM ${authAuthoritySql.expected}
+      ) THEN
+        RAISE EXCEPTION USING
+          ERRCODE = 'P0001',
+          MESSAGE = 'TASK_AUTH_AUTHORITY_MISMATCH',
+          DETAIL = 'Active project_tasks rows must match the configured GoTrue authority';
+      END IF;
+    END;
+    $$;
+
+    ALTER TABLE project_tasks ALTER COLUMN auth_authority_ref SET NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_project_tasks_invoker_active
+      ON project_tasks(project_ref, invoker_user_id, status)
+      WHERE invoker_user_id IS NOT NULL
+        AND status IN ('pending', 'leased', 'running', 'retry_scheduled');
+    CREATE INDEX IF NOT EXISTS idx_project_tasks_authority_invoker_active
+      ON project_tasks(auth_authority_ref, invoker_user_id, status)
+      WHERE invoker_user_id IS NOT NULL
+        AND status IN ('pending', 'leased', 'running', 'retry_scheduled');
+
     DROP TRIGGER IF EXISTS project_tasks_user_deletion_fence ON project_tasks;
     CREATE TRIGGER project_tasks_user_deletion_fence
       BEFORE INSERT OR UPDATE OF status, payload, project_ref, invoker_user_id, auth_authority_ref ON project_tasks

--- a/packages/management-api/tests/unit/platform-v2.schema.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.schema.test.ts
@@ -131,6 +131,24 @@ describe("platform v2 schema contract", () => {
   });
 
   test("serializes task activation with durable GoTrue user deletion fences", () => {
+    const taskFenceTrigger = schema.slice(
+      schema.indexOf("CREATE OR REPLACE FUNCTION enforce_project_user_deletion_fence()"),
+      schema.indexOf("CREATE TABLE IF NOT EXISTS project_webhooks"),
+    );
+    const activeStatusGuard = "IF NEW.status NOT IN ('pending', 'leased', 'running', 'retry_scheduled')";
+    const payloadBackfillIndex = schema.indexOf(
+      "UPDATE project_tasks\n    SET payload = COALESCE(payload, '{}'::jsonb)",
+    );
+    const functionIndex = schema.indexOf(
+      "CREATE OR REPLACE FUNCTION enforce_project_user_deletion_fence()",
+    );
+    const invokerBackfillIndex = schema.indexOf(
+      "UPDATE project_tasks\n    SET invoker_user_id = BTRIM",
+    );
+    const triggerCreateIndex = schema.indexOf(
+      "CREATE TRIGGER project_tasks_user_deletion_fence",
+    );
+
     expect(schema).toContain("CREATE OR REPLACE FUNCTION enforce_project_user_deletion_fence()");
     expect(schema).toContain("pg_advisory_xact_lock(hashtextextended(");
     expect(schema).toContain("AND status IN ('requested', 'deleting', 'deleted')");
@@ -146,12 +164,39 @@ describe("platform v2 schema contract", () => {
     expect(schema).toContain("MESSAGE = 'TASK_INVOKER_MISMATCH'");
     expect(schema).toContain("BEFORE INSERT OR UPDATE OF status, payload, project_ref, invoker_user_id, auth_authority_ref ON project_tasks");
     expect(schema).toContain("MESSAGE = 'USER_DELETION_FENCED'");
+    expect(taskFenceTrigger.indexOf(activeStatusGuard)).toBeGreaterThanOrEqual(0);
+    expect(taskFenceTrigger.indexOf(activeStatusGuard)).toBeLessThan(
+      taskFenceTrigger.indexOf("IF NEW.auth_authority_ref IS NULL"),
+    );
+    expect(taskFenceTrigger.indexOf(activeStatusGuard)).toBeLessThan(
+      taskFenceTrigger.indexOf("MESSAGE = 'TASK_AUTH_AUTHORITY_MISMATCH'"),
+    );
+    expect(taskFenceTrigger.indexOf(activeStatusGuard)).toBeLessThan(
+      taskFenceTrigger.indexOf("payload_invoker_user_id :="),
+    );
+    expect(taskFenceTrigger).toContain(`${activeStatusGuard} THEN`);
+    expect(taskFenceTrigger).toContain("RETURN NEW;\n      END IF;");
+    expect(payloadBackfillIndex).toBeGreaterThanOrEqual(0);
+    expect(functionIndex).toBeLessThan(payloadBackfillIndex);
+    expect(payloadBackfillIndex).toBeLessThan(invokerBackfillIndex);
+    expect(payloadBackfillIndex).toBeLessThan(triggerCreateIndex);
+    expect(schema).toContain("auth_authority_ref IS DISTINCT FROM ${authAuthoritySql.expected}");
+    expect(schema).toContain(
+      "Active project_tasks rows must match the configured GoTrue authority",
+    );
+    expect(schema).toContain("SET auth_authority_ref = ${authAuthoritySql.backfill}");
+    expect(schema).toContain("WHEN status IN ('pending', 'leased', 'running', 'retry_scheduled')");
+    expect(schema).toContain("ELSE project_ref");
+    expect(schema).toContain("SET payload = COALESCE(payload, '{}'::jsonb)");
+    expect(schema).toContain("WHERE payload IS NULL;");
     expect(userSafetyService).toContain("projectUserLifecycleLockKey(projectRef, userId)");
     expect(userSafetyService).toContain("operation_expires_at > NOW() AS operation_active");
     expect(userSafetyService).toContain("AND operation_id = ${input.operationId}::uuid");
     expect(taskRepository).toContain("invoker_user_id = $6::uuid");
     expect(taskRepository).toContain("payload_invoker_user_id = $6::uuid");
-    expect(databaseInit).toContain("WHERE auth_authority_ref IS NULL");
+    expect(databaseInit).not.toContain("UPDATE project_tasks SET payload = COALESCE");
+    expect(databaseInit).not.toContain("UPDATE project_tasks SET auth_authority_ref");
+    expect(databaseInit).not.toContain("DROP TRIGGER IF EXISTS project_tasks_user_deletion_fence");
     expect(databaseInit).not.toContain("SET auth_authority_ref = project_ref\";");
   });
 });


### PR DESCRIPTION
Fix control-plane init-db for existing project_tasks rows when shared GoTrue authority mode is enabled. The migration now installs the terminal-row-compatible fence function before backfills, preserves existing terminal authorities, maps only NULL active authorities to the configured shared owner and terminal NULL values to project_ref, and explicitly rejects existing active authority mismatches. Adds regression coverage for ordering and fail-closed behavior. Validated with 57 targeted unit tests, management-api typecheck, and git diff --check.