### PR TITLE
feat(cli): allow explicit insecure TLS for test environments

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -516,12 +516,14 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     const http = new HttpTransport({
         baseUrl: context.apiUrl,
         token: context.apiToken,
+        insecureTls: context.insecureTls,
     });
     const applicationHttp = context.inferredSupabaseUrl && context.inferredServiceRoleKey
         ? new HttpTransport({
             baseUrl: context.inferredSupabaseUrl,
             token: context.inferredServiceRoleKey,
             apiKey: context.inferredServiceRoleKey,
+            insecureTls: context.insecureTls,
         })
         : undefined;
 

--- a/packages/cli/src/shared/context.test.ts
+++ b/packages/cli/src/shared/context.test.ts
@@ -25,6 +25,28 @@ function writeEnvironment(workspace: string, filename: string, values: Record<st
 }
 
 describe("resolveSupaCloudContext", () => {
+    test("allows explicit insecure TLS only for non-production environments", () => {
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://management.internal.example",
+            SUPACLOUD_API_TOKEN: "token",
+            SUPACLOUD_PROJECT_REF: "project-ref",
+            SUPACLOUD_TLS_INSECURE: "true",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.insecureTls).toBe(true);
+    });
+
+    test("rejects insecure TLS for production environments", () => {
+        expect(() => resolveSupaCloudContext({
+            SUPACLOUD_ENV: "production",
+            SUPACLOUD_API_URL: "https://management.example.com",
+            SUPACLOUD_API_TOKEN: "token",
+            SUPACLOUD_PROJECT_REF: "project-ref",
+            SUPACLOUD_TLS_INSECURE: "true",
+        }, "/tmp/no-such-supacloud-context")).toThrow("forbidden for production");
+    });
+
     test("keeps custom project application credentials out of Management context", () => {
         const context = resolveSupaCloudContext({
             SUPABASE_URL: "https://api.xg.aizhuliren.cn",

--- a/packages/cli/src/shared/context.ts
+++ b/packages/cli/src/shared/context.ts
@@ -28,6 +28,7 @@ export interface ResolvedContext {
     credentialScope: ContextCredentialScope;
     source: ContextSourceKind;
     sourcePath: string | null;
+    insecureTls: boolean;
 }
 
 interface ContextSource {
@@ -162,6 +163,16 @@ function completeProjectContext(values: Record<string, string>): boolean {
     return Boolean(core.apiUrl && core.apiToken && core.projectRef);
 }
 
+function parseInsecureTls(values: Record<string, string>, environment: string): boolean {
+    const requested = values.SUPACLOUD_TLS_INSECURE?.trim().toLowerCase();
+    if (!requested) return false;
+    if (!["1", "true", "yes"].includes(requested)) return false;
+    if (environment === "production") {
+        throw new Error("SUPACLOUD_TLS_INSECURE is forbidden for production environments");
+    }
+    return true;
+}
+
 function namedEnvironmentSource(cwd: string, selector: string): ContextSource {
     const environment = normalizeEnvironmentName(selector);
     const path = resolve(cwd, `.env.supacloud.${selector}`);
@@ -216,6 +227,7 @@ export function resolveSupaCloudContext(
     const core = sourceProjectCore(source.values);
     const host = source.values.SUPACLOUD_HOST || hostFromUrl(core.apiUrl || core.supabaseUrl);
     const readOnly = env.SUPACLOUD_READ_ONLY === "true" || source.values.SUPACLOUD_READ_ONLY === "true";
+    const insecureTls = parseInsecureTls(source.values, source.environment);
 
     return {
         host,
@@ -234,5 +246,6 @@ export function resolveSupaCloudContext(
         credentialScope: core.credentialScope,
         source: source.kind,
         sourcePath: source.path,
+        insecureTls,
     };
 }

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -61,6 +61,7 @@ function context(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
         credentialScope: "management",
         source: "process_env",
         sourcePath: null,
+        insecureTls: false,
         ...overrides,
     };
 }

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -77,6 +77,23 @@ test("HttpTransport sends an optional application API key only when configured",
     ]);
 });
 
+test("HttpTransport opts into Bun's insecure TLS mode only when configured", async () => {
+    const tlsOptions: unknown[] = [];
+    globalThis.fetch = (async (_input, init) => {
+        tlsOptions.push((init as RequestInit & { tls?: unknown }).tls);
+        return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await createTransport().get("/strict");
+    await new HttpTransport({
+        baseUrl: "https://api.example.test",
+        token: "test-token",
+        insecureTls: true,
+    }).get("/insecure");
+
+    expect(tlsOptions).toEqual([undefined, { rejectUnauthorized: false }]);
+});
+
 function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET"): Error {
     const error = new Error(kind);
     if (kind === "AbortError") error.name = kind;

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -9,6 +9,7 @@ export interface HttpConfig {
     baseUrl: string;
     token: string;
     apiKey?: string;
+    insecureTls?: boolean;
 }
 
 export interface HttpResult<T = unknown> {
@@ -136,15 +137,17 @@ async function fetchWithTimeout(
     url: string,
     options: RequestInit,
     timeoutMs = DEFAULT_TIMEOUT,
+    insecureTls = false,
 ): Promise<Response> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
         return await fetch(url, {
             ...options,
+            ...(insecureTls ? { tls: { rejectUnauthorized: false } } : {}),
             signal: controller.signal,
             redirect: "error",
-        });
+        } as RequestInit);
     } finally {
         clearTimeout(timeout);
     }
@@ -154,11 +157,12 @@ async function fetchWithRetry(
     url: string,
     options: RequestInit,
     timeoutMs = DEFAULT_TIMEOUT,
+    insecureTls = false,
 ): Promise<Response> {
     const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
     for (let attempt: number = 0; attempt <= retries; attempt++) {
         try {
-            const res = await fetchWithTimeout(url, options, timeoutMs);
+            const res = await fetchWithTimeout(url, options, timeoutMs, insecureTls);
 
             if (res.status >= 500 && res.status < 600 && attempt < retries) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
@@ -334,11 +338,13 @@ export class HttpTransport {
     private baseUrl: string;
     private token: string;
     private apiKey: string;
+    private insecureTls: boolean;
 
     constructor(config: HttpConfig) {
         this.baseUrl = config.baseUrl.replace(/\/$/, "");
         this.token = config.token;
         this.apiKey = config.apiKey ?? "";
+        this.insecureTls = config.insecureTls ?? false;
     }
 
     private headers(): Record<string, string> {
@@ -361,7 +367,7 @@ export class HttpTransport {
                 method,
                 headers: this.headers(),
                 body: serializedBody,
-            }, timeoutMs);
+            }, timeoutMs, this.insecureTls);
             const responseBody = await responseReader(response);
             return responseBody.ok
                 ? { ok: response.ok, status: response.status, data: responseBody.parsedJson }
@@ -382,7 +388,7 @@ export class HttpTransport {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "GET",
                 headers: this.headers(),
-            });
+            }, DEFAULT_TIMEOUT, this.insecureTls);
             if (maxJsonBytes !== undefined) {
                 const data = await boundedResponseJson(res, maxJsonBytes, responseTimeoutMs);
                 return data === null
@@ -416,7 +422,7 @@ export class HttpTransport {
                 method: "POST",
                 headers: this.headers(),
                 body: serializedRequestBody(body),
-            }, timeoutMs);
+            }, timeoutMs, this.insecureTls);
             const data = await boundedResponseJson(response, maxJsonBytes, responseTimeoutMs);
             return data === null
                 ? responseReadFailure<T>(response.status)
@@ -472,7 +478,7 @@ export class HttpTransport {
                 body: body.stream,
                 duplex: "half",
             } as RequestInit & { duplex: "half" };
-            const response = await fetchWithRetry(`${this.baseUrl}${path}`, request, timeoutMs);
+            const response = await fetchWithRetry(`${this.baseUrl}${path}`, request, timeoutMs, this.insecureTls);
             const data = await boundedResponseJson(response, maxJsonBytes, responseTimeoutMs);
             return data === null
                 ? responseReadFailure<T>(response.status)
@@ -507,7 +513,7 @@ export class HttpTransport {
                 method: "POST",
                 headers,
                 body: formData,
-            });
+            }, DEFAULT_TIMEOUT, this.insecureTls);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
@@ -521,7 +527,7 @@ export class HttpTransport {
                 method: "PATCH",
                 headers: this.headers(),
                 body: body ? JSON.stringify(body) : undefined,
-            });
+            }, DEFAULT_TIMEOUT, this.insecureTls);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
@@ -535,7 +541,7 @@ export class HttpTransport {
                 method: "PUT",
                 headers: this.headers(),
                 body: body ? JSON.stringify(body) : undefined,
-            });
+            }, DEFAULT_TIMEOUT, this.insecureTls);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
@@ -549,7 +555,7 @@ export class HttpTransport {
                 method: "DELETE",
                 headers: this.headers(),
                 body: serializedRequestBody(body),
-            });
+            }, DEFAULT_TIMEOUT, this.insecureTls);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {


### PR DESCRIPTION
## 背景
内网测试环境使用 Caddy 内部 CA，CLI 在未导入本地证书时因 TLS 校验失败而将请求表现为网络错误。

## 变更
- 新增 `SUPACLOUD_TLS_INSECURE=true` 配置。
- 仅非生产环境允许；生产环境显式拒绝。
- 默认仍启用 TLS 证书校验。
- 所有 CLI HTTP 请求统一透传 Bun TLS 配置。
- 增加上下文、传输和生产保护测试。

## 验证
- `bun run --cwd packages/cli typecheck`
- `bun test packages/cli/src/shared/context.test.ts packages/cli/src/shared/transports/http.test.ts packages/cli/src/shared/execution-policy.test.ts`
- 149 pass / 0 fail