### PR TITLE
feat(management-api): add stateless MCP AI operations

### DIFF
--- a/docs/enterprise-architecture-readiness.md
+++ b/docs/enterprise-architecture-readiness.md
@@ -1,0 +1,147 @@
+# Enterprise Architecture Readiness
+
+> Status: baseline contract
+> Updated: 2026-09-07
+
+This document defines the boundary between Pigsty-managed node capabilities and
+SupaCloud-managed platform capabilities. A feature is not considered complete
+because a command or script exists; it must have an owner, a reversible
+operation, an observable result, and an acceptance check.
+
+For the concrete Pigsty/pgBackRest operating procedure, see
+[Pigsty Backup Operations](./pigsty-backup-operations.md).
+
+## Ownership Boundary
+
+### Pigsty is the infrastructure substrate
+
+Pigsty may own or provision:
+
+- PostgreSQL cluster topology, Patroni, leader election, and failover
+- PostgreSQL replication, connection pooling, extensions, and node-level tuning
+- pgBackRest backups and WAL/PITR transport
+- Node-level Prometheus/Grafana exporters and infrastructure dashboards
+- Base operating-system/database configuration and cluster lifecycle primitives
+
+Pigsty does not by itself complete:
+
+- SupaCloud project and tenant isolation
+- Caddy routing, TLS, per-tenant rate limits, and gateway policy
+- Management API authorization, approval, audit, and idempotency
+- PostgREST, GoTrue, Edge Runtime, Realtime, and pgredis lifecycle coordination
+- Release compatibility, artifact identity, deployment receipts, and rollback
+- Cross-component request tracing, platform SLOs, or customer-facing incidents
+- Object-storage durability, secret rotation, data deletion, and tenant cleanup
+- Recovery acceptance for a complete SupaCloud project
+
+### SupaCloud owns the platform contract
+
+SupaCloud must treat Pigsty as a replaceable infrastructure provider. The
+platform contract must work with the supported Pigsty deployment and must expose
+provider-neutral health, backup, restore, scaling, and failover state.
+
+## Readiness Domains
+
+| Domain | Current baseline | Required completion proof |
+| --- | --- | --- |
+| Node HA | Patroni/HA scripts and Pigsty integration exist | Automated failover and switchover drill with measured RTO |
+| Backup/DR | pgBackRest/PITR and project restore surfaces exist | Off-host backup, scheduled restore drill, measured RPO/RTO |
+| Observability | VictoriaLogs, Grafana, metrics, request IDs exist | Trace propagation, SLI/SLO, alert rules, incident runbooks |
+| Release safety | SHA-256, provenance, manifests, rollback helpers exist | One receipt covering all components and verified rollback |
+| Tenant isolation | RLS, per-tenant runtimes, capability boundaries exist | Cross-tenant negative tests and resource fairness tests |
+| Security | TLS, secret files, audit chain, dependency audit exist | Rotation drill, container scan, SBOM archive, access review |
+| Capacity | Gateway, worker, queue and database controls exist | Per-tenant quotas, noisy-neighbor test, capacity report |
+| Data lifecycle | Backup, storage and deletion operations exist | Retention, deletion, export, and restore-without-access-drift tests |
+| Operations | Health checks and upgrade scripts exist | Runbooks, ownership, escalation, change and incident records |
+
+## Required SLO Model
+
+The platform must define and publish at least:
+
+- Control-plane availability and latency
+- Tenant REST/Auth/Storage availability
+- Edge Function success rate, latency, cold-start rate, and queue delay
+- Database failover duration and replication lag
+- Backup freshness, backup success rate, and restore success rate
+- Log ingestion delay and retention compliance
+
+Each SLO needs an owner, a measurement source, an alert threshold, and a
+runbook. A dashboard without an alert and a runbook is not an operational
+control.
+
+## Recovery Acceptance
+
+The minimum complete recovery drill must:
+
+1. Select a real or representative tenant fixture.
+2. Verify the latest backup and its digest from an independent location.
+3. Restore the database, object storage, secrets, and runtime metadata.
+4. Reconcile migrations and component versions.
+5. Verify anonymous-deny and authenticated-allow boundaries.
+6. Verify tenant isolation, active routes, functions, queues, and audit records.
+7. Record measured RPO, RTO, restore receipt, and unresolved deviations.
+
+Successful `pgBackRest info` or a healthy Patroni cluster alone is not recovery
+acceptance.
+
+## Release Acceptance
+
+A production release is complete only when all of the following are available:
+
+- immutable source commit and component versions
+- artifact digests and provenance verification
+- compatibility result for database/runtime versions
+- preflight backup and migration inventory
+- deployment receipt with per-component state
+- health and readiness read-back
+- representative authenticated smoke
+- rollback target and rollback receipt
+
+## Gherkin Acceptance Criteria
+
+```gherkin
+Feature: Enterprise recovery readiness
+
+  Scenario: A node failure is recovered through the infrastructure provider
+    Given a two-node PostgreSQL cluster managed by Pigsty and Patroni
+    And the SupaCloud tenant runtime is healthy
+    When the current leader is made unavailable
+    Then Patroni elects a healthy replica
+    And SupaCloud reports the new leader and replication state
+    And the measured recovery time is recorded against the configured RTO
+
+  Scenario: A complete tenant restore is independently verified
+    Given a verified off-host backup for a tenant
+    When the operator restores the database, storage, secrets, and runtime metadata
+    Then the tenant starts with the expected component versions
+    And authenticated requests succeed
+    And cross-tenant requests remain denied
+    And the restore receipt contains measured RPO and RTO
+
+  Scenario: A release cannot report success with incomplete evidence
+    Given one component has an unknown deployment outcome
+    When the release workflow evaluates the deployment
+    Then the release is marked incomplete
+    And no retry is issued automatically for a non-idempotent mutation
+    And the operator receives the component identity and required read-back
+
+  Scenario: A tenant cannot exhaust shared capacity
+    Given two tenants share one Edge Runtime and gateway
+    When one tenant exceeds its configured concurrency or queue quota
+    Then that tenant is rejected or delayed according to policy
+    And the other tenant remains within its latency and availability SLO
+    And the quota event is observable by project and request ID
+```
+
+## Implementation Order
+
+1. Freeze the current working tree into an independently testable branch.
+2. Add the release/readiness contract and machine-readable evidence schema.
+3. Add unified trace and SLO measurement across gateway, API, workers, queues,
+   database, and recovery operations.
+4. Add off-host backup verification and scheduled restore drills.
+5. Add tenant quotas, capacity reports, and noisy-neighbor tests.
+6. Add security rotation, container scanning, SBOM retention, and access review.
+7. Add cross-component upgrade orchestration and verified rollback.
+8. Add multi-node and multi-region procedures only after the single-region
+   recovery contract is green.

