### PR TITLE
fix(ci): publish CLI with registry compiler dependency

### DIFF
--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -159,8 +159,8 @@ describe('trusted review workflow', () => {
       if (contents === releaseWorkflow) {
         assert.deepEqual(lockfileGenerationLines, [
           '            bun install --lockfile-only --registry https://registry.npmjs.org',
-          '          bun install --lockfile-only --registry https://registry.npmjs.org',
-          '          bun install --lockfile-only --registry https://registry.npmjs.org',
+          '            bun install --lockfile-only --registry https://registry.npmjs.org',
+          '            bun install --lockfile-only --registry https://registry.npmjs.org',
         ]);
       } else {
         assert.deepEqual(lockfileGenerationLines, []);

--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -158,9 +158,9 @@ describe('trusted review workflow', () => {
       }
       if (contents === releaseWorkflow) {
         assert.deepEqual(lockfileGenerationLines, [
-          '            bun install --lockfile-only --registry https://registry.npmjs.org',
-          '            bun install --lockfile-only --registry https://registry.npmjs.org',
-          '            bun install --lockfile-only --registry https://registry.npmjs.org',
+          '          bun install --lockfile-only --registry https://registry.npmjs.org',
+          '          bun install --lockfile-only --registry https://registry.npmjs.org',
+          '          bun install --lockfile-only --registry https://registry.npmjs.org',
         ]);
       } else {
         assert.deepEqual(lockfileGenerationLines, []);

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -471,25 +471,27 @@ jobs:
         if: ${{ needs.release-please.outputs.cli_released == 'true' }}
         working-directory: packages/cli
         run: |
-          if [[ "${{ needs.release-please.outputs.compiler_released }}" == "true" ]]; then
-            compiler_version="$(node -p "require('../compiler/package.json').version")"
-            published=""
-            for attempt in $(seq 1 12); do
-              published="$(npm view "@supacloud/compiler@$compiler_version" version 2>/dev/null || true)"
-              if [[ "$published" == "$compiler_version" ]]; then
-                break
-              fi
-              if [[ "$attempt" -lt 12 ]]; then
-                sleep 5
-              fi
-            done
-            if [[ "$published" != "$compiler_version" ]]; then
-              echo "Published compiler is not visible: @supacloud/compiler@$compiler_version" >&2
-              exit 1
+          # npm packages cannot contain a local `file:` dependency. The CLI
+          # keeps a workspace reference for development, so resolve it to the
+          # published compiler before every release (including CLI-only
+          # releases where the compiler was not released in the same run).
+          compiler_version="$(node -p "require('../compiler/package.json').version")"
+          published=""
+          for attempt in $(seq 1 12); do
+            published="$(npm view "@supacloud/compiler@$compiler_version" version 2>/dev/null || true)"
+            if [[ "$published" == "$compiler_version" ]]; then
+              break
             fi
-            node "$GITHUB_WORKSPACE/.github/scripts/sync-compiler-dependency.mjs"
-            bun install --lockfile-only --registry https://registry.npmjs.org
+            if [[ "$attempt" -lt 12 ]]; then
+              sleep 5
+            fi
+          done
+          if [[ "$published" != "$compiler_version" ]]; then
+            echo "Published compiler is not visible: @supacloud/compiler@$compiler_version" >&2
+            exit 1
           fi
+          node "$GITHUB_WORKSPACE/.github/scripts/sync-compiler-dependency.mjs"
+          bun install --lockfile-only --registry https://registry.npmjs.org
           bun install --frozen-lockfile --registry https://registry.npmjs.org
           bun run build
           node "$GITHUB_WORKSPACE/.github/scripts/publish-npm-package.mjs"


### PR DESCRIPTION
修复 Release Please 中 CLI 发布失败问题：发布前始终将本地 compiler file 依赖转换为已发布的 npm 版本，并重新生成 lockfile。