### PR TITLE
feat(compiler): configure command capabilities

### DIFF
--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -44,11 +44,19 @@ export default defineSupacloudConfig({
   generateClient: true,
   generatePermissions: true,
   moduleBoundaryPreset: "modular-monolith",
+  commandCapabilities: {
+    permission: true,
+    audit: true,
+    idempotency: true,
+    transaction: true,
+  },
 });
 ```
 
 命令行参数优先级高于配置文件。`--no-strict`、`--no-client` 和
 `--no-permissions` 只建议用于本地迁移或调试；生产 CI 应保留默认 strict。
+`commandCapabilities` 用于声明运行时实际支持的命令治理能力；命令声明了
+`permission`、`audit` 或 `idempotency` 时，若对应能力关闭，编译器会失败。
 
 ## API
 

--- a/packages/compiler/src/config.test.ts
+++ b/packages/compiler/src/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { defineSupacloudConfig, resolveSupacloudConfig } from "./config";
+import {
+  compileOptionsFromConfig,
+  defineSupacloudConfig,
+  resolveSupacloudConfig,
+} from "./config";
 
 describe("SupaCloud default configuration", () => {
   test("provides a strict zero-config project baseline", () => {
@@ -28,6 +32,24 @@ describe("SupaCloud default configuration", () => {
       generateClient: false,
       generatePermissions: true,
       moduleBoundaryPreset: "clean-architecture",
+    });
+  });
+
+  test("passes command execution capabilities to compiler validation", () => {
+    const config = defineSupacloudConfig({
+      commandCapabilities: {
+        permission: true,
+        audit: false,
+        idempotency: false,
+        transaction: "rpc-only",
+      },
+    });
+
+    expect(compileOptionsFromConfig(config, "/workspace/app").commandCapabilities).toEqual({
+      permission: true,
+      audit: false,
+      idempotency: false,
+      transaction: "rpc-only",
     });
   });
 });

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -1,7 +1,11 @@
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import type { CompileOptions, ModuleBoundaryPresetName } from "./types";
+import type {
+  CommandExecutionCapabilities,
+  CompileOptions,
+  ModuleBoundaryPresetName,
+} from "./types";
 
 export interface SupaCloudConfig {
   root?: string;
@@ -11,10 +15,14 @@ export interface SupaCloudConfig {
   generateClient?: boolean;
   generatePermissions?: boolean;
   moduleBoundaryPreset?: ModuleBoundaryPresetName;
+  commandCapabilities?: CommandExecutionCapabilities;
   treeShakeUnusedProviders?: boolean;
 }
 
-export const DEFAULT_SUPACLOUD_CONFIG: Required<Omit<SupaCloudConfig, "include" | "moduleBoundaryPreset">> & {
+export const DEFAULT_SUPACLOUD_CONFIG: Required<Omit<
+  SupaCloudConfig,
+  "include" | "moduleBoundaryPreset" | "commandCapabilities"
+>> & {
   include: string[];
   moduleBoundaryPreset: ModuleBoundaryPresetName;
 } = {
@@ -47,6 +55,7 @@ export function resolveSupacloudConfig(
   generateClient: boolean;
   generatePermissions: boolean;
   moduleBoundaryPreset: ModuleBoundaryPresetName;
+  commandCapabilities?: CommandExecutionCapabilities;
   treeShakeUnusedProviders: boolean;
 } {
   const resolved = defineSupacloudConfig(config);
@@ -58,6 +67,7 @@ export function resolveSupacloudConfig(
     generateClient: resolved.generateClient ?? DEFAULT_SUPACLOUD_CONFIG.generateClient,
     generatePermissions: resolved.generatePermissions ?? DEFAULT_SUPACLOUD_CONFIG.generatePermissions,
     moduleBoundaryPreset: resolved.moduleBoundaryPreset ?? DEFAULT_SUPACLOUD_CONFIG.moduleBoundaryPreset,
+    commandCapabilities: resolved.commandCapabilities,
     treeShakeUnusedProviders: resolved.treeShakeUnusedProviders ?? DEFAULT_SUPACLOUD_CONFIG.treeShakeUnusedProviders,
   };
 }
@@ -90,6 +100,7 @@ export function compileOptionsFromConfig(
     generateClient: resolved.generateClient,
     generatePermissions: resolved.generatePermissions,
     moduleBoundaryPreset: resolved.moduleBoundaryPreset,
+    commandCapabilities: resolved.commandCapabilities,
     treeShakeUnusedProviders: resolved.treeShakeUnusedProviders,
   };
 }


### PR DESCRIPTION
## Summary

- expose compiler command execution capabilities through `supacloud.config.ts`
- pass configured capabilities into `compileProject` and CLI validation
- document and test permission, audit, idempotency, and transaction capability gates

## Scope boundary

This is framework-only. It does not introduce FA state machines, RPCs, RLS, projections, business receipts, or release policy. Applications retain ownership of their domain facts and may opt into the generic capability declaration.

## Verification

- `bun run --cwd packages/compiler typecheck`
- `bun run --cwd packages/compiler build`
- `bun test packages/compiler/src/config.test.ts packages/compiler/src/validate.test.ts`
- `git diff --check`

Results: 55 tests passed, 0 failed.