### PR TITLE
feat(management-api): add generic release control contract

### DIFF
--- a/packages/management-api/src/release-control-contract.test.ts
+++ b/packages/management-api/src/release-control-contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertReleaseReceiptTransition,
+  parseReleaseReceipt,
+  parseReleaseScope,
+  releaseScopeSha256,
+} from "./release-control-contract";
+
+const scope = {
+  schema: "supacloud.release-control.v1",
+  releaseId: "release-20260906-001",
+  sourceCommit: "a".repeat(40),
+  targetProjectRef: "a".repeat(20),
+  components: [
+    { kind: "function", slug: "fa-api", artifactSha256: "b".repeat(64) },
+    { kind: "migration", name: "20260906120000_feedback_assignee_name_fallback" },
+    { kind: "web", artifactSha256: "c".repeat(64) },
+  ],
+} as const;
+
+describe("release control contract", () => {
+  test("parses a deterministic cross-surface scope and hashes its canonical form", () => {
+    const parsed = parseReleaseScope(scope);
+    expect(releaseScopeSha256(parsed)).toHaveLength(64);
+    expect(releaseScopeSha256(parsed)).toBe(releaseScopeSha256(parseReleaseScope({
+      schema: scope.schema,
+      releaseId: scope.releaseId,
+      sourceCommit: scope.sourceCommit,
+      targetProjectRef: scope.targetProjectRef,
+      components: scope.components.map((component) => ({ ...component })),
+    })));
+  });
+
+  test("rejects duplicate or unsorted release components", () => {
+    expect(() => parseReleaseScope({
+      ...scope,
+      components: [scope.components[1], scope.components[0], scope.components[2]],
+    })).toThrow("unique and sorted");
+  });
+
+  test("requires read-back payloads for applied and reconciled receipts", () => {
+    const receipt = parseReleaseReceipt({
+      schema: "supacloud.release-control.v1",
+      releaseId: scope.releaseId,
+      scopeSha256: "d".repeat(64),
+      phase: "reconciled",
+      beforeReadBack: { functions: [] },
+      afterReadBack: { functions: [{ slug: "fa-api", artifactSha256: "b".repeat(64) }] },
+    });
+    expect(receipt.phase).toBe("reconciled");
+    expect(() => parseReleaseReceipt({
+      ...receipt,
+      afterReadBack: null,
+    })).toThrow("requires before and after read-back");
+  });
+
+  test("allows recovery from unknown mutation outcomes but rejects terminal rewrites", () => {
+    expect(() => assertReleaseReceiptTransition("mutating", "rollback-required")).not.toThrow();
+    expect(() => assertReleaseReceiptTransition("rollback-required", "reconciled")).not.toThrow();
+    expect(() => assertReleaseReceiptTransition("reconciled", "mutating")).toThrow("Invalid release receipt transition");
+    expect(() => assertReleaseReceiptTransition("rolled-back", "reconciled")).toThrow("Invalid release receipt transition");
+  });
+});

--- a/packages/management-api/src/release-control-contract.ts
+++ b/packages/management-api/src/release-control-contract.ts
@@ -60,15 +60,6 @@ function nonEmptyString(value: unknown, label: string, pattern?: RegExp): string
   return value;
 }
 
