### PR TITLE
fix(elysia): distinguish response contract failures and isolate error mapping

### DIFF
--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -26,7 +26,8 @@ Runtime adapter that turns `@supacloud/compiler` output into a production-ready
   performed.
 - **Public error mapping**: transforms framework / application errors via
   `errorMapper` with standard `ApplicationError` envelope support, preserving
-  Elysia's default behavior (422) for schema validation errors.
+  HTTP 422 for request validation and HTTP 500 / `RESPONSE_VALIDATION_ERROR`
+  for invalid handler output, without exposing payloads or schema internals.
 
 ## Installation
 
@@ -83,8 +84,15 @@ sandbox.reset();
 
 Route `body`, `params`, `query`, and `response` schemas are enforced by
 Elysia before and after the handler. Invalid input returns the standard `422`
-validation response; invalid handler output is rejected before it reaches the
-client.
+validation response; invalid structured handler output returns HTTP 500 with
+`RESPONSE_VALIDATION_ERROR`. A response validation failure can occur **after a
+command has committed**; it does not imply rollback and must not trigger a blind
+write retry. Confirm the outcome using the application's durable receipt or
+read-back protocol. A custom `errorMapper` can override this public envelope.
+
+Native `Response` objects are passed through by Elysia, including JSON responses.
+Handlers returning a native `Response` must validate their JSON payload before
+constructing it. The adapter does not consume or parse binary/streaming responses.
 
 Jobs are executed explicitly with `executeJob(compiledModule, services, job,
 input, requestContext)`. The asynchronous compiler-generated job scope is

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -236,11 +236,16 @@ describe("createApplication", () => {
     expect(res.status).toBe(422);
   });
 
