### PR TITLE
feat(cli): default to permissive TLS for internal deployments

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -66,6 +66,28 @@ SUPACLOUD_API_TOKEN=<production-management-api-token>
 SUPACLOUD_PROJECT_REF=production-ref
 ```
 
+CLI requests (including `status`) default to `SUPACLOUD_TLS_VERIFY=false`, skipping HTTPS certificate verification so that
+air-gapped installations using private or self-signed certificates work
+without extra configuration. To enable strict certificate verification, set:
+
+```dotenv
+SUPACLOUD_TLS_VERIFY=true
+```
+
+This setting only affects HTTPS requests made by the CLI transport. It does not
+change server-side SupaCloud, Caddy, Edge Runtime, or browser certificate
+verification. Keep the default only on trusted internal networks; use a
+trusted CA and `SUPACLOUD_TLS_VERIFY=true` for public or untrusted networks.
+The legacy inverse setting `SUPACLOUD_TLS_INSECURE=false` is also accepted.
+`SUPACLOUD_TLS_VERIFY` takes precedence if both are present. Both settings use
+the selected context source, not a mix of profile and process variables.
+Values accept `true/false`, `1/0`, `yes/no`, and `on/off` (case-insensitive).
+Invalid or empty values stop the command before requests are sent.
+Skipping verification accepts any certificate, not just a private CA, and
+removes server identity authentication. HTTPS encryption and redirect refusal
+remain enabled. Install your organization's CA and set verification to `true`
+where identity authentication is required.
+
 Run commands with the selected profile:
 
 ```bash

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -74,7 +74,7 @@ function failedEndpointProbe(error: unknown): EndpointProbe {
     return { reachable: false, ok: false, httpStatus: null, error: timedOut ? "timeout" : "unreachable" };
 }
 
-async function probeEndpoint(url: string, headers?: HeadersInit): Promise<EndpointProbe> {
+async function probeEndpoint(url: string, headers?: HeadersInit, insecureTls = false): Promise<EndpointProbe> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3_000);
     try {
@@ -82,6 +82,7 @@ async function probeEndpoint(url: string, headers?: HeadersInit): Promise<Endpoi
             method: "GET",
             headers,
             redirect: "error",
+            ...(new URL(url).protocol === "https:" ? { tls: { rejectUnauthorized: !insecureTls } } : {}),
             signal: controller.signal,
         });
         return successfulEndpointProbe(response);
@@ -172,13 +173,14 @@ async function collectProjectStatusChecks(context: ResolvedContext): Promise<Pro
     const missing = missingProjectContextFields(context);
     const probePlan = projectStatusProbePlan(context);
     const connectivity = probePlan.apiUrl
-        ? await probeEndpoint(`${probePlan.apiUrl}${probePlan.connectivityPath}`)
+        ? await probeEndpoint(`${probePlan.apiUrl}${probePlan.connectivityPath}`, undefined, context.insecureTls)
         : null;
     const connectivityOk = connectivityProbeIsHealthy(context.credentialScope, connectivity);
     const authentication = missing.length === 0 && connectivityOk
         ? await probeEndpoint(
             `${probePlan.apiUrl}${probePlan.authenticationPath}`,
             probePlan.authenticationHeaders,
+            context.insecureTls,
         )
         : null;
     return projectStatusChecks(missing, connectivity, authentication, connectivityOk);