--- a/docs/mcp-ai-operations-test-requirements.md
+++ b/docs/mcp-ai-operations-test-requirements.md
@@ -1,0 +1,90 @@
+# AI 运维 MCP 测试需求
+
+## 1. 测试目标
+
+验证可选 AI 运维能力满足以下边界：
+
+- MCP 使用新版无状态 Streamable HTTP 协议；
+- AI 客户端只能读取授权范围内的证据；
+- 变更操作只能生成计划，不能绕过审批直接执行；
+- Pigsty/pgBackRest 备份状态必须来自已验证的 inventory；
+- 请求、审批、执行和恢复验证能够关联 trace、correlation、审计和操作回执。
+
+## 2. 测试范围
+
+### 2.1 协议与传输
+
+| 编号 | 需求 | 验收标准 |
+| --- | --- | --- |
+| MCP-P-01 | 初始化 | 返回 `protocolVersion=2025-06-18`、serverInfo 和 capabilities |
+| MCP-P-02 | 无状态 | 任意响应不包含 `Mcp-Session-Id`；服务端不依赖前一次请求 |
+| MCP-P-03 | 内容类型 | 非 `application/json` 返回 HTTP 415 |
+| MCP-P-04 | 协议版本 | 不支持的 `MCP-Protocol-Version` 返回 HTTP 400 |
+| MCP-P-05 | JSON-RPC | 非法 JSON 返回 `-32700`；未知方法返回 `-32601`；非法参数返回 `-32602` |
+| MCP-P-06 | 通知 | `notifications/initialized` 返回 HTTP 202 且无响应体 |
+| MCP-P-07 | 缓存 | 响应包含 `Cache-Control: no-store` |
+
+### 2.2 认证与租户隔离
+
+| 编号 | 需求 | 验收标准 |
+| --- | --- | --- |
+| MCP-A-01 | 平台接口 | `/mcp` 仅允许 master/admin |
+| MCP-A-02 | 项目接口 | `/mcp/projects/{ref}` 仅允许该项目或 admin |
+| MCP-A-03 | 资源隔离 | 项目 token 不能读取其他项目的 backups/metrics |
+| MCP-A-04 | 机密保护 | 工具、资源和错误响应不返回 token、密码、数据库 URL 或 service-role key |
+| MCP-A-05 | 默认关闭 | 未配置 AI 客户端或授权凭据时，不产生隐式 AI 行为 |
+
+### 2.3 工具与资源
+
+| 编号 | 需求 | 验收标准 |
+| --- | --- | --- |
+| MCP-T-01 | capabilities | 工具、资源、scope 和 `plan_only` 策略稳定可解析 |
+| MCP-T-02 | 备份就绪度 | 结果包含 stanza、PITR 状态、可读完成备份数量和最新备份 |
+| MCP-T-03 | 备份失败关闭 | inventory 缺失、stanza/repository unhealthy 或记录不可读时不得返回 ready |
+| MCP-T-04 | 指标 | 返回 Prometheus 指标，且不泄漏认证信息 |
+| MCP-T-05 | 资源清单 | admin 和 project scope 返回符合授权范围的资源 |
+| MCP-T-06 | PITR 计划 | 返回项目、目标时间、前置条件、审批要求和确认字符串 |
+| MCP-T-07 | PITR 禁止直执 | MCP 调用不得触发 restore 命令、数据库写入或集群切换 |
+
+### 2.4 变更闭环
+
+| 编号 | 需求 | 验收标准 |
+| --- | --- | --- |
+| MCP-O-01 | 计划审批 | 任何写操作必须先形成计划并经过显式人工审批 |
+| MCP-O-02 | 幂等性 | 执行 API 使用 idempotency key，重复请求不会重复变更 |
+| MCP-O-03 | 操作回执 | 返回 operation/receipt，可查询状态、结果和失败原因 |
+| MCP-O-04 | 结果验证 | 变更成功必须有组件健康 read-back 和最终状态证据 |
+| MCP-O-05 | 关联追踪 | 计划、审批、执行、告警、回滚和恢复演练关联 request ID、trace ID、correlation ID |
+
+## 3. 非功能测试
+
+- 安全：认证失败、越权、提示注入、超长参数、恶意 URI、重放和敏感信息扫描。
+- 稳定性：并发只读调用、客户端重试、网络断开、重复 notification、服务重启后继续请求。
+- 性能：`initialize`、`tools/list`、`resources/list` 在正常负载下无明显阻塞；备份查询超时必须失败关闭。
+- 可观测性：HTTP 状态、错误计数、慢请求、审计事件和操作回执可检索。
+- 灾备：Pigsty/pgBackRest 异地备份、PITR 恢复演练和恢复后业务验收必须有独立证据。
+
+## 4. 必须执行的测试层级
+
+1. 单元测试：协议解析、scope 判断、计划生成、机密脱敏。
+2. 路由测试：真实 Elysia route、Bearer auth、项目隔离和响应头。
+3. 服务集成测试：pgBackRest inventory、备份异常、PITR plan/execute 边界。
+4. 安全测试：越权、重放、注入、敏感字段和错误信息泄漏。
+5. 部署验收：启用/禁用配置、真实 MCP 客户端 initialize/tools/list/read/call。
+6. 灾备验收：备份恢复、跨组件健康检查、trace/SLO/告警和回滚证据闭环。
+
+## 5. 当前实现验收基线
+
+本次提交应至少通过：
+
+```text
+management-api typecheck
+mcp.server.test.ts
+observability.test.ts
+backup.service.test.ts
+workspace boundaries
+business invariants
+git diff --check
+```
+
+生产发布前还必须补充真实凭据、真实 Pigsty/pgBackRest inventory、外部 MCP 客户端和恢复演练证据；本地单元测试不能替代这些验收。