-  test("rejects invalid responses with 422 via Elysia response validation", async () => {
+  test("classifies invalid responses as server contract failures without leaking output", async () => {
     const app = createApp({});
 
     const res = await testRequest(app, "/cases/invalid-response");
-    expect(res.status).toBe(422);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      ok: false,
+      code: "RESPONSE_VALIDATION_ERROR",
+      message: "Response validation failed",
+    });
   });
 
   test("uses the compiler-emitted positional invoker after schema decoding", async () => {
@@ -580,6 +585,28 @@ describe("SupaCloud request context", () => {
 });
 
 describe("defaultErrorResponse", () => {
+  test("keeps request validation at 422 and ignores payload-bearing framework details", async () => {
+    for (const type of ["body", "params", "query", "headers", "cookie"]) {
+      const response = defaultErrorResponse(Object.assign(new Error("private input"), {
+        type, value: { password: "private" },
+      }), "VALIDATION");
+      expect(response.status).toBe(422);
+      expect(await response.json()).toEqual({
+        ok: false, code: "VALIDATION_ERROR", message: "Request validation failed",
+      });
+    }
+    expect(defaultErrorResponse({ type: "response" }, "UNKNOWN").status).toBe(500);
+  });
+
+  test("preserves explicitly exposed business errors even when their type is response", async () => {
+    const error = Object.assign(new ApplicationError("Version conflict", {
+      status: 409, code: "VERSION_CONFLICT",
+    }), { type: "response" });
+    const response = defaultErrorResponse(error, "VALIDATION");
+    expect(response.status).toBe(409);
+    expect((await response.json()).code).toBe("VERSION_CONFLICT");
+  });
+
   test("accepts structural public errors from platform packages", async () => {
     const error = Object.assign(new Error("Service role reason is not allowed"), {
       expose: true as const,

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -568,6 +568,17 @@ export function createModulePlugin(
     return { requestContext };
   });
 
+  // Bind before routes and keep the handler local to its module's request context.
+  plugin.onError(async ({ code, error, request }) => {
+    const context: ErrorContext = {
+      request,
+      requestContext: requestContexts.get(request),
+      frameworkCode: code,
+    };
+    const mapped = await options.errorMapper?.(error, context);
+    return mapped ?? defaultErrorResponse(error, code);
+  });
+
   for (const controller of compiled.controllers) {
     for (const route of controller.routes) {
       const path = joinPaths(controller.path, route.path);
@@ -695,16 +706,6 @@ export function createModulePlugin(
     }
   }
 
-  plugin.onError({ as: "global" }, async ({ code, error, request }) => {
-    const context: ErrorContext = {
-      request,
-      requestContext: requestContexts.get(request),
-      frameworkCode: code,
-    };
-    const mapped = await options.errorMapper?.(error, context);
-    return mapped ?? defaultErrorResponse(error, code);
-  });
-
   return plugin as unknown as Elysia;
 }
 
@@ -785,6 +786,14 @@ export function defaultErrorResponse(
     }, { status: error.status });
   }
   if (frameworkCode === "VALIDATION") {
+    // A response failure can occur after a command commits; it is not invalid input.
+    if (isRecord(error) && error.type === "response") {
+      return Response.json({
+        ok: false,
+        code: "RESPONSE_VALIDATION_ERROR",
+        message: "Response validation failed",
+      }, { status: 500 });
+    }
     return Response.json({
       ok: false,
       code: "VALIDATION_ERROR",

--- a/packages/elysia/src/response-validation.test.ts
+++ b/packages/elysia/src/response-validation.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import Elysia, { t } from "elysia";
+import { createApplication, createModulePlugin, type CompiledModule } from "./index";
+
+function commandModule(write: () => unknown): CompiledModule {
+  return {
+    name: "receipt",
+    createServices: () => ({ controller: { write } }),
+    controllers: [{
+      path: "/receipt", serviceKey: "controller", scope: "application",
+      routes: [{
+        method: "POST", path: "", handler: "write",
+        response: t.Object({ id: t.String() }),
+        command: "WriteCommand",
+      }],
+    }],
+    commands: [{ className: "WriteCommand", name: "receipt.write" }],
+  };
+}
+
+test("invalid output after a write is a server failure and does not execute the command again", async () => {
+  let writes = 0;
+  const app = createApplication({
+    modules: [commandModule(() => { writes++; return { secret: "private receipt" }; })],
+    commandExecutor: (_invocation, next) => next(),
+  });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+  expect(response.status).toBe(500);
+  expect(await response.json()).toEqual({
+    ok: false, code: "RESPONSE_VALIDATION_ERROR", message: "Response validation failed",
+  });
+  expect(writes).toBe(1);
+});
+
+test("custom error mapping still receives the response validation error and request context", async () => {
+  let observed: unknown;
+  const app = createApplication({
+    modules: [commandModule(() => ({ id: 42 }))],
+    commandExecutor: (_invocation, next) => next(),
+    requestContext: () => ({ requestId: "request-1" }),
+    errorMapper: (error, context) => {
+      observed = { error, context };
+      return Response.json({ code: "CUSTOM_OUTCOME_UNKNOWN" }, { status: 503 });
+    },
+  });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+  expect(response.status).toBe(503);
+  expect(await response.json()).toEqual({ code: "CUSTOM_OUTCOME_UNKNOWN" });
+  expect(observed).toMatchObject({
+    error: { type: "response" },
+    context: { frameworkCode: "VALIDATION", requestContext: { requestId: "request-1" } },
+  });
+});
+
+test("native Response passthrough is unchanged and must be validated by the handler", async () => {
+  const app = createApplication({
+    modules: [commandModule(() => Response.json({ id: 42 }, { headers: { "x-receipt": "native" } }))],
+    commandExecutor: (_invocation, next) => next(),
+  });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+  expect(response.status).toBe(200);
+  expect(response.headers.get("x-receipt")).toBe("native");
+  expect(await response.json()).toEqual({ id: 42 });
+});
+
+test("error mapping retains request context for every module", async () => {
+  const first = commandModule(() => ({ id: 42 }));
+  const second = commandModule(() => ({ id: 42 }));
+  second.name = "second";
+  second.controllers[0]!.path = "/second";
+  const app = createApplication({
+    modules: [first, second],
+    commandExecutor: (_invocation, next) => next(),
+    requestContext: (request) => ({ path: new URL(request.url).pathname }),
+    errorMapper: (_error, context) => Response.json(context.requestContext, { status: 503 }),
+  });
+  for (const path of ["/receipt", "/second"]) {
+    const response = await app.handle(new Request(`http://localhost${path}`, { method: "POST" }));
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ path });
+  }
+});
+
+test("standalone plugins enforce the same output error boundary without capturing host errors", async () => {
+  const compiled = commandModule(() => ({ id: 42 }));
+  const app = new Elysia()
+    .use(createModulePlugin(compiled, compiled.createServices({}, {}), undefined, {
+      commandExecutor: (_invocation, next) => next(),
+    }))
+    .get("/host", () => { throw new Error("host failure"); }, {
+      error: () => Response.json({ code: "HOST_ERROR" }, { status: 502 }),
+    });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+  expect(response.status).toBe(500);
+  expect((await response.json()).code).toBe("RESPONSE_VALIDATION_ERROR");
+  const host = await app.handle(new Request("http://localhost/host"));
+  expect(host.status).toBe(502);
+  expect(await host.json()).toEqual({ code: "HOST_ERROR" });
+});


### PR DESCRIPTION
## Summary

- Map invalid structured handler output to HTTP 500 / `RESPONSE_VALIDATION_ERROR`, keeping request validation at 422 and sanitizing details.
- Register the error mapper before module routes. Keep the hook module-local so single-module applications and standalone plugins inherit it, and multi-module errors retain the correct request context without capturing unrelated host routes.
- Preserve custom error mapper precedence, exposed application errors, and native `Response` passthrough. Document that native JSON responses require explicit handler validation.

## Why

Response validation happens after the handler and can occur after a write has committed. Reporting it as an invalid request encourages the wrong recovery behavior. This patch does not imply transaction rollback or implement automatic retries.

## Verification

- `bun test` in `packages/elysia`: 45 pass, 0 fail.
- `bun run typecheck`, `bun run typecheck:test`, `bun run build`: pass.
- Built `dist/index.js` import smoke: malformed output returns the sanitized 500 envelope.
- `git diff --check`: pass.
- Negative tests reproduced 422 response misclassification, missing single-module error mapping, and cross-module loss of request context before the corresponding fixes.

No version bump, publication or deployment. Remote CI was not polled.
