### PR TITLE
feat(db): add decoder-inferred RPC contracts

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -79,6 +79,40 @@ const userDb = await database.forUser(requireTrustedIdentity(requestContext));
 const workerDb = await database.forService("scheduled-worker");
 ```
 
+### Typed RPC boundary
+
+`createRpcClient(transport, contracts)` validates arguments before transport and results
+before returning them. Names, arguments and results are inferred from the registry;
+callers cannot supply an arbitrary result type. It uses the supplied client without
+changing its identity, RLS policy or credentials.
+
+```ts
+import { createRpcClient, defineRpcContract } from '@supacloud/db';
+
+const rpc = createRpcClient(userDb, {
+  case_create: defineRpcContract({
+    args: decodeCreateCaseArgs,
+    result: decodeCreatedCase,
+  }),
+});
+const result = await rpc.call('case_create', { title: 'Investigation' });
+if (result.ok) {
+  console.log(result.data);
+} else {
+  handleDatabaseFailure(result.error);
+}
+```
+
+Decoders must accept `unknown`, validate it at runtime and throw on invalid values.
+They may project extra fields away. Schema libraries such as TypeBox can supply
+these functions; this driver-independent package adds no schema-library dependency.
+Database failures bypass result decoding. Contract failures throw `RpcContractError`
+with a phase and no raw payload or decoder error. Calls are never retried automatically,
+including result-validation failures after a potentially committed command.
+
+This is an explicit contract boundary, not inference of JSONB fields from SQL,
+authorization, migration execution or automatic HTTP client generation.
+
 ## 诊断码
 
 ### 对账（reconcile）

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -51,3 +51,15 @@ export {
   type DatabaseAccessBoundaryOptions,
   type DatabaseAccessErrorCode,
 } from './access.js';
+
+export {
+  createRpcClient,
+  defineRpcContract,
+  RpcContractError,
+  type RpcArgs,
+  type RpcCallResult,
+  type RpcContract,
+  type RpcDecoder,
+  type RpcResult,
+  type RpcTransport,
+} from './rpc.js';

--- a/packages/db/src/rpc.test.ts
+++ b/packages/db/src/rpc.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { createRpcClient, defineRpcContract, RpcContractError } from './index';
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('not an object');
+  return value as Record<string, unknown>;
+}
+
+const contract = defineRpcContract({
+  args(value) {
+    const record = object(value);
+    if (typeof record.id !== 'string') throw new Error('sensitive argument');
+    return { id: record.id };
+  },
+  result(value) {
+    const record = object(value);
+    if (typeof record.version !== 'number') throw new Error('sensitive result');
+    return { version: record.version };
+  },
+});
+
+describe('typed RPC contracts', () => {
+  test('validates both boundaries and sends projected arguments through the supplied client', async () => {
+    const rpc = mock(async (_name: string, _args: Record<string, unknown>) => ({
+      data: { version: 2, internal: 'not returned' }, error: null,
+    }));
+    const client = createRpcClient({ rpc }, { update_item: contract });
+    const result = await client.call('update_item', { id: 'item', extra: 'not sent' } as { id: string });
+    expect(rpc).toHaveBeenCalledWith('update_item', { id: 'item' });
+    expect(result).toEqual({ ok: true, data: { version: 2 }, error: null });
+    if (result.ok) {
+      const version: number = result.data.version;
+      expect(version).toBe(2);
+    }
+  });
+
+  test('rejects invalid arguments before transport without exposing decoder errors', async () => {
+    const rpc = mock(async () => ({ data: null, error: null }));
+    const client = createRpcClient({ rpc }, { update_item: contract });
+    await expect(client.call('update_item', { id: 1 } as unknown as { id: string }))
+      .rejects.toMatchObject({ code: 'RPC_CONTRACT_INVALID', phase: 'args' });
+    expect(rpc).not.toHaveBeenCalled();
+    await expect(client.call('update_item', null as unknown as { id: string }))
+      .rejects.toThrow('RPC contract validation failed (args)');
+  });
+
+  test.each([null, {}, { version: '2' }, []].map(data => [data]))('rejects malformed successful results without replaying a write: %j', async (data) => {
+    const rpc = mock(async () => ({ data, error: null }));
+    const client = createRpcClient({ rpc }, { update_item: contract });
+    await expect(client.call('update_item', { id: 'item' }))
+      .rejects.toMatchObject({ name: 'RpcContractError', phase: 'result' });
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves database failures and never decodes partial data', async () => {
+    const error = { code: '42501', message: 'denied' };
+    const resultDecoder = mock(contract.result);
+    const client = createRpcClient({ rpc: async () => ({ data: { version: 3 }, error }) }, {
+      update_item: { ...contract, result: resultDecoder },
+    });
+    expect(await client.call('update_item', { id: 'item' }))
+      .toEqual({ ok: false, data: null, error });
+    expect(resultDecoder).not.toHaveBeenCalled();
+  });
+
+  test.each([null, [], {}, { data: { version: 1 } }, { error: null }].map(value => [value]))(
+    'rejects malformed transport envelopes without decoding or retrying: %j', async (value) => {
+      const rpc = mock(async () => value as { data: unknown; error: unknown });
+      const resultDecoder = mock(contract.result);
+      const client = createRpcClient({ rpc }, {
+        update_item: { ...contract, result: resultDecoder },
+      });
+      await expect(client.call('update_item', { id: 'item' }))
+        .rejects.toMatchObject({ phase: 'result' });
+      expect(resultDecoder).not.toHaveBeenCalled();
+      expect(rpc).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('permits null only when the declared decoder accepts it', async () => {
+    const client = createRpcClient({ rpc: async () => ({ data: null, error: null }) }, {
+      find_item: defineRpcContract({
+        args: contract.args,
+        result: (value) => value === null ? null : contract.result(value),
+      }),
+    });
+    expect(await client.call('find_item', { id: 'missing' }))
+      .toEqual({ ok: true, data: null, error: null });
+  });
+
+  test('rejects undeclared and prototype names before making requests', async () => {
+    const rpc = mock(async () => ({ data: {}, error: null }));
+    const client = createRpcClient({ rpc }, { update_item: contract });
+    for (const name of ['toString', '__proto__', 'unregistered']) {
+      await expect(Reflect.apply(client.call, client, [name, {}]))
+        .rejects.toBeInstanceOf(RpcContractError);
+    }
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  test('snapshots decoder registrations', async () => {
+    const mutable = { ...contract };
+    const client = createRpcClient({ rpc: async () => ({ data: {}, error: null }) }, { update_item: mutable });
+    mutable.result = () => ({ version: 999 });
+    await expect(client.call('update_item', { id: 'item' })).rejects.toBeInstanceOf(RpcContractError);
+  });
+
+  test('does not retry rejected transports', async () => {
+    const error = new Error('network failure');
+    const rpc = mock(async () => { throw error; });
+    await expect(createRpcClient({ rpc }, { update_item: contract }).call('update_item', { id: 'item' }))
+      .rejects.toBe(error);
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+});
+
+// These calls are compile-time fixtures, not runtime assertions.
+function typeAssertions() {
+  const client = createRpcClient({ rpc: async () => ({ data: {}, error: null }) }, {
+    update_item: contract,
+    find_by_version: defineRpcContract({ args: (value) => ({ version: Number(value) }), result: String }),
+  });
+  // @ts-expect-error Only declared names are callable.
+  void client.call('missing', { id: 'item' });
+  // @ts-expect-error Arguments are inferred from the selected contract.
+  void client.call('update_item', { id: 1 });
+  // @ts-expect-error Another registration must not widen the selected arguments.
+  void client.call('update_item', { version: 1 });
+  void client.call('update_item', { id: 'item' }).then((result) => {
+    if (result.ok) {
+      // @ts-expect-error Result fields are inferred from the decoder.
+      const version: string = result.data.version;
+      void version;
+    }
+  });
+}
+void typeAssertions;

--- a/packages/db/src/rpc.ts
+++ b/packages/db/src/rpc.ts
@@ -1,0 +1,79 @@
+export type RpcDecoder<T> = (value: unknown) => T;
+
+export interface RpcContract<Args extends Record<string, unknown>, Result> {
+  args: RpcDecoder<Args>;
+  result: RpcDecoder<Result>;
+}
+
+export type RpcArgs<Contract> = Contract extends RpcContract<infer Args, unknown> ? Args : never;
+export type RpcResult<Contract> = Contract extends RpcContract<Record<string, unknown>, infer Result> ? Result : never;
+
+export interface RpcTransport {
+  rpc(name: string, args: Record<string, unknown>): PromiseLike<{ data: unknown; error: unknown }>;
+}
+
+export type RpcCallResult<T> =
+  | { ok: true; data: T; error: null }
+  | { ok: false; data: null; error: unknown };
+
+export class RpcContractError extends Error {
+  readonly code = 'RPC_CONTRACT_INVALID';
+
+  constructor(readonly rpcName: string, readonly phase: 'registration' | 'args' | 'result') {
+    // Do not expose arguments, response payloads or decoder errors in diagnostics.
+    super(`RPC contract validation failed (${phase})`);
+    this.name = 'RpcContractError';
+  }
+}
+
+export function defineRpcContract<Args extends Record<string, unknown>, Result>(
+  contract: RpcContract<Args, Result>,
+): Readonly<RpcContract<Args, Result>> {
+  return Object.freeze({ ...contract });
+}
+
+type Contracts = Record<string, RpcContract<Record<string, unknown>, unknown>>;
+
+export function createRpcClient<const Registry extends Contracts>(
+  transport: RpcTransport,
+  contracts: Registry,
+) {
+  // Snapshot registrations so later mutations cannot replace a trusted decoder.
+  const registered = new Map(Object.entries(contracts).map(([name, contract]) => [
+    name, defineRpcContract(contract),
+  ]));
+
+  return {
+    async call<Name extends Extract<keyof Registry, string>>(
+      name: Name,
+      args: RpcArgs<Registry[NoInfer<Name>]>,
+    ): Promise<RpcCallResult<RpcResult<Registry[Name]>>> {
+      const contract = registered.get(name);
+      if (!contract) throw new RpcContractError(name, 'registration');
+      let decodedArgs: Record<string, unknown>;
+      try {
+        decodedArgs = contract.args(args);
+        if (!decodedArgs || typeof decodedArgs !== 'object' || Array.isArray(decodedArgs)) {
+          throw new TypeError('RPC arguments must decode to an object');
+        }
+      } catch {
+        throw new RpcContractError(name, 'args');
+      }
+      // One transport call only: a failed decode may follow a committed command.
+      const response = await transport.rpc(name, decodedArgs);
+      if (!response || typeof response !== 'object' || Array.isArray(response)
+        || !Object.hasOwn(response, 'error')) {
+        throw new RpcContractError(name, 'result');
+      }
+      if (response.error != null) return { ok: false, data: null, error: response.error };
+      if (!Object.hasOwn(response, 'data')) throw new RpcContractError(name, 'result');
+      try {
+        // The registry index loses generic correlation; this cast follows decoding.
+        const data = contract.result(response.data) as RpcResult<Registry[Name]>;
+        return { ok: true, data, error: null };
+      } catch {
+        throw new RpcContractError(name, 'result');
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add driver-independent `defineRpcContract` and `createRpcClient` exports to `@supacloud/db`.
- Infer RPC names, arguments and results from decoder registrations; callers cannot supply an arbitrary result generic.
- Validate arguments before transport and successful data before returning it. Preserve database/transport failures and never retry commands automatically.
- Snapshot decoder registrations, reject unknown/prototype RPC names and malformed transport envelopes, and redact payloads from contract diagnostics.

## Verification

- `packages/db`: `bun test`: 80 passed.
- `bun run typecheck` and `bun run typecheck:test`: passed, including negative compile-time fixtures.
- `bun run build`: passed.
- `git diff --check`: passed.

## Scope and Compatibility

This is an additive, opt-in contract boundary. Existing callers are unchanged. Decoders must genuinely validate unknown input; this does not infer JSONB projections from SQL or migrate application RPCs automatically.

The supplied transport retains its existing identity and permissions. No credential creation, RLS changes, migrations, CLI TLS/default-certificate changes, compiler strict-mode changes, release or deployment are included.

Rollback: revert this commit before adoption, or revert application adoption alongside removal of these new exports.