--- a/docs/mcp-ai-operations.md
+++ b/docs/mcp-ai-operations.md
@@ -1,0 +1,110 @@
+# Optional AI Operations MCP
+
+SupaCloud provides an optional, customer-facing AI operations surface over the
+新版 Streamable HTTP MCP protocol. It is disabled as a product capability
+unless the customer explicitly connects an MCP client and presents an
+existing SupaCloud admin or project-scoped credential.
+
+## Contract
+
+- Endpoint: `POST /mcp` for platform administrators.
+- Endpoint: `POST /mcp/projects/{project_ref}` for a project-scoped client.
+- Protocol: `2025-06-18`.
+- Transport: JSON-RPC over `application/json`.
+- State model: stateless. SupaCloud does not return `Mcp-Session-Id`, keep a
+  session map, or store model conversation state.
+- Authentication: existing `Authorization: Bearer ...` admin/project auth.
+- Response caching: disabled with `Cache-Control: no-store`.
+- Write policy: plan-only. A model cannot execute shell commands, receive
+  database credentials, or directly perform a restore through MCP.
+
+The client should send the `MCP-Protocol-Version` request header after
+initialization. The server returns the same protocol version in responses. A
+`notifications/initialized` request receives `202` with an empty body.
+
+## Tools
+
+### `supacloud.get_capabilities`
+
+Returns the machine-readable AI operations contract, including scope, tools,
+resources, stateless behavior, and write policy.
+
+### `supacloud.get_backup_readiness`
+
+Returns project backup evidence from the configured Pigsty/pgBackRest
+inventory:
+
+- stanza and PITR configuration state;
+- count of completed, readable backups;
+- latest completed backup;
+- readiness status.
+
+The tool reads the authoritative pgBackRest inventory. It does not infer
+success from a shell exit code alone.
+
+### `supacloud.get_request_metrics`
+
+Returns the current Management API Prometheus metrics, including request,
+error, and status counters. These metrics are process-local and should be
+combined with the customer's external metrics retention for incident history.
+
+### `supacloud.plan_pitr_restore`
+
+Creates a non-executing PITR restore plan for an RFC3339 UTC timestamp. The
+plan records the project, target, prerequisites, approval requirement, and
+confirmation string. Execution remains behind the normal backup API workflow,
+maker-checker approval, idempotency, audit, operation receipt, and post-restore
+health verification.
+
+## Resources
+
+- `supacloud://capabilities`
+- `supacloud://project/{project_ref}/backups`
+- `supacloud://project/{project_ref}/metrics`
+
+Project-scoped credentials can read only resources for their own project.
+Platform administrators can use the platform endpoint and explicitly provide a
+project reference where the tool schema allows it.
+
+## Example
+
+```http
+POST /mcp/projects/demo-project
+Authorization: Bearer <existing-project-or-admin-token>
+Content-Type: application/json
+MCP-Protocol-Version: 2025-06-18
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "supacloud.plan_pitr_restore",
+    "arguments": {
+      "target": "2026-09-07T00:00:00Z"
+    }
+  }
+}
+```
+
+## Customer integration requirements
+
+An AI client integration should:
+
+1. Keep the MCP connection opt-in and tenant-scoped.
+2. Treat tool results as evidence, not authorization to mutate state.
+3. Display the returned plan and require a human approval step before any
+   existing write API is called.
+4. Persist the operation receipt, trace ID, correlation ID, and audit event
+   across the approval and execution workflow.
+5. Redact bearer tokens, database URLs, passwords, service-role keys, and
+   provider credentials from prompts, logs, tool output, and exported traces.
+6. Retry only idempotent reads. Long-running writes must use the existing
+   operation status and receipt APIs rather than MCP session state.
+
+Pigsty/pgBackRest backup configuration remains an infrastructure concern. MCP
+exposes its verified inventory and planning inputs; it does not replace
+Pigsty, pgBackRest, backup retention, off-site repository replication, or
+restore drills.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -53,3 +53,29 @@ Edge Function 的函数级运行日志仍写入各项目的 `.logs/<function>.lo
 ## 历史主机
 
 旧 Logflare 主机只能通过现有的迁移/清理工具显式处理。新安装调用兼容脚本时固定传入 `--skip-analytics`，不会创建、迁移或重建 Analytics 数据库或容器；不要把旧 Logflare 数据库作为 VictoriaLogs 的数据目录。
+
+## 请求关联与 SLO 指标
+
+Management API 为每个请求生成或验证以下标识，并在响应中回写：
+
+- `x-request-id`：单次请求标识
+- `x-supacloud-trace-id`：跨组件追踪标识；优先承接合法 W3C `traceparent`
+- `x-supacloud-correlation-id`：业务流程或工作流关联标识
+
+Management API 的 `/metrics` 输出 Prometheus 文本格式。默认适合本机受控
+采集；设置 `SUPACLOUD_METRICS_TOKEN` 后必须使用对应 Bearer Token。指标包括
+请求总数、5xx 数量、HTTP 状态分布和延迟桶。
+
+建议由 Pigsty/VictoriaMetrics 采集并配置以下最小 SLO：
+
+| SLI | 推荐告警条件 |
+| --- | --- |
+| Management API 5xx 比例 | 5 分钟窗口 > 1% |
+| Management API p95 延迟 | 5 分钟窗口 > 500ms |
+| Edge Function 失败率 | 5 分钟窗口 > 2% |
+| pgBackRest 最新成功备份年龄 | 超过备份周期的 2 倍 |
+| Patroni/数据库复制延迟 | 超过业务 RPO 阈值 |
+| VictoriaLogs ingestion delay | 超过 5 分钟 |
+
+告警必须关联 `x-supacloud-trace-id`、租户 project ref 和对应 runbook；
+只有 Grafana 面板而没有告警阈值和处置手册，不算 SLO 闭环。

--- a/docs/pigsty-backup-operations.md
+++ b/docs/pigsty-backup-operations.md
@@ -1,0 +1,99 @@
+# Pigsty Backup Operations
+
+SupaCloud uses Pigsty's PostgreSQL backup substrate. The platform does not
+replace pgBackRest or `pig pitr`; it validates their state and records the
+result as a SupaCloud readiness contract.
+
+## Provider Responsibilities
+
+Pigsty/pgBackRest owns:
+
+- PostgreSQL physical full, differential, and incremental backups
+- WAL archiving and point-in-time recovery
+- Repository configuration and retention
+- Patroni coordination during cluster recovery
+
+SupaCloud owns:
+
+- fail-closed availability checks
+- tenant/project API authorization
+- backup and restore receipts
+- component health read-back after recovery
+- object storage, secrets, runtime metadata, and tenant isolation checks
+
+## Configuration
+
+The installer persists these values in `/etc/supabase/install.env` or the
+Management API environment:
+
+```text
+SUPACLOUD_PGBACKREST_CONFIG=/etc/supabase/pgbackrest.conf
+SUPACLOUD_PGBACKREST_STANZA=db-main
+SUPACLOUD_PGBACKREST_USER=postgres
+SUPACLOUD_PGBACKREST_BIN=pgbackrest
+SUPACLOUD_PITR_ENABLED=true
+```
+
+The configuration must point to the Pigsty-managed repository. A successful
+local PostgreSQL process is not evidence that a backup repository is usable.
+
+## Readiness Check
+
+Run on the management host:
+
+```bash
+sudo /usr/local/libexec/supacloud/backup_manager.sh verify
+```
+
+The command emits one JSON readiness record with:
+
+- `schema`
+- `provider`
+- `stanza`
+- `repository_count`
+- `completed_backup_count`
+- `latest_completed_backup`
+
+It exits non-zero when pgBackRest is missing, the stanza is unhealthy, the
+repository status disagrees with the stanza status, or the inventory cannot be
+read. It never converts an unavailable provider into an empty backup list.
+
+## Backup And PITR
+
+```bash
+sudo /usr/local/libexec/supacloud/backup_manager.sh create db-main full
+sudo /usr/local/libexec/supacloud/backup_manager.sh create db-main incr
+sudo /usr/local/libexec/supacloud/backup_manager.sh restore \
+  2026-09-06T12:30:00Z
+```
+
+`create` validates the pgBackRest inventory after the command returns.
+`restore` requires `SUPACLOUD_PITR_ENABLED=true`, uses Pigsty's `pig pitr`, and
+returns success only after the command exits successfully.
+
+For normal production use, prefer the authenticated Management API:
+
+- `GET /v1/projects/:ref/database/backups`
+- `POST /v1/projects/:ref/database/backups`
+- `POST /v1/platform/backups/restore`
+
+The Management API additionally applies project/admin authorization,
+confirmation strings, concurrent-restore protection, and structured error
+responses.
+
+## Enterprise Recovery Drill
+
+Pigsty backup readiness is only the database-layer gate. A complete SupaCloud
+recovery drill must also:
+
+1. Verify the selected backup from an independent repository location.
+2. Restore the database and record the actual recovery timestamp.
+3. Restore the project's object storage and runtime metadata.
+4. Reconcile migrations and component versions.
+5. Verify Management API, Caddy, PostgREST, GoTrue, Edge Runtime, Realtime,
+   and pgredis health.
+6. Verify authenticated access and cross-tenant denial.
+7. Record measured RPO, RTO, backup identity, and unresolved deviations.
+
+`pgbackrest info` success, a healthy Patroni leader, or a successful database
+PITR alone is not a complete SupaCloud recovery acceptance.

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -38,7 +38,14 @@ import { closeTaskWebSocket, messageTaskWebSocket, openTaskWebSocket } from "./r
 import { isS3DataPlaneRequest } from "./utils/storage-s3-paths";
 import { studioAuthRoutes } from "./routes/studio-auth";
 import { caddyAskRoutes } from "./routes/caddy-ask";
+import { mcpRoutes } from "./mcp/server";
 import { validationErrorResponse } from "./utils/http-validation";
+import {
+  applyObservabilityHeaders,
+  beginRequestObservability,
+  recordRequestObservation,
+  renderRequestMetrics,
+} from "./utils/observability";
 import { withLogicalBackupMutationTimeoutController } from "./utils/logical-backup-request-timeout";
 import {
   CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE,
@@ -275,7 +282,15 @@ async function reconcileGatewayBeforeServe(): Promise<void> {
 }
 
 const app = new Elysia({ strictPath: false })
-  .onError({ as: "global" }, ({ code, error, set }) => {
+  .onRequest(({ request, set }) => {
+    const context = beginRequestObservability(request);
+    set.headers ??= {};
+    applyObservabilityHeaders(set.headers, context);
+  })
+  .onError({ as: "global" }, ({ request, code, error, set }) => {
+    const observation = recordRequestObservation(request, Number(set.status || 500));
+    set.headers ??= {};
+    applyObservabilityHeaders(set.headers, observation.context);
     if (code === "VALIDATION") {
       return validationErrorResponse(set);
     }
@@ -376,19 +391,41 @@ const app = new Elysia({ strictPath: false })
   )
 
   // Rate limit headers + API version (Studio compatibility)
-  .onAfterHandle(({ set }) => {
+  .onAfterHandle(({ request, set }) => {
+    const observation = recordRequestObservation(request, Number(set.status || 200));
     set.headers ??= {};
+    applyObservabilityHeaders(set.headers, observation.context);
     set.headers["x-ratelimit-limit"] ??= "1000";
     set.headers["x-ratelimit-remaining"] ??= "999";
     set.headers["x-ratelimit-reset"] ??= String(
       Math.ceil(Date.now() / 60000) * 60,
     );
     set.headers["x-supabase-api-version"] = "2024-01-01";
+    if (observation.slow) {
+      logger.warn("[Observability] Slow Management API request", {
+        requestId: observation.context.requestId,
+        traceId: observation.context.traceId,
+        durationMs: Math.round(observation.durationMs),
+      });
+    }
   })
 
   // Health check (no auth required)
   .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
+  .get("/metrics", ({ request, set }) => {
+    const token = process.env.SUPACLOUD_METRICS_TOKEN?.trim();
+    if (token && request.headers.get("authorization") !== `Bearer ${token}`) {
+      set.status = 401;
+      return { message: "Unauthorized" };
+    }
+    set.headers["content-type"] = "text/plain; version=0.0.4";
+    return renderRequestMetrics();
+  })
   .use(studioAuthRoutes)
+  // Optional stateless MCP surface for customer-selected AI operations.
+  // Keep this before API/static route registration so it is never swallowed
+  // by the SPA fallback.
+  .use(mcpRoutes)
 
   .get("/platform/projects", async ({ request, set }) => {
     const rejected = await rejectStudioCompatibilityRequest(request, set);

--- a/packages/management-api/src/mcp/server.ts
+++ b/packages/management-api/src/mcp/server.ts
@@ -1,0 +1,306 @@
+import { Elysia, status } from "elysia";
+import {
+  getPgBackRestStanza,
+  isPitrEnabled,
+  listBackups,
+} from "../services/backup.service";
+import {
+  renderRequestMetrics,
+} from "../utils/observability";
+import {
+  requireAdminAuth,
+  requireProjectOrAdminAuth,
+} from "../middleware/auth";
+
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const SERVER_NAME = "supacloud-management";
+const SERVER_VERSION = "0.1.0";
+
+type JsonRpcId = string | number | null;
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id?: JsonRpcId;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+type McpScope = { role: "admin" | "project"; ref?: string };
+
+function rpcResult(id: JsonRpcId | undefined, result: unknown): Record<string, unknown> {
+  return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function rpcError(
+  id: JsonRpcId | undefined,
+  code: number,
+  message: string,
+  data?: unknown,
+): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  };
+}
+
+function textContent(text: string): { type: "text"; text: string }[] {
+  return [{ type: "text", text }];
+}
+
+function scopedRef(scope: McpScope, params: Record<string, unknown>): string | null {
+  if (scope.ref) return scope.ref;
+  return typeof params.project_ref === "string" && /^[A-Za-z0-9_-]{1,64}$/.test(params.project_ref)
+    ? params.project_ref
+    : null;
+}
+
+function capabilities(scope: McpScope) {
+  return {
+    schema: "supacloud.mcp-capabilities.v1",
+    transport: {
+      type: "streamable-http",
+      stateless: true,
+      endpoint: scope.ref ? `/mcp/projects/${scope.ref}` : "/mcp",
+      session: "none",
+    },
+    scopes: scope.ref ? ["project.read"] : ["platform.read", "project.read"],
+    write_policy: "plan_only",
+    tools: [
+      "supacloud.get_capabilities",
+      "supacloud.get_backup_readiness",
+      "supacloud.get_request_metrics",
+      "supacloud.plan_pitr_restore",
+    ],
+    resources: [
+      "supacloud://capabilities",
+      "supacloud://project/{project_ref}/backups",
+      "supacloud://project/{project_ref}/metrics",
+    ],
+  };
+}
+
+async function callTool(
+  name: string,
+  params: Record<string, unknown>,
+  scope: McpScope,
+): Promise<Record<string, unknown>> {
+  if (name === "supacloud.get_capabilities") {
+    return { content: textContent(JSON.stringify(capabilities(scope), null, 2)) };
+  }
+
+  if (name === "supacloud.get_request_metrics") {
+    return { content: textContent(renderRequestMetrics()) };
+  }
+
+  if (name === "supacloud.get_backup_readiness") {
+    const ref = scopedRef(scope, params);
+    if (!ref) throw new Error("project_ref is required for project backup readiness");
+    const backups = await listBackups(ref);
+    return {
+      content: textContent(JSON.stringify({
+        schema: "supacloud.backup-readiness.v1",
+        provider: "pigsty.pgbackrest",
+        stanza: getPgBackRestStanza(),
+        pitr_enabled: isPitrEnabled(),
+        status: backups.length > 0 ? "ready" : "no_completed_backup",
+        completed_backup_count: backups.length,
+        latest_completed_backup: backups.at(-1) ?? null,
+      }, null, 2)),
+    };
+  }
+
+  if (name === "supacloud.plan_pitr_restore") {
+    const ref = scopedRef(scope, params);
+    const target = typeof params.target === "string" ? params.target : "";
+    if (!ref) throw new Error("project_ref is required for a PITR plan");
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$/.test(target)) {
+      throw new Error("target must be an RFC3339 UTC timestamp");
+    }
+    return {
+      content: textContent(JSON.stringify({
+        schema: "supacloud.ai-operation-plan.v1",
+        operation: "physical_pitr_restore",
+        project_ref: ref,
+        target,
+        mode: "plan_only",
+        requires: [
+          "SUPACLOUD_PITR_ENABLED=true",
+          "completed physical backup",
+          "admin approval",
+          "post-restore component health read-back",
+        ],
+        execute_endpoint: "/v1/platform/backups/restore",
+        confirmation: `RESTORE_CLUSTER:${target}`,
+      }, null, 2)),
+    };
+  }
+
+  throw new Error(`Unknown MCP tool: ${name}`);
+}
+
+function resourceContents(uri: string, value: unknown) {
+  return {
+    contents: [{
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify(value, null, 2),
+    }],
+  };
+}
+
+async function readResource(uri: string, scope: McpScope) {
+  if (uri === "supacloud://capabilities") {
+    return resourceContents(uri, capabilities(scope));
+  }
+  const backupMatch = uri.match(/^supacloud:\/\/project\/([A-Za-z0-9_-]{1,64})\/backups$/);
+  if (backupMatch) {
+    const ref = scopedRef(scope, { project_ref: backupMatch[1] });
+    if (!ref) throw new Error("Project resource is outside the authorized scope");
+    return resourceContents(uri, {
+      schema: "supacloud.backup-readiness.v1",
+      provider: "pigsty.pgbackrest",
+      stanza: getPgBackRestStanza(),
+      pitr_enabled: isPitrEnabled(),
+      backups: await listBackups(ref),
+    });
+  }
+  if (uri.match(/^supacloud:\/\/project\/[A-Za-z0-9_-]{1,64}\/metrics$/)) {
+    const ref = uri.split("/")[3];
+    if (scope.ref && scope.ref !== ref) throw new Error("Project resource is outside the authorized scope");
+    return resourceContents(uri, { project_ref: ref, metrics: renderRequestMetrics() });
+  }
+  throw new Error(`Unknown MCP resource: ${uri}`);
+}
+
+export async function processMessage(message: JsonRpcRequest, scope: McpScope) {
+  if (!message || message.jsonrpc !== "2.0" || typeof message.method !== "string") {
+    return rpcError(message?.id, -32600, "Invalid Request");
+  }
+  const params = message.params ?? {};
+
+  if (message.method === "initialize") {
+    return rpcResult(message.id, {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: { listChanged: false }, resources: { subscribe: false, listChanged: false } },
+      serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
+      instructions: "SupaCloud MCP is stateless. No MCP session is created. Use operation receipts for long-running work.",
+    });
+  }
+  if (message.method === "ping") return rpcResult(message.id, {});
+  if (message.method === "notifications/initialized") return null;
+  if (message.method === "tools/list") {
+    return rpcResult(message.id, {
+      tools: [
+        {
+          name: "supacloud.get_capabilities",
+          description: "Read the stateless SupaCloud AI operations contract.",
+          inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        },
+        {
+          name: "supacloud.get_backup_readiness",
+          description: "Read Pigsty/pgBackRest backup readiness for one project.",
+          inputSchema: {
+            type: "object",
+            properties: { project_ref: { type: "string" } },
+            additionalProperties: false,
+          },
+        },
+        {
+          name: "supacloud.get_request_metrics",
+          description: "Read the current Management API Prometheus metrics.",
+          inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        },
+        {
+          name: "supacloud.plan_pitr_restore",
+          description: "Create a non-executing, approval-bound PITR restore plan.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project_ref: { type: "string" },
+              target: { type: "string", description: "RFC3339 UTC timestamp" },
+            },
+            required: ["target"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+  }
+  if (message.method === "resources/list") {
+    const resources = [{ uri: "supacloud://capabilities", name: "SupaCloud capabilities", mimeType: "application/json" }];
+    if (scope.ref) {
+      resources.push(
+        { uri: `supacloud://project/${scope.ref}/backups`, name: "Project backups", mimeType: "application/json" },
+        { uri: `supacloud://project/${scope.ref}/metrics`, name: "Project metrics", mimeType: "application/json" },
+      );
+    }
+    return rpcResult(message.id, { resources });
+  }
+  if (message.method === "resources/read") {
+    if (typeof params.uri !== "string") return rpcError(message.id, -32602, "uri is required");
+    return rpcResult(message.id, await readResource(params.uri, scope));
+  }
+  if (message.method === "tools/call") {
+    if (typeof params.name !== "string") return rpcError(message.id, -32602, "name is required");
+    const result = await callTool(params.name, (params.arguments ?? {}) as Record<string, unknown>, scope);
+    return rpcResult(message.id, result);
+  }
+  return rpcError(message.id, -32601, `Method not found: ${message.method}`);
+}
+
+export async function handleMcpRequest(request: Request, scope: McpScope): Promise<Response> {
+  const contentType = request.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return Response.json({ error: "MCP Streamable HTTP requires application/json" }, { status: 415 });
+  }
+  const protocolVersion = request.headers.get("mcp-protocol-version");
+  if (protocolVersion && protocolVersion !== MCP_PROTOCOL_VERSION && protocolVersion !== "2025-03-26") {
+    return Response.json({ error: "Unsupported MCP protocol version" }, { status: 400 });
+  }
+  let message: JsonRpcRequest;
+  try {
+    message = await request.json() as JsonRpcRequest;
+  } catch {
+    return Response.json(rpcError(null, -32700, "Parse error"), { status: 400 });
+  }
+  try {
+    const response = await processMessage(message, scope);
+    if (response === null) {
+      return new Response(null, {
+        status: 202,
+        headers: {
+          "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+    return Response.json(response, {
+      headers: {
+        "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return Response.json(rpcError(message.id, -32000, error instanceof Error ? error.message : "MCP request failed"), {
+      headers: { "MCP-Protocol-Version": MCP_PROTOCOL_VERSION },
+      status: 200,
+    });
+  }
+}
+
+async function authorizeMcp(request: Request, ref?: string) {
+  if (ref) return requireProjectOrAdminAuth(request, ref);
+  return requireAdminAuth(request);
+}
+
+export const mcpRoutes = new Elysia()
+  .post("/mcp", async ({ request }) => {
+    const authError = await authorizeMcp(request);
+    if (authError) return status(authError.status, authError.body);
+    return handleMcpRequest(request, { role: "admin" });
+  })
+  .post("/mcp/projects/:ref", async ({ request, params }) => {
+    const authError = await authorizeMcp(request, params.ref);
+    if (authError) return status(authError.status, authError.body);
+    return handleMcpRequest(request, { role: "project", ref: params.ref });
+  });

--- a/packages/management-api/src/utils/observability.ts
+++ b/packages/management-api/src/utils/observability.ts
@@ -1,0 +1,114 @@
+import { randomBytes } from "node:crypto";
+
+const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
+const SLOW_REQUEST_MS = 1000;
+const latencyBuckets = [10, 50, 100, 250, 500, 1000, 5000];
+
+export interface RequestObservabilityContext {
+  requestId: string;
+  traceId: string;
+  correlationId: string;
+  startedAt: number;
+}
+
+interface RequestMetricState {
+  requests: number;
+  errors: number;
+  durations: number[];
+  status: Map<number, number>;
+}
+
+const requestContexts = new WeakMap<Request, RequestObservabilityContext>();
+const metricState: RequestMetricState = {
+  requests: 0,
+  errors: 0,
+  durations: [],
+  status: new Map(),
+};
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function validRequestId(value: string | null): string | undefined {
+  if (!value || !REQUEST_ID_PATTERN.test(value)) return undefined;
+  return value;
+}
+
+function traceIdFromTraceparent(value: string | null): string | undefined {
+  const match = value?.match(/^[\da-f]{2}-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i);
+  return match && TRACE_ID_PATTERN.test(match[1]!) ? match[1]!.toLowerCase() : undefined;
+}
+
+export function beginRequestObservability(request: Request): RequestObservabilityContext {
+  const existing = requestContexts.get(request);
+  if (existing) return existing;
+
+  const requestId = validRequestId(request.headers.get("x-request-id"))
+    ?? validRequestId(request.headers.get("x-sb-execution-id"))
+    ?? randomHex(16);
+  const suppliedTraceId = request.headers.get("x-supacloud-trace-id");
+  const traceId = traceIdFromTraceparent(request.headers.get("traceparent"))
+    ?? (suppliedTraceId && TRACE_ID_PATTERN.test(suppliedTraceId) ? suppliedTraceId.toLowerCase() : randomHex(16));
+  const correlationId = validRequestId(request.headers.get("x-supacloud-correlation-id"))
+    ?? requestId;
+
+  const context = { requestId, traceId, correlationId, startedAt: performance.now() };
+  requestContexts.set(request, context);
+  return context;
+}
+
+export function applyObservabilityHeaders(
+  headers: Record<string, string | number>,
+  context: RequestObservabilityContext,
+): void {
+  headers["x-request-id"] ??= context.requestId;
+  headers["x-supacloud-trace-id"] ??= context.traceId;
+  headers["x-supacloud-correlation-id"] ??= context.correlationId;
+}
+
+export function recordRequestObservation(
+  request: Request,
+  status: number,
+): { context: RequestObservabilityContext; durationMs: number; slow: boolean } {
+  const context = beginRequestObservability(request);
+  const durationMs = Math.max(0, performance.now() - context.startedAt);
+  metricState.requests += 1;
+  if (status >= 500) metricState.errors += 1;
+  metricState.status.set(status, (metricState.status.get(status) ?? 0) + 1);
+  metricState.durations.push(durationMs);
+  if (metricState.durations.length > 10_000) metricState.durations.shift();
+  return { context, durationMs, slow: durationMs >= SLOW_REQUEST_MS };
+}
+
+export function renderRequestMetrics(): string {
+  const lines = [
+    "# HELP supacloud_management_http_requests_total Total Management API requests.",
+    "# TYPE supacloud_management_http_requests_total counter",
+    `supacloud_management_http_requests_total ${metricState.requests}`,
+    "# HELP supacloud_management_http_errors_total Total Management API 5xx responses.",
+    "# TYPE supacloud_management_http_errors_total counter",
+    `supacloud_management_http_errors_total ${metricState.errors}`,
+  ];
+  for (const [status, count] of metricState.status) {
+    lines.push(`supacloud_management_http_responses_total{status="${status}"} ${count}`);
+  }
+  for (const bucket of latencyBuckets) {
+    lines.push(
+      `supacloud_management_http_request_duration_ms_bucket{le="${bucket}"} `
+      + `${metricState.durations.filter((duration) => duration <= bucket).length}`,
+    );
+  }
+  lines.push(
+    `supacloud_management_http_request_duration_ms_bucket{le="+Inf"} ${metricState.durations.length}`,
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+export function resetRequestMetricsForTests(): void {
+  metricState.requests = 0;
+  metricState.errors = 0;
+  metricState.durations = [];
+  metricState.status.clear();
+}

--- a/packages/management-api/tests/unit/mcp.server.test.ts
+++ b/packages/management-api/tests/unit/mcp.server.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { handleMcpRequest, processMessage } from "../../src/mcp/server";
+
+const adminScope = { role: "admin" as const };
+const projectScope = { role: "project" as const, ref: "demo-project" };
+
+async function post(body: unknown, headers: Record<string, string> = {}) {
+  return handleMcpRequest(
+    new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }),
+    adminScope,
+  );
+}
+
+describe("stateless MCP Streamable HTTP endpoint", () => {
+  test("initializes with the current protocol and never creates a session", async () => {
+    const response = await post({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-06-18" },
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("mcp-protocol-version")).toBe("2025-06-18");
+    expect(response.headers.get("mcp-session-id")).toBeNull();
+    expect(body.result.protocolVersion).toBe("2025-06-18");
+    expect(body.result.capabilities.tools).toEqual({ listChanged: false });
+  });
+
+  test("returns deterministic tools and project-scoped resources", async () => {
+    const tools = await processMessage({ jsonrpc: "2.0", id: 1, method: "tools/list" }, adminScope);
+    expect(tools.result.tools.map((tool: { name: string }) => tool.name)).toEqual([
+      "supacloud.get_capabilities",
+      "supacloud.get_backup_readiness",
+      "supacloud.get_request_metrics",
+      "supacloud.plan_pitr_restore",
+    ]);
+
+    const resources = await processMessage({ jsonrpc: "2.0", id: 2, method: "resources/list" }, projectScope);
+    expect(resources.result.resources.map((resource: { uri: string }) => resource.uri)).toEqual([
+      "supacloud://capabilities",
+      "supacloud://project/demo-project/backups",
+      "supacloud://project/demo-project/metrics",
+    ]);
+  });
+
+  test("rejects unsupported content and protocol versions", async () => {
+    const contentType = await handleMcpRequest(
+      new Request("http://localhost/mcp", { method: "POST", body: "{}" }),
+      adminScope,
+    );
+    expect(contentType.status).toBe(415);
+
+    const protocol = await post(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { "mcp-protocol-version": "2099-01-01" },
+    );
+    expect(protocol.status).toBe(400);
+  });
+
+  test("uses JSON-RPC errors and keeps PITR planning non-executing", async () => {
+    const unknown = await post({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "missing.tool" },
+    });
+    const unknownBody = await unknown.json();
+    expect(unknownBody.error.code).toBe(-32000);
+
+    const plan = await processMessage(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "supacloud.plan_pitr_restore",
+          arguments: {
+            project_ref: "demo-project",
+            target: "2026-09-07T00:00:00Z",
+          },
+        },
+      },
+      adminScope,
+    );
+    expect(plan.result.content[0].text).toContain('"mode": "plan_only"');
+    expect(plan.result.content[0].text).toContain("admin approval");
+    expect(plan.result.content[0].text).not.toContain("restore_started");
+  });
+
+  test("accepts initialized notifications without a response body", async () => {
+    const response = await post({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("mcp-session-id")).toBeNull();
+  });
+
+  test("rejects resources outside a project token scope", async () => {
+    const response = await handleMcpRequest(
+      new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "resources/read",
+          params: { uri: "supacloud://project/other-project/metrics" },
+        }),
+      }),
+      projectScope,
+    );
+    const body = await response.json();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("outside the authorized scope");
+  });
+});

