### PR TITLE
feat(cli): add release scope rebind, inspect, and create controls

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -267,6 +267,45 @@ query parameters and accepts only its authoritative JSON boolean `false`
 read-back. The fixture binding comes from the validated disable receipt before
 reporting success. Management endpoint projection is checked before and after.
 
+### Release scope rebinding and inspection
+
+Release scopes bind deployment manifests (functions, migrations, web assets) to
+an exact 40-character base commit SHA. When upstream `main` advances with
+unrelated fixes, `release scope_rebind` rebinds release manifests to the updated
+base commit without manual JSON editing or risk of dirtying non-manifest fields.
+
+```bash
+# Rebind a single scope manifest to latest git main (or origin/main)
+supacloud-cli release scope_rebind --file supacloud/fa/release-scopes/20260907-intake-p1-production.json
+
+# Rebind multiple files (e.g. production and staging together)
+supacloud-cli release scope_rebind --files "20260907-intake-p1-production.json,20260907-intake-p1-staging.json"
+
+# Rebind all scopes matching a task ID or filename prefix in standard directories
+supacloud-cli release scope_rebind --task 20260907-intake-p1
+
+# Specify an explicit base commit SHA or git ref
+supacloud-cli release scope_rebind --task 20260907-intake-p1 --base_commit origin/main
+
+# Preview changes without modifying files
+supacloud-cli release scope_rebind --task 20260907-intake-p1 --dry_run
+
+# Inspect scope status, SHA-256 hash, and alignment with git HEAD / origin/main
+supacloud-cli release scope_inspect --file 20260907-intake-p1-production.json
+
+# Scaffold a new canonical release scope
+supacloud-cli release scope_create \
+  --file supacloud/fa/release-scopes/20260907-intake-p1.json \
+  --task FA-INTAKE-P1 \
+  --ref abc123 \
+  --functions "fa-api,fa-worker" \
+  --migrations "20260907120000_init"
+```
+
+Scope actions run locally without requiring Management API credentials. Files
+are formatted canonically with 2 spaces and sorted keys, and the authoritative
+`scope_sha256` checksum is recalculated automatically.
+
 The legacy `.env` fallback is unclassified and therefore does not enable the
 production confirmation gate. Production automation must select a `prod` or
 `production` profile, or set `SUPACLOUD_ENV=production` together with a complete

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -17,6 +17,9 @@ Load this reference when selecting a command surface or when a user asks an AI t
 | Inspect or back up a remote database | `supabase db_pull`, `migration_list`, `db_dump`, `gen_types` | Requires explicit PostgreSQL DSN; redact it |
 | Replay the release-canary fixture stage receipt | `release release_canary_fixture_stage_replay` | Dual-bind Management project context and that project's service-role application origin; accepts only the exact subject/request UUID pair and a strict idempotent receipt |
 | Disable a staged release-canary fixture | `release release_canary_fixture_disable_replay` | Uses the fixed disable RPC once, accepts idempotent false/true receipts, then queries the existing pending RPC with issuer/subject and requires authoritative JSON `false`; fixture binding comes from the strict disable receipt |
+| Rebind release scope manifest to upstream base commit | `release scope_rebind` | Local action; updates baseCommit in scope JSON files canonically to target git commit, supports `--dry_run`, `--task`, and recalculates `scope_sha256` |
+| Inspect release scope manifest and git alignment | `release scope_inspect` | Local action; validates scope structure, returns canonical hash, and checks alignment with HEAD / origin/main |
+| Scaffold a new canonical release scope manifest | `release scope_create` | Local action; outputs canonical JSON scope with sorted functions, migrations, and baseCommit |
 | Preview/apply migrations remotely | `supabase push` | Always dry-run first; production needs explicit approval |
 | Mark proven-equivalent historical migrations as applied | `database baseline_migrations` | Dry-run, schema-equivalence proof, backup, explicit approval |
 | Inspect auth users or generate a controlled login link | `auth list_users`, `auth get_user`, `auth generate_link` | User reads are bounded; generation supports only `magiclink`, `recovery`, and `invite`, requires production confirmation, and returns only a validated action URL |
@@ -41,7 +44,7 @@ until a project-scoped context is resolved.
 - `secrets`: project secret management; never print values after write.
 - `queue`, `task_events`, `diagnostics`: asynchronous workload operations and bounded diagnostics.
 - `gateway`: project route/config/rebuild operations.