-function stringArray(value: unknown, label: string, pattern: RegExp): string[] {
-  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
-  const result = value.map((item) => nonEmptyString(item, label, pattern));
-  if (new Set(result).size !== result.length || [...result].sort().some((item, index) => item !== result[index])) {
-    throw new Error(`${label} must be unique and sorted`);
-  }
-  return result;
-}
-
 function parseComponent(value: unknown, index: number): ReleaseComponent {
   const candidate = record(value, `Release component ${index}`);
   if (candidate.kind === "migration") {

--- a/packages/management-api/src/release-control-contract.ts
+++ b/packages/management-api/src/release-control-contract.ts
@@ -1,0 +1,184 @@
+import { createHash } from "node:crypto";
+
+export const RELEASE_CONTROL_CONTRACT_VERSION = "supacloud.release-control.v1";
+
+const SHA256 = /^[0-9a-f]{64}$/;
+const COMMIT = /^[0-9a-f]{40}$/;
+const PROJECT_REF = /^[a-z0-9]{20}$/;
+const FUNCTION_SLUG = /^[a-z0-9][a-z0-9-]{0,62}$/;
+const MIGRATION_NAME = /^\d{14}_[a-z0-9_]+$/;
+
+export type ReleaseComponent =
+  | { kind: "migration"; name: string }
+  | { kind: "function"; slug: string; artifactSha256: string }
+  | { kind: "web"; artifactSha256: string };
+
+export interface ReleaseScope {
+  schema: typeof RELEASE_CONTROL_CONTRACT_VERSION;
+  releaseId: string;
+  sourceCommit: string;
+  targetProjectRef: string;
+  components: ReleaseComponent[];
+}
+
+export type ReleaseReceiptPhase =
+  | "planned"
+  | "mutating"
+  | "applied"
+  | "reconciled"
+  | "rollback-required"
+  | "rolled-back";
+
+export interface ReleaseReceipt {
+  schema: typeof RELEASE_CONTROL_CONTRACT_VERSION;
+  releaseId: string;
+  scopeSha256: string;
+  phase: ReleaseReceiptPhase;
+  beforeReadBack: Record<string, unknown> | null;
+  afterReadBack: Record<string, unknown> | null;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const keys = [...expected].sort();
+  if (actual.length !== keys.length || actual.some((key, index) => key !== keys[index])) {
+    throw new Error(`${label} contains unsupported or missing fields`);
+  }
+}
+
+function nonEmptyString(value: unknown, label: string, pattern?: RegExp): string {
+  if (typeof value !== "string" || value.length === 0 || (pattern && !pattern.test(value))) {
+    throw new Error(`${label} is invalid`);
+  }
+  return value;
+}
+
+function stringArray(value: unknown, label: string, pattern: RegExp): string[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  const result = value.map((item) => nonEmptyString(item, label, pattern));
+  if (new Set(result).size !== result.length || [...result].sort().some((item, index) => item !== result[index])) {
+    throw new Error(`${label} must be unique and sorted`);
+  }
+  return result;
+}
+
+function parseComponent(value: unknown, index: number): ReleaseComponent {
+  const candidate = record(value, `Release component ${index}`);
+  if (candidate.kind === "migration") {
+    exactKeys(candidate, ["kind", "name"], `Release migration ${index}`);
+    return { kind: "migration", name: nonEmptyString(candidate.name, `Release migration ${index}`, MIGRATION_NAME) };
+  }
+  if (candidate.kind === "function") {
+    exactKeys(candidate, ["artifactSha256", "kind", "slug"], `Release Function ${index}`);
+    return {
+      kind: "function",
+      slug: nonEmptyString(candidate.slug, `Release Function ${index}`, FUNCTION_SLUG),
+      artifactSha256: nonEmptyString(candidate.artifactSha256, `Release Function ${index}`, SHA256),
+    };
+  }
+  if (candidate.kind === "web") {
+    exactKeys(candidate, ["artifactSha256", "kind"], `Release Web ${index}`);
+    return {
+      kind: "web",
+      artifactSha256: nonEmptyString(candidate.artifactSha256, `Release Web ${index}`, SHA256),
+    };
+  }
+  throw new Error(`Release component ${index} kind is invalid`);
+}
+
+export function parseReleaseScope(value: unknown): ReleaseScope {
+  const candidate = record(value, "Release scope");
+  exactKeys(candidate, ["components", "releaseId", "schema", "sourceCommit", "targetProjectRef"], "Release scope");
+  if (candidate.schema !== RELEASE_CONTROL_CONTRACT_VERSION) {
+    throw new Error("Release scope schema is invalid");
+  }
+  if (!Array.isArray(candidate.components) || candidate.components.length === 0) {
+    throw new Error("Release scope components must be non-empty");
+  }
+  const components = candidate.components.map(parseComponent);
+  const componentKeys = components.map((component) => component.kind === "migration"
+    ? `${component.kind}:${component.name}`
+    : component.kind === "function" ? `${component.kind}:${component.slug}` : component.kind);
+  if (new Set(componentKeys).size !== componentKeys.length
+    || componentKeys.some((key, index) => key !== [...componentKeys].sort()[index])) {
+    throw new Error("Release scope components must be unique and sorted");
+  }
+  return {
+    schema: RELEASE_CONTROL_CONTRACT_VERSION,
+    releaseId: nonEmptyString(candidate.releaseId, "Release scope releaseId"),
+    sourceCommit: nonEmptyString(candidate.sourceCommit, "Release scope sourceCommit", COMMIT),
+    targetProjectRef: nonEmptyString(candidate.targetProjectRef, "Release scope targetProjectRef", PROJECT_REF),
+    components,
+  };
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => [key, canonical(item)]));
+}
+
+export function releaseScopeSha256(scope: ReleaseScope): string {
+  return createHash("sha256").update(JSON.stringify(canonical(scope))).digest("hex");
+}
+
+const VALID_PHASES: readonly ReleaseReceiptPhase[] = [
+  "planned",
+  "mutating",
+  "applied",
+  "reconciled",
+  "rollback-required",
+  "rolled-back",
+];
+
+export function parseReleaseReceipt(value: unknown): ReleaseReceipt {
+  const candidate = record(value, "Release receipt");
+  exactKeys(candidate, ["afterReadBack", "beforeReadBack", "phase", "releaseId", "schema", "scopeSha256"], "Release receipt");
+  if (candidate.schema !== RELEASE_CONTROL_CONTRACT_VERSION
+    || typeof candidate.phase !== "string"
+    || !VALID_PHASES.includes(candidate.phase as ReleaseReceiptPhase)) {
+    throw new Error("Release receipt identity is invalid");
+  }
+  for (const key of ["beforeReadBack", "afterReadBack"] as const) {
+    if (candidate[key] !== null) record(candidate[key], `Release receipt ${key}`);
+  }
+  if ((candidate.phase === "applied" || candidate.phase === "reconciled")
+    && (candidate.beforeReadBack === null || candidate.afterReadBack === null)) {
+    throw new Error(`Release receipt ${candidate.phase} requires before and after read-back`);
+  }
+  return {
+    schema: RELEASE_CONTROL_CONTRACT_VERSION,
+    releaseId: nonEmptyString(candidate.releaseId, "Release receipt releaseId"),
+    scopeSha256: nonEmptyString(candidate.scopeSha256, "Release receipt scopeSha256", SHA256),
+    phase: candidate.phase as ReleaseReceiptPhase,
+    beforeReadBack: candidate.beforeReadBack as Record<string, unknown> | null,
+    afterReadBack: candidate.afterReadBack as Record<string, unknown> | null,
+  };
+}
+
+const ALLOWED_PHASE_TRANSITIONS: ReadonlyMap<ReleaseReceiptPhase, readonly ReleaseReceiptPhase[]> = new Map([
+  ["planned", ["mutating", "rollback-required"]],
+  ["mutating", ["applied", "rollback-required"]],
+  ["applied", ["reconciled", "rollback-required"]],
+  ["reconciled", []],
+  ["rollback-required", ["rolled-back", "reconciled"]],
+  ["rolled-back", []],
+]);
+
+export function assertReleaseReceiptTransition(
+  from: ReleaseReceiptPhase,
+  to: ReleaseReceiptPhase,
+): void {
+  if (!ALLOWED_PHASE_TRANSITIONS.get(from)?.includes(to)) {
+    throw new Error(`Invalid release receipt transition: ${from} -> ${to}`);
+  }
+}


### PR DESCRIPTION
## Summary

Add a reusable release-control contract for applications using SupaCloud.

## What this provides

- Strict release scope parsing for migrations, Functions, and Web artifacts.
- Canonical scope SHA-256 for retry and receipt binding.
- Strict receipt parsing with mandatory before/after read-back for applied and reconciled phases.
- Explicit receipt phase transition validation, including rollback-required recovery.

## Boundary

This is platform-level release metadata and receipt validation only. It does not encode FA state machines, RLS policy, projections, or application-specific auth rules, and it does not claim atomic multi-function deployment.

## Verification

- `bun test packages/management-api/src/release-control-contract.test.ts`
- `bunx tsc --noEmit -p packages/management-api/tsconfig.json`
- `git diff --check`