--- a/packages/management-api/tests/unit/observability.test.ts
+++ b/packages/management-api/tests/unit/observability.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  applyObservabilityHeaders,
+  beginRequestObservability,
+  recordRequestObservation,
+  renderRequestMetrics,
+  resetRequestMetricsForTests,
+} from "../../src/utils/observability";
+
+afterEach(() => {
+  resetRequestMetricsForTests();
+});
+
+describe("request observability", () => {
+  test("preserves a valid inbound request and trace identity", () => {
+    const request = new Request("http://localhost/health", {
+      headers: {
+        "x-request-id": "req-123",
+        "x-supacloud-correlation-id": "workflow-123",
+        traceparent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+      },
+    });
+    const context = beginRequestObservability(request);
+    const headers: Record<string, string | number> = {};
+
+    applyObservabilityHeaders(headers, context);
+
+    expect(context.requestId).toBe("req-123");
+    expect(context.traceId).toBe("0123456789abcdef0123456789abcdef");
+    expect(context.correlationId).toBe("workflow-123");
+    expect(headers).toEqual({
+      "x-request-id": "req-123",
+      "x-supacloud-trace-id": "0123456789abcdef0123456789abcdef",
+      "x-supacloud-correlation-id": "workflow-123",
+    });
+  });
+
+  test("rejects unsafe inbound identifiers and records Prometheus metrics", () => {
+    const request = new Request("http://localhost/failure", {
+      headers: {
+        "x-request-id": "bad value",
+        "x-supacloud-trace-id": "not-a-trace",
+      },
+    });
+    const context = beginRequestObservability(request);
+    recordRequestObservation(request, 503);
+    const metrics = renderRequestMetrics();
+
+    expect(context.requestId).not.toBe("bad value");
+    expect(context.traceId).not.toBe("not-a-trace");
+    expect(metrics).toContain("supacloud_management_http_requests_total 1");
+    expect(metrics).toContain("supacloud_management_http_errors_total 1");
+    expect(metrics).toContain('supacloud_management_http_responses_total{status="503"} 1');
+  });
+});