-- `release`: verified backup/PostgREST lifecycle controls plus production-confirmed, non-retried, strict release-canary fixture stage and disable replay actions. These actions require both the selected Management project binding and that project's `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`.
+- `release`: local release scope rebinding/inspection (`scope_rebind`, `scope_inspect`, `scope_create`), verified backup/PostgREST lifecycle controls, plus production-confirmed, non-retried, strict release-canary fixture stage and disable replay actions.
 - `ai`: inspect or install this packaged Skill.
 
 ## Safe inspection pattern

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -307,6 +307,8 @@ EXAMPLES
   ${preferredCommand} release postgrest_restart --ref abc123
   ${preferredCommand} release release_canary_fixture_stage_replay --ref abc123 --subject <uuid> --request_id <uuid>
   ${preferredCommand} release release_canary_fixture_disable_replay --ref abc123 --fixture_id <uuid> --disable_request_id <uuid> --issuer <issuer-url> --subject <uuid>
+  ${preferredCommand} release scope_rebind --file supacloud/fa/release-scopes/20260907-intake-p1-production.json
+  ${preferredCommand} release scope_inspect --file supacloud/fa/release-scopes/20260907-intake-p1-production.json
   ${preferredCommand} queue stats --queue emails
   ${preferredCommand} queue dlq --queue emails --limit 20
   ${preferredCommand} frontend list --ref abc123
