### PR TITLE
fix(management-api): avoid project get 500 on status probe failure

### DIFF
--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -281,7 +281,7 @@ function buildPitrStatus(ref: string, stanza: string, backups: BackupInfo[]) {
   };
 }
 
-async function buildProjectResponse(
+export async function buildProjectResponse(
   project: any,
   detailed = false,
 ): Promise<Record<string, unknown>> {
@@ -335,7 +335,15 @@ async function buildProjectResponse(
     connectionCount = connectionResult[0]?.count || 0;
   } catch {}
 
-  const serviceStatuses = await tenantRuntimeService.getProjectServiceStatuses(ref, project.config, "detail");
+  let serviceStatuses: Awaited<ReturnType<typeof tenantRuntimeService.getProjectServiceStatuses>> | undefined;
+  try {
+    serviceStatuses = await tenantRuntimeService.getProjectServiceStatuses(ref, project.config, "detail");
+  } catch (error: unknown) {
+    logger.warn("[ProjectCRUD] Project service status probe failed; returning project details without services", {
+      ref,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   return {
     ...base,
@@ -353,7 +361,7 @@ async function buildProjectResponse(
     db_name: dbName,
     db_user: dbUser,
     connection_string: `postgresql://${dbUser}:[YOUR-PASSWORD]@${project.database?.host || "localhost"}:${(project.database as Record<string, unknown>)?.port || 5432}/${dbName}`,
-    services: serviceStatuses,
+    ...(serviceStatuses ? { services: serviceStatuses } : {}),
     anon_key: project.anon_key,
     api: project.api,
     studio: project.studio,

--- a/packages/management-api/tests/unit/project-crud-public-config.test.ts
+++ b/packages/management-api/tests/unit/project-crud-public-config.test.ts
@@ -1,8 +1,10 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import {
+  buildProjectResponse,
   toPublicV1ProjectCreateResponse,
   toPublicV1ProjectWithDatabaseResponse,
 } from "../../src/routes/project-crud";
+import { tenantRuntimeService } from "../../src/services/tenant-runtime.service";
 import { publicScheduledFunctionProjectConfig } from "../../src/utils/scheduled-function-config";
 
 function unsignedRoleKey(
@@ -55,6 +57,36 @@ test("project detail serialization redacts scheduled Function payloads", () => {
   expect(schedules[0]).not.toHaveProperty("headers");
   expect(responseText).not.toContain(bodySentinel);
   expect(responseText).not.toContain(headerSentinel);
+});
+
+test("project detail remains available when service status probing fails", async () => {
+  const statusProbe = spyOn(tenantRuntimeService, "getProjectServiceStatuses")
+    .mockRejectedValueOnce(new Error("runtime probe unavailable"));
+
+  try {
+    const response = await buildProjectResponse({
+      id: "project-id",
+      ref: "abcdefghijklmnopqrst",
+      name: "Project",
+      status: "active",
+      region: "local",
+      organization_id: "default",
+      created_at: new Date("2026-09-06T00:00:00.000Z"),
+      updated_at: new Date("2026-09-06T00:00:00.000Z"),
+      config: {},
+      database: { host: "db.example.test" },
+      api: { url: "https://api.example.test" },
+      studio: { url: "https://studio.example.test" },
+    }, true);
+
+    expect(response.ref).toBe("abcdefghijklmnopqrst");
+    expect(response.api).toEqual({ url: "https://api.example.test" });
+    expect(response).not.toHaveProperty("services");
+    expect(JSON.stringify(response)).not.toContain("runtime probe unavailable");
+    expect(statusProbe).toHaveBeenCalledTimes(1);
+  } finally {
+    statusProbe.mockRestore();
+  }
 });
 
 test("project detail serialization preserves redaction metadata when applied twice", () => {


### PR DESCRIPTION
## Summary
- keep `GET /v1/projects/:ref` available when optional service-status probing fails
- log the probe failure and omit only the unavailable `services` field
- add a regression test covering the failure path without reflecting the error text

## Root cause
Project detail assembly already degraded database metrics, but `tenantRuntimeService.getProjectServiceStatuses()` was awaited without a guard. Any runtime/systemd probe exception therefore converted an otherwise readable project response into HTTP 500.

## Validation
- `bun test tests/unit/project-crud-public-config.test.ts`
- `bun test src/project-read-process.test.ts src/shared/tools/project-cli-tools.test.ts`
- `bun run typecheck`
- `git diff --check`

The related `project-services.runtime.test.ts` could not load in this local shell because `DATABASE_URL` is not configured; this is an environment prerequisite failure, not a test assertion failure.