--- a/scripts/lib/backup_manager.sh
+++ b/scripts/lib/backup_manager.sh
@@ -3,36 +3,112 @@
 # backup_manager.sh
 # Manage project database backups (based on Pigsty 4.x / pgBackRest)
 
-set -e
+set -euo pipefail
 
-COMMAND=$1
-TARGET=$2  # For pgBackRest, usually stanza name; for PITR, target time
-OPTIONS=$3
+COMMAND=${1:-}
+TARGET=${2:-}  # For pgBackRest, usually stanza name; for PITR, target time
+OPTIONS=${3:-}
 
-# Default Stanza name (usually configured by Pigsty, default is db-main)
-STANZA=${TARGET:-"db-main"}
+# Pigsty owns the physical backup implementation. SupaCloud only validates
+# the provider state and exposes a stable, fail-closed operator interface.
+STANZA="${SUPACLOUD_PGBACKREST_STANZA:-db-main}"
+if [[ -z "${SUPACLOUD_PGBACKREST_STANZA:-}" && ( "$COMMAND" == "list" || "$COMMAND" == "create" ) && -n "$TARGET" ]]; then
+    STANZA="$TARGET"
+fi
+BACKUP_USER="${SUPACLOUD_PGBACKREST_USER:-postgres}"
+BACKUP_BIN="${SUPACLOUD_PGBACKREST_BIN:-pgbackrest}"
+BACKUP_CONFIG="${SUPACLOUD_PGBACKREST_CONFIG:-}"
 
 log_info() { echo -e "\033[0;32m[INFO]\033[0m $1"; }
 log_error() { echo -e "\033[0;31m[ERROR]\033[0m $1"; }
 