@@ -473,6 +475,10 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         };
         Object.assign(tools, captureTools((server) => registerDatabaseTools(server as any, undefined, {
             localOnly: true,
+        })));
+        Object.assign(tools, captureTools((server) => registerReleaseTools(server as any, undefined, {
+            localOnly: true,
+            projectRef: context.projectRef || undefined,
         })));
         Object.assign(tools, captureTools((server) => registerRemoteDevTools(server as any, {
             cwd: process.cwd(),

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -233,6 +233,13 @@ describe("CLI execution policy", () => {
         expect(executionMode("release", "postgrest_restart", {})).toBe("write");
         expect(executionMode("release", "release_canary_fixture_stage_replay", {})).toBe("write");
         expect(executionMode("release", "release_canary_fixture_disable_replay", {})).toBe("write");
+        expect(executionMode("release", "scope_inspect", {})).toBe("local");
+        expect(executionMode("release", "scope_rebind", {})).toBe("local");
+        expect(executionMode("release", "scope_create", {})).toBe("local");
+        expect(() => authorizeExecution("release", { action: "scope_rebind" }, { context: context() })).not.toThrow();
+        expect(() => authorizeExecution("release", { action: "scope_rebind" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).not.toThrow();
         expect(() => authorizeExecution("release", { action: "logical_backup_create" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -53,6 +53,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     mutations: { read: ["status"] },
     release: {
         read: ["logical_backup_list", "postgrest_status"],
+        local: ["scope_inspect", "scope_rebind", "scope_create"],
         write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart", "release_canary_fixture_stage_replay", "release_canary_fixture_disable_replay"],
     },
     secrets: { read: ["list"], write: ["upsert", "delete"] },

--- a/packages/cli/src/shared/tools/release-tools.test.ts
+++ b/packages/cli/src/shared/tools/release-tools.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { registerReleaseTools } from "./release-tools";
 
 const PROJECT_REF = "proj";
@@ -74,8 +77,8 @@ function captureReleaseTool(
     return callback;
 }
 
-function payload(response: ToolResult): Record<string, unknown> {
-    return JSON.parse(response.content[0].text) as Record<string, unknown>;
+function payload(response: ToolResult): Record<string, any> {
+    return JSON.parse(response.content[0].text) as Record<string, any>;
 }
 
 test("logical backup list returns only the safe verified receipt projection", async () => {
@@ -585,4 +588,217 @@ test("an unsupported release action cannot issue a mutation", async () => {
 
     await expect(callback({ action: "delete_everything" })).rejects.toThrow("Unknown release control action");
     expect(postCalls).toBe(0);
+});
+
+test("scope_rebind updates single file baseCommit canonically and computes scope_sha256", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "scope-rebind-single-"));
+    try {
+        const oldCommit = "1".repeat(40);
+        const newCommit = "2".repeat(40);
+        const scopePath = join(dir, "20260907-intake-p1-production.json");
+        const initialScope = {
+            baseCommit: oldCommit,
+            excludedFunctions: ["fa-worker"],
+            functions: ["fa-api"],
+            migrations: ["20260907120000_init"],
+            targetProjectRef: "vxmnblbzsxzutzrjntyu",
+            taskId: "FA-INTAKE-P1-PROD",
+            web: false,
+        };
+        writeFileSync(scopePath, JSON.stringify(initialScope, null, 2) + "\n", "utf8");
+
+        const callback = captureReleaseTool({});
+        const response = await callback({
+            action: "scope_rebind",
+            file: scopePath,
+            base_commit: newCommit,
+            cwd: dir,
+        });
+
+        const result = payload(response);
+        expect(result).toMatchObject({
+            ok: true,
+            operation: "release.scope_rebind",
+            base_commit: newCommit,
+            count: 1,
+            updated_count: 1,
+            scopes: [{
+                previous_base_commit: oldCommit,
+                new_base_commit: newCommit,
+                updated: true,
+            }],
+        });
+
+        const updatedContent = readFileSync(scopePath, "utf8");
+        const parsed = JSON.parse(updatedContent);
+        expect(parsed.baseCommit).toBe(newCommit);
+        expect(parsed.taskId).toBe("FA-INTAKE-P1-PROD");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scope_rebind handles dry_run and unchanged baseCommit", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "scope-rebind-dry-"));
+    try {
+        const oldCommit = "3".repeat(40);
+        const newCommit = "4".repeat(40);
+        const scopePath = join(dir, "scope.json");
+        const initialScope = {
+            baseCommit: oldCommit,
+            excludedFunctions: [],
+            functions: [],
+            migrations: [],
+            targetProjectRef: "vxmnblbzsxzutzrjntyu",
+            taskId: "FA-TASK-1",
+            web: true,
+        };
+        writeFileSync(scopePath, JSON.stringify(initialScope, null, 2) + "\n", "utf8");
+
+        const callback = captureReleaseTool({});
+        const dryResponse = await callback({
+            action: "scope_rebind",
+            file: scopePath,
+            base_commit: newCommit,
+            dry_run: true,
+            cwd: dir,
+        });
+        const dryResult = payload(dryResponse);
+        expect(dryResult.dry_run).toBe(true);
+        expect(dryResult.updated_count).toBe(1);
+        expect(JSON.parse(readFileSync(scopePath, "utf8")).baseCommit).toBe(oldCommit);
+
+        const unchangedResponse = await callback({
+            action: "scope_rebind",
+            file: scopePath,
+            base_commit: oldCommit,
+            cwd: dir,
+        });
+        const unchangedResult = payload(unchangedResponse);
+        expect(unchangedResult.updated_count).toBe(0);
+        expect(unchangedResult.scopes[0].updated).toBe(false);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scope_rebind updates multiple files and scans directories by task", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "scope-rebind-multi-"));
+    try {
+        const scopesDir = join(dir, "supacloud/fa/release-scopes");
+        mkdirSync(scopesDir, { recursive: true });
+        const oldCommit = "5".repeat(40);
+        const newCommit = "6".repeat(40);
+        const prodPath = join(scopesDir, "20260907-intake-p1-production.json");
+        const stagingPath = join(scopesDir, "20260907-intake-p1-staging.json");
+        writeFileSync(prodPath, JSON.stringify({
+            baseCommit: oldCommit,
+            excludedFunctions: [],
+            functions: [],
+            migrations: [],
+            targetProjectRef: "vxmnblbzsxzutzrjntyu",
+            taskId: "FA-INTAKE-P1-PROD",
+            web: false,
+        }, null, 2) + "\n", "utf8");
+        writeFileSync(stagingPath, JSON.stringify({
+            baseCommit: oldCommit,
+            excludedFunctions: [],
+            functions: [],
+            migrations: [],
+            targetProjectRef: "stagingprojectref1234",
+            taskId: "FA-INTAKE-P1-STAGING",
+            web: false,
+        }, null, 2) + "\n", "utf8");
+
+        const callback = captureReleaseTool({});
+        const response = await callback({
+            action: "scope_rebind",
+            task: "20260907-intake-p1",
+            base_commit: newCommit,
+            cwd: dir,
+        });
+
+        const result = payload(response);
+        expect(result.count).toBe(2);
+        expect(result.updated_count).toBe(2);
+        expect(JSON.parse(readFileSync(prodPath, "utf8")).baseCommit).toBe(newCommit);
+        expect(JSON.parse(readFileSync(stagingPath, "utf8")).baseCommit).toBe(newCommit);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scope_inspect verifies structure and computes canonical scope_sha256", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "scope-inspect-"));
+    try {
+        const commit = "7".repeat(40);
+        const scopePath = join(dir, "scope.json");
+        writeFileSync(scopePath, JSON.stringify({
+            baseCommit: commit,
+            excludedFunctions: ["fa-b"],
+            functions: ["fa-a"],
+            migrations: ["20260907120000_test"],
+            targetProjectRef: "vxmnblbzsxzutzrjntyu",
+            taskId: "FA-TASK-INSPECT",
+            web: false,
+        }, null, 2) + "\n", "utf8");
+
+        const callback = captureReleaseTool({});
+        const response = await callback({
+            action: "scope_inspect",
+            file: scopePath,
+            cwd: dir,
+        });
+
+        const result = payload(response);
+        expect(result.ok).toBe(true);
+        expect(result.operation).toBe("release.scope_inspect");
+        expect(result.scope.task_id).toBe("FA-TASK-INSPECT");
+        expect(result.scope.base_commit).toBe(commit);
+        expect(typeof result.scope.scope_sha256).toBe("string");
+        expect(result.scope.scope_sha256).toHaveLength(64);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("scope_create scaffolds a canonical scope manifest with resolved baseCommit", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "scope-create-"));
+    try {
+        const commit = "8".repeat(40);
+        const scopePath = join(dir, "supacloud/fa/release-scopes/20260907-new.json");
+
+        const callback = captureReleaseTool({});
+        const response = await callback({
+            action: "scope_create",
+            file: scopePath,
+            task: "FA-NEW-TASK",
+            ref: "vxmnblbzsxzutzrjntyu",
+            base_commit: commit,
+            functions: "fa-api, fa-worker",
+            migrations: "20260907120000_first, 20260907130000_second",
+            web: true,
+            cwd: dir,
+        });
+
+        const result = payload(response);
+        expect(result.ok).toBe(true);
+        expect(result.operation).toBe("release.scope_create");
+        expect(result.base_commit).toBe(commit);
+        expect(typeof result.scope_sha256).toBe("string");
+        expect(result.scope_sha256).toHaveLength(64);
+
+        const created = JSON.parse(readFileSync(scopePath, "utf8"));
+        expect(created).toEqual({
+            baseCommit: commit,
+            excludedFunctions: [],
+            functions: ["fa-api", "fa-worker"],
+            migrations: ["20260907120000_first", "20260907130000_second"],
+            targetProjectRef: "vxmnblbzsxzutzrjntyu",
+            taskId: "FA-NEW-TASK",
+            web: true,
+        });
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
 });

--- a/packages/cli/src/shared/tools/release-tools.ts
+++ b/packages/cli/src/shared/tools/release-tools.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
@@ -21,7 +25,10 @@ type ReleaseOperation =
     | "release.postgrest.status"
     | "release.postgrest.restart"
     | "release.release_canary.fixture_stage_replay"
-    | "release.release_canary.fixture_disable_replay";
+    | "release.release_canary.fixture_disable_replay"
+    | "release.scope_inspect"
+    | "release.scope_rebind"
+    | "release.scope_create";
 
 type ReleaseCanaryStageReceipt = {
     fixtureId: string;
@@ -368,19 +375,372 @@ async function applicationOriginMatches(http: HttpTransport, projectRef: string,
     return projectApiOrigins(endpointRead, projectRef)?.includes(applicationOrigin) === true;
 }
 
+function canonicalValue(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(canonicalValue);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalValue(item)]));
+}
+
+function genericScopedReleaseScopeJson(scope: unknown): string {
+    return JSON.stringify(canonicalValue(scope));
+}
+
+function genericScopedReleaseScopeSha256(scope: unknown): string {
+    return createHash("sha256").update(genericScopedReleaseScopeJson(scope)).digest("hex");
+}
+
+function resolveGitBaseCommit(cwd: string, explicitRef?: unknown): string {
+    if (typeof explicitRef === "string" && explicitRef.trim()) {
+        const trimmed = explicitRef.trim();
+        if (/^[0-9a-f]{40}$/.test(trimmed)) {
+            try {
+                const verified = execFileSync("git", ["rev-parse", "--verify", `${trimmed}^{commit}`], {
+                    cwd,
+                    encoding: "utf8",
+                    stdio: ["ignore", "pipe", "pipe"],
+                }).trim();
+                if (/^[0-9a-f]{40}$/.test(verified)) return verified;
+            } catch {
+                return trimmed;
+            }
+            return trimmed;
+        }
+        try {
+            const sha = execFileSync("git", ["rev-parse", "--verify", `${trimmed}^{commit}`], {
+                cwd,
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "pipe"],
+            }).trim();
+            if (/^[0-9a-f]{40}$/.test(sha)) return sha;
+        } catch {
+            throw new Error(`Unable to resolve base commit from git ref '${trimmed}'`);
+        }
+    }
+    const candidateRefs = ["origin/main", "main", "HEAD^", "HEAD"];
+    for (const candidate of candidateRefs) {
+        try {
+            const sha = execFileSync("git", ["rev-parse", "--verify", `${candidate}^{commit}`], {
+                cwd,
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "pipe"],
+            }).trim();
+            if (/^[0-9a-f]{40}$/.test(sha)) return sha;
+        } catch {
+            continue;
+        }
+    }
+    throw new Error("Unable to resolve git base commit. Pass --base_commit explicitly.");
+}
+
+function gitCommitInfo(cwd: string): { head: string | null; originMain: string | null; parent: string | null } {
+    let head: string | null = null;
+    let originMain: string | null = null;
+    let parent: string | null = null;
+    try {
+        head = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    } catch {}
+    try {
+        originMain = execFileSync("git", ["rev-parse", "--verify", "origin/main^{commit}"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    } catch {}
+    try {
+        parent = execFileSync("git", ["rev-parse", "HEAD^"], { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    } catch {}
+    return { head, originMain, parent };
+}
+
+function collectScopeFiles(
+    cwd: string,
+    file?: unknown,
+    files?: unknown,
+    dir?: unknown,
+    task?: unknown,
+): string[] {
+    const results: string[] = [];
+    const resolvePathWithFallbacks = (filePath: string): string => {
+        const trimmed = filePath.trim();
+        const resolved = resolve(cwd, trimmed);
+        if (existsSync(resolved)) return resolved;
+        const candidates = [
+            resolve(cwd, "supacloud/fa/release-scopes", trimmed),
+            resolve(cwd, "release-scopes", trimmed),
+            resolve(cwd, "scopes", trimmed),
+        ];
+        const found = candidates.find(existsSync);
+        if (found) return found;
+        throw new Error(`Scope file not found: ${filePath}`);
+    };
+    if (typeof file === "string" && file.trim()) {
+        results.push(resolvePathWithFallbacks(file));
+    }
+    if (typeof files === "string" && files.trim()) {
+        const parts = files.split(",").map((s) => s.trim()).filter(Boolean);
+        for (const part of parts) {
+            results.push(resolvePathWithFallbacks(part));
+        }
+    }
+    if (results.length > 0) {
+        return [...new Set(results)];
+    }
+
+    const taskFilter = typeof task === "string" && task.trim() ? task.trim().toLowerCase() : null;
+    if (!taskFilter && (!dir || typeof dir !== "string" || !dir.trim())) {
+        throw new Error("At least one of --file, --files, or --task is required for scope_rebind");
+    }
+
+    const candidates = typeof dir === "string" && dir.trim()
+        ? [resolve(cwd, dir.trim())]
+        : [
+            resolve(cwd, "supacloud/fa/release-scopes"),
+            resolve(cwd, "release-scopes"),
+            resolve(cwd, "scopes"),
+        ];
+
+    for (const directory of candidates) {
+        if (existsSync(directory)) {
+            try {
+                const entries = readdirSync(directory, { withFileTypes: true });
+                for (const entry of entries) {
+                    if (entry.isFile() && entry.name.endsWith(".json")) {
+                        const fullPath = join(directory, entry.name);
+                        if (!taskFilter) {
+                            results.push(fullPath);
+                        } else if (entry.name.toLowerCase().includes(taskFilter)) {
+                            results.push(fullPath);
+                        } else {
+                            try {
+                                const parsed = JSON.parse(readFileSync(fullPath, "utf8"));
+                                if (typeof parsed?.taskId === "string" && parsed.taskId.toLowerCase() === taskFilter) {
+                                    results.push(fullPath);
+                                }
+                            } catch {}
+                        }
+                    }
+                }
+                if (results.length > 0) break;
+            } catch {}
+        }
+    }
+    if (results.length === 0) {
+        throw new Error("No release scope files found to rebind");
+    }
+    return [...new Set(results)];
+}
+
+interface ScopeRebindItem {
+    file: string;
+    task_id: string;
+    target_project_ref: string;
+    previous_base_commit: string;
+    new_base_commit: string;
+    scope_sha256: string;
+    updated: boolean;
+}
+
+function handleScopeRebind(args: Record<string, unknown>): ReleaseControlToolResponse {
+    const cwd = typeof args.cwd === "string" && args.cwd.trim() ? resolve(args.cwd.trim()) : process.cwd();
+    const targetBaseCommit = resolveGitBaseCommit(cwd, args.base_commit);
+    const scopeFiles = collectScopeFiles(cwd, args.file, args.files, args.dir, args.task);
+    const dryRun = args.dry_run === true;
+
+    const scopes: ScopeRebindItem[] = [];
+    for (const filePath of scopeFiles) {
+        let content: string;
+        try {
+            content = readFileSync(filePath, "utf8");
+        } catch (cause) {
+            throw new Error(`Failed to read scope file '${filePath}': ${cause instanceof Error ? cause.message : String(cause)}`);
+        }
+        let parsed: Record<string, unknown>;
+        try {
+            parsed = JSON.parse(content);
+        } catch {
+            throw new Error(`Scope file '${filePath}' is not valid JSON`);
+        }
+        if (!isRecord(parsed) || typeof parsed.baseCommit !== "string" || !/^[0-9a-f]{40}$/.test(parsed.baseCommit)) {
+            throw new Error(`Scope file '${filePath}' has missing or invalid baseCommit`);
+        }
+        const previousBaseCommit = parsed.baseCommit;
+        const updated = previousBaseCommit !== targetBaseCommit;
+        if (updated) {
+            parsed.baseCommit = targetBaseCommit;
+        }
+        const canonicalJson = genericScopedReleaseScopeJson(parsed);
+        const scopeSha256 = genericScopedReleaseScopeSha256(parsed);
+        if (updated && !dryRun) {
+            const formatted = JSON.stringify(canonicalValue(parsed), null, 2) + "\n";
+            writeFileSync(filePath, formatted, "utf8");
+        }
+        scopes.push({
+            file: relative(cwd, filePath),
+            task_id: typeof parsed.taskId === "string" ? parsed.taskId : "",
+            target_project_ref: typeof parsed.targetProjectRef === "string" ? parsed.targetProjectRef : "",
+            previous_base_commit: previousBaseCommit,
+            new_base_commit: targetBaseCommit,
+            scope_sha256: scopeSha256,
+            updated,
+        });
+    }
+
+    return releaseControlSuccess("release.scope_rebind", {
+        base_commit: targetBaseCommit,
+        dry_run: dryRun,
+        count: scopes.length,
+        updated_count: scopes.filter((s) => s.updated).length,
+        scopes,
+    });
+}
+
+function handleScopeInspect(args: Record<string, unknown>): ReleaseControlToolResponse {
+    const cwd = typeof args.cwd === "string" && args.cwd.trim() ? resolve(args.cwd.trim()) : process.cwd();
+    if (typeof args.file !== "string" || !args.file.trim()) {
+        throw new Error("'file' is required for scope_inspect");
+    }
+    const trimmed = args.file.trim();
+    let filePath = resolve(cwd, trimmed);
+    if (!existsSync(filePath)) {
+        const candidates = [
+            resolve(cwd, "supacloud/fa/release-scopes", trimmed),
+            resolve(cwd, "release-scopes", trimmed),
+            resolve(cwd, "scopes", trimmed),
+        ];
+        const found = candidates.find(existsSync);
+        if (found) filePath = found;
+        else throw new Error(`Scope file not found: ${args.file}`);
+    }
+    let content: string;
+    try {
+        content = readFileSync(filePath, "utf8");
+    } catch (cause) {
+        throw new Error(`Failed to read scope file '${args.file}': ${cause instanceof Error ? cause.message : String(cause)}`);
+    }
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(content);
+    } catch {
+        throw new Error(`Scope file '${args.file}' is not valid JSON`);
+    }
+    if (!isRecord(parsed) || typeof parsed.baseCommit !== "string" || !/^[0-9a-f]{40}$/.test(parsed.baseCommit)) {
+        throw new Error(`Scope file '${args.file}' has missing or invalid baseCommit`);
+    }
+    const scopeSha256 = genericScopedReleaseScopeSha256(parsed);
+    const git = gitCommitInfo(cwd);
+
+    return releaseControlSuccess("release.scope_inspect", {
+        file: relative(cwd, filePath),
+        scope: {
+            task_id: parsed.taskId,
+            target_project_ref: parsed.targetProjectRef,
+            base_commit: parsed.baseCommit,
+            functions: parsed.functions,
+            excluded_functions: parsed.excludedFunctions,
+            migrations: parsed.migrations,
+            deferred_migrations: parsed.deferredMigrations,
+            baseline_migrations: parsed.baselineMigrations,
+            web: parsed.web,
+            scope_sha256: scopeSha256,
+        },
+        git: {
+            matches_head: git.head !== null && parsed.baseCommit === git.head,
+            matches_origin_main: git.originMain !== null && parsed.baseCommit === git.originMain,
+            matches_parent: git.parent !== null && parsed.baseCommit === git.parent,
+            current_head: git.head,
+            origin_main: git.originMain,
+        },
+    });
+}
+
+function parseCommaList(value: unknown): string[] {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+        return [...new Set(value.map(String).map((s) => s.trim()).filter(Boolean))].sort();
+    }
+    if (typeof value === "string") {
+        return [...new Set(value.split(",").map((s) => s.trim()).filter(Boolean))].sort();
+    }
+    return [];
+}
+
+function handleScopeCreate(args: Record<string, unknown>, fallbackRef?: string): ReleaseControlToolResponse {
+    const cwd = typeof args.cwd === "string" && args.cwd.trim() ? resolve(args.cwd.trim()) : process.cwd();
+    if (typeof args.file !== "string" || !args.file.trim()) {
+        throw new Error("'file' is required for scope_create");
+    }
+    if (typeof args.task !== "string" || !args.task.trim()) {
+        throw new Error("'task' is required for scope_create");
+    }
+    const projectRef = (typeof args.ref === "string" && args.ref.trim()) || fallbackRef;
+    if (!projectRef) {
+        throw new Error("'ref' is required for scope_create");
+    }
+    if (!validProjectRef(projectRef)) {
+        throw new Error("'ref' is invalid for release controls");
+    }
+    const targetBaseCommit = resolveGitBaseCommit(cwd, args.base_commit);
+    const filePath = resolve(cwd, args.file.trim());
+    mkdirSync(dirname(filePath), { recursive: true });
+
+    const scope = {
+        baseCommit: targetBaseCommit,
+        excludedFunctions: parseCommaList(args.excluded_functions),
+        functions: parseCommaList(args.functions),
+        migrations: parseCommaList(args.migrations),
+        targetProjectRef: projectRef,
+        taskId: String(args.task).trim(),
+        web: Boolean(args.web),
+    };
+
+    const canonicalJson = genericScopedReleaseScopeJson(scope);
+    const scopeSha256 = genericScopedReleaseScopeSha256(scope);
+    const formatted = JSON.stringify(canonicalValue(scope), null, 2) + "\n";
+    writeFileSync(filePath, formatted, "utf8");
+
+    return releaseControlSuccess("release.scope_create", {
+        file: relative(cwd, filePath),
+        task_id: scope.taskId,
+        target_project_ref: projectRef,
+        base_commit: targetBaseCommit,
+        scope_sha256: scopeSha256,
+        scope,
+    });
+}
+
 export function registerReleaseTools(
     server: ToolServer,
-    http: HttpTransport,
-    options: { projectRef?: string; applicationHttp?: HttpTransport; applicationOrigin?: string } = {},
+    http?: HttpTransport,
+    options: {
+        localOnly?: boolean;
+        projectRef?: string;
+        applicationHttp?: HttpTransport;
+        applicationOrigin?: string;
+    } = {},
 ): void {
+    const localActions = ["scope_inspect", "scope_rebind", "scope_create"] as const;
+    const remoteActions = [
+        "logical_backup_list", "logical_backup_create", "logical_backup_restore",
+        "postgrest_status", "postgrest_restart",
+        "release_canary_fixture_stage_replay", "release_canary_fixture_disable_replay",
+    ] as const;
+    const allActions = [...remoteActions, ...localActions] as const;
+
     server.tool(
         "release",
-        "Verified release controls. Management actions use the Management API; release canary stage/disable replay additionally require the selected project's SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+        "Verified release controls. Scope management actions operate locally; management actions use the Management API; release canary stage/disable replay additionally require the selected project's SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
         {
-            action: withDescription(stringEnum([
-                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart", "release_canary_fixture_stage_replay", "release_canary_fixture_disable_replay",
-            ]), "Release control action"),
+            action: withDescription(stringEnum(allActions as unknown as [string, ...string[]]), "Release control action"),
             ref: optional(Type.String(), options.projectRef ? "Optional override when not auto-linked" : "Project ref"),
+            file: optional(Type.String(), "[scope_inspect/scope_rebind/scope_create] Path to release scope JSON file"),
+            files: optional(Type.String(), "[scope_rebind] Comma-separated list of release scope JSON files"),
+            dir: optional(Type.String(), "[scope_rebind] Directory containing release scope JSON files (defaults to supacloud/fa/release-scopes, release-scopes, or scopes)"),
+            task: optional(Type.String(), "[scope_rebind/scope_create] Task ID or prefix filter for scope files"),
+            base_commit: optional(Type.String(), "[scope_rebind/scope_create] Target 40-character base commit SHA or git ref (defaults to origin/main -> main -> HEAD^ -> HEAD)"),
+            functions: optional(Type.String(), "[scope_create] Comma-separated list of functions to deploy"),
+            excluded_functions: optional(Type.String(), "[scope_create] Comma-separated list of functions to exclude"),
+            migrations: optional(Type.String(), "[scope_create] Comma-separated list of migrations to apply"),
+            web: optional(Type.Boolean(), "[scope_create] Whether web assets are included in release scope"),
+            dry_run: optional(Type.Boolean(), "[scope_rebind] Perform calculation and validation without writing files"),
+            cwd: optional(Type.String(), "[scope_inspect/scope_rebind/scope_create] Base directory for relative file and git resolution"),
             backup_id: optional(Type.String(), "[logical_backup_restore] Exact verified logical-full backup ID from the selected project inventory"),
             expected_sha256: optional(Type.String(), "[logical_backup_restore] Exact lowercase SHA-256 from the selected project inventory"),
             restore_confirmation: optional(Type.String(), "[logical_backup_restore] Exact RESTORE_PROJECT:<ref>:<backup_id>:<sha256> confirmation"),
@@ -390,7 +750,31 @@ export function registerReleaseTools(
             disable_request_id: optional(Type.String(), "[release_canary_fixture_disable_replay] Exact idempotent disable request UUID"),
             issuer: optional(Type.String(), "[release_canary_fixture_disable_replay] Exact HTTP(S) issuer"),
         },
-        async ({ action, ref, backup_id, expected_sha256, restore_confirmation, subject, request_id, fixture_id, disable_request_id, issuer }) => {
+        async (args: any) => {
+            const { action } = args;
+            if (action === "scope_rebind") {
+                return handleScopeRebind(args);
+            }
+            if (action === "scope_inspect") {
+                return handleScopeInspect(args);
+            }
+            if (action === "scope_create") {
+                return handleScopeCreate(args, options.projectRef);
+            }
+
+            if (options.localOnly || !http) {
+                return {
+                    isError: true,
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: "⚠️ This command requires Management API context. Run `supacloud-cli status` to inspect current detection.",
+                        },
+                    ],
+                };
+            }
+
+            const { ref, backup_id, expected_sha256, restore_confirmation, subject, request_id, fixture_id, disable_request_id, issuer } = args;
             const projectRef = typeof ref === "string" && ref || options.projectRef;
             if (!projectRef) throw new Error("'ref' is required for release controls");
             if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");


### PR DESCRIPTION
### Summary
- Add release scope governance tools to `@supacloud/cli`:
  - `release scope_rebind`: re-resolves base commit, recalculates canonical JSON formatting, and updates `scope_sha256`.
  - `release scope_inspect`: validates manifest structure, SHA-256 hash match, and alignment against HEAD/main.
  - `release scope_create`: generates canonical release scope manifests.
- Classified as `local` execution policy.
- Verified with unit tests and type checks.