--- a/packages/cli/src/shared/context.test.ts
+++ b/packages/cli/src/shared/context.test.ts
@@ -25,26 +25,39 @@ function writeEnvironment(workspace: string, filename: string, values: Record<st
 }
 
 describe("resolveSupaCloudContext", () => {
-    test("allows explicit insecure TLS only for non-production environments", () => {
+    test("defaults to insecure TLS for internal and production environments", () => {
         const context = resolveSupaCloudContext({
-            SUPACLOUD_ENV: "test",
+            SUPACLOUD_ENV: "production",
             SUPACLOUD_API_URL: "https://management.internal.example",
             SUPACLOUD_API_TOKEN: "token",
             SUPACLOUD_PROJECT_REF: "project-ref",
-            SUPACLOUD_TLS_INSECURE: "true",
         }, "/tmp/no-such-supacloud-context");
 
         expect(context.insecureTls).toBe(true);
     });
 
-    test("rejects insecure TLS for production environments", () => {
-        expect(() => resolveSupaCloudContext({
+    test("allows strict TLS when explicitly configured", () => {
+        const context = resolveSupaCloudContext({
             SUPACLOUD_ENV: "production",
             SUPACLOUD_API_URL: "https://management.example.com",
             SUPACLOUD_API_TOKEN: "token",
             SUPACLOUD_PROJECT_REF: "project-ref",
-            SUPACLOUD_TLS_INSECURE: "true",
-        }, "/tmp/no-such-supacloud-context")).toThrow("forbidden for production");
+            SUPACLOUD_TLS_VERIFY: "true",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.insecureTls).toBe(false);
+    });
+
+    test("supports the previous inverse-named setting for compatibility", () => {
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://management.internal.example",
+            SUPACLOUD_API_TOKEN: "token",
+            SUPACLOUD_PROJECT_REF: "project-ref",
+            SUPACLOUD_TLS_INSECURE: "false",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.insecureTls).toBe(false);
     });
 
     test("keeps custom project application credentials out of Management context", () => {

--- a/packages/cli/src/shared/context.ts
+++ b/packages/cli/src/shared/context.ts
@@ -163,12 +163,13 @@ function completeProjectContext(values: Record<string, string>): boolean {
     return Boolean(core.apiUrl && core.apiToken && core.projectRef);
 }
 
-function parseInsecureTls(values: Record<string, string>, environment: string): boolean {
-    const requested = values.SUPACLOUD_TLS_INSECURE?.trim().toLowerCase();
-    if (!requested) return false;
-    if (!["1", "true", "yes"].includes(requested)) return false;
-    if (environment === "production") {
-        throw new Error("SUPACLOUD_TLS_INSECURE is forbidden for production environments");
+function parseInsecureTls(values: Record<string, string>): boolean {
+    for (const key of ["SUPACLOUD_TLS_VERIFY", "SUPACLOUD_TLS_INSECURE"]) {
+        const value = values[key]?.trim().toLowerCase();
+        if (value === undefined) continue;
+        if (["1", "true", "yes", "on"].includes(value)) return key === "SUPACLOUD_TLS_INSECURE";
+        if (["0", "false", "no", "off"].includes(value)) return key === "SUPACLOUD_TLS_VERIFY";
+        throw new Error(`${key} must be a boolean (true or false)`);
     }
     return true;
 }
@@ -227,7 +228,7 @@ export function resolveSupaCloudContext(
     const core = sourceProjectCore(source.values);
     const host = source.values.SUPACLOUD_HOST || hostFromUrl(core.apiUrl || core.supabaseUrl);
     const readOnly = env.SUPACLOUD_READ_ONLY === "true" || source.values.SUPACLOUD_READ_ONLY === "true";
-    const insecureTls = parseInsecureTls(source.values, source.environment);
+    const insecureTls = parseInsecureTls(source.values);
 
     return {
         host,

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -77,21 +77,37 @@ test("HttpTransport sends an optional application API key only when configured",
     ]);
 });
 
-test("HttpTransport opts into Bun's insecure TLS mode only when configured", async () => {
+test("HttpTransport defaults to insecure TLS and allows an explicit strict override", async () => {
     const tlsOptions: unknown[] = [];
     globalThis.fetch = (async (_input, init) => {
         tlsOptions.push((init as RequestInit & { tls?: unknown }).tls);
         return Response.json({ ok: true });
     }) as typeof fetch;
 
-    await createTransport().get("/strict");
+    await createTransport().get("/insecure");
     await new HttpTransport({
         baseUrl: "https://api.example.test",
         token: "test-token",
-        insecureTls: true,
-    }).get("/insecure");
+        insecureTls: false,
+    }).get("/strict");
 
-    expect(tlsOptions).toEqual([undefined, { rejectUnauthorized: false }]);
+    expect(tlsOptions).toEqual([{ rejectUnauthorized: false }, { rejectUnauthorized: true }]);
+});
+
+test("HttpTransport never adds TLS options to HTTP URLs", async () => {
+    const tlsOptions: unknown[] = [];
+    globalThis.fetch = (async (_input, init) => {
+        tlsOptions.push((init as RequestInit & { tls?: unknown }).tls);
+        return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await new HttpTransport({
+        baseUrl: "http://127.0.0.1:9090",
+        token: "test-token",
+        insecureTls: true,
+    }).get("/health");
+
+    expect(tlsOptions).toEqual([undefined]);
 });
 
 function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET"): Error {

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -53,6 +53,7 @@ export interface HttpBinaryBody {
 const DEFAULT_TIMEOUT = 30_000;
 const MAX_POST_TIMEOUT_MS = 36 * 60_000;
 const RELEASE_MUTATION_RESPONSE_TIMEOUT = 5_000;
+
 const RELEASE_MUTATION_RESPONSE_MAX_BYTES = 64 * 1024;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
@@ -144,7 +145,7 @@ async function fetchWithTimeout(
     try {
         return await fetch(url, {
             ...options,
-            ...(insecureTls ? { tls: { rejectUnauthorized: false } } : {}),
+            ...(new URL(url).protocol === "https:" ? { tls: { rejectUnauthorized: !insecureTls } } : {}),
             signal: controller.signal,
             redirect: "error",
         } as RequestInit);
@@ -344,7 +345,7 @@ export class HttpTransport {
         this.baseUrl = config.baseUrl.replace(/\/$/, "");
         this.token = config.token;
         this.apiKey = config.apiKey ?? "";
-        this.insecureTls = config.insecureTls ?? false;
+        this.insecureTls = config.insecureTls ?? true;
     }
 
     private headers(): Record<string, string> {


### PR DESCRIPTION
## 变更

- CLI HTTPS 请求默认跳过证书校验，兼容纯内网和自签名证书部署。
- `SUPACLOUD_TLS_VERIFY=true` 可恢复严格证书校验。
- 兼容已有 `SUPACLOUD_TLS_INSECURE=false` 配置。
- HTTP 请求不会附加 TLS 选项。

## 范围与风险

- 仅影响 SupaCloud CLI 发起的 HTTPS 请求，不改变服务端 SupaCloud、Caddy、Edge Runtime 或浏览器校验策略。
- 默认行为适用于受信任内网；公网或不受信网络应配置 `SUPACLOUD_TLS_VERIFY=true`，并优先使用受信 CA。

## 验证

- `bun test`（packages/cli）：996 pass / 0 fail
- `bun run typecheck`（packages/cli）
- `git diff --check`