+die() {
+    log_error "$1"
+    exit 1
+}
+
+require_tools() {
+    command -v "$BACKUP_BIN" >/dev/null 2>&1 || die "pgBackRest is unavailable: ${BACKUP_BIN}"
+    command -v jq >/dev/null 2>&1 || die "jq is required to validate pgBackRest inventory"
+    command -v sudo >/dev/null 2>&1 || die "sudo is required to run pgBackRest as ${BACKUP_USER}"
+}
+
+pgbackrest_args() {
+    if [[ -n "$BACKUP_CONFIG" ]]; then
+        printf '%s\n' "--config=${BACKUP_CONFIG}"
+    fi
+    printf '%s\n' "--stanza=${STANZA}"
+}
+
+run_pgbackrest() {
+    local timeout_seconds="$1"
+    shift
+    mapfile -t common_args < <(pgbackrest_args)
+    timeout --kill-after=30s "$timeout_seconds" \
+        sudo -u "$BACKUP_USER" "$BACKUP_BIN" "${common_args[@]}" "$@"
+}
+
+inventory_json() {
+    require_tools
+    run_pgbackrest 15 info --output=json
+}
+
+validate_inventory() {
+    local inventory="$1"
+    jq -e --arg stanza "$STANZA" '
+        .[0] as $cluster
+        | type == "array" and length == 1
+        and $cluster.name == $stanza
+        and (($cluster.status.code == 0) or ($cluster.status.code == 2 and (($cluster.backup // []) | length == 0)))
+        and (($cluster.repo // []) | length > 0)
+        and all(($cluster.repo // [])[]; .status.code == $cluster.status.code)
+    ' <<<"$inventory" >/dev/null \
+        || die "pgBackRest inventory is unavailable or unhealthy for stanza ${STANZA}"
+}
+
+verify_inventory() {
+    local inventory
+    inventory="$(inventory_json)"
+    validate_inventory "$inventory"
+    jq -c --arg stanza "$STANZA" '
+        .[0] as $cluster
+        | {
+            schema: "supacloud.backup-readiness.v1",
+            provider: "pigsty.pgbackrest",
+            stanza: $stanza,
+            status: "ready",
+            repository_count: (($cluster.repo // []) | length),
+            completed_backup_count: ([($cluster.backup // [])[] | select(.error != true and .timestamp.stop > 0)] | length),
+            latest_completed_backup: (
+              [($cluster.backup // [])[] | select(.error != true and .timestamp.stop > 0)]
+              | sort_by(.timestamp.stop)
+              | last // null
+            )
+          }
+    ' <<<"$inventory"
+}
+
 case $COMMAND in
     list)
-        # Get backup list (JSON format)
-        # Result usually contains backup ID, type, time, size etc.
-        if ! command -v pgbackrest &> /dev/null; then
-            echo "[]"
-            exit 0
-        fi
-        timeout 15 sudo -u postgres pgbackrest --stanza="$STANZA" info --output=json 2>/dev/null || echo "[]"
+        inventory="$(inventory_json)"
+        validate_inventory "$inventory"
+        printf '%s\n' "$inventory"
+        ;;
+
+    verify)
+        verify_inventory
         ;;
 
     create)
         # Trigger immediate backup
         # Optional types: full, incr, diff (default incr)
         TYPE=${OPTIONS:-"incr"}
+        [[ "$TYPE" =~ ^(full|incr|diff)$ ]] || die "Unsupported backup type: ${TYPE}"
+        require_tools
         log_info "Starting $TYPE backup for stanza $STANZA..."
-        sudo -u postgres pgbackrest --stanza="$STANZA" --type="$TYPE" backup
-        log_info "Backup completed successfully"
+        run_pgbackrest 1800 "--type=${TYPE}" backup
+        log_info "Backup command completed; validating inventory..."
+        verify_inventory
         ;;
 
     restore)
@@ -43,15 +119,20 @@ case $COMMAND in
             exit 1
         fi
         
+        [[ "${SUPACLOUD_PITR_ENABLED:-${PITR_ENABLED:-false}}" == "true" ]] \
+            || die "Physical PITR is disabled"
+        require_tools
+        command -v pig >/dev/null 2>&1 || die "Pigsty pig command is unavailable"
         log_info "Initiating PITR restore to: $TARGET"
         # Use Pigsty's advanced orchestration tool pig pitr
         # It will automatically handle Patroni pause, data recovery, startup etc.
-        sudo -u postgres pig pitr "$TARGET"
-        log_info "Restore process initiated"
+        timeout --kill-after=30s 1800 sudo -u "$BACKUP_USER" pig pitr \
+            -s "$STANZA" -t "$TARGET" -y
+        log_info "PITR restore completed"
         ;;
 
     *)
-        echo "Usage: $0 {list|create|restore} [stanza/target] [options]"
+        echo "Usage: $0 {list|verify|create|restore} [stanza/target] [options]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- add optional stateless Streamable HTTP MCP for AI operations
- expose scoped capabilities, backup readiness, metrics, resources, and plan-only PITR
- enforce existing admin/project authentication and no MCP session state
- harden Pigsty/pgBackRest backup evidence and add request observability
- add customer integration and test requirements documentation

## Validation
- `bun run typecheck` in `packages/management-api`
- `bun test tests/unit/mcp.server.test.ts tests/unit/observability.test.ts tests/unit/backup.service.test.ts`
- `bun run scripts/check_workspace_boundaries.ts`
- `bun run scripts/check_business_invariants.ts`
- `git diff --check`

## Security boundary
MCP is read-oriented and plan-only. It does not expose shell/root/database credentials or direct PITR execution. Production acceptance still requires real credentials, external MCP client smoke, and restore-drill evidence.
