### PR TITLE
feat: validated HTTP contracts and opt-in route contract policy

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -183,3 +183,31 @@ export const CaseFeature = defineFeatureSlice({
 
 The compiler validates that feature states, commands, permissions, and transactions
 remain synchronized and detects architectural drift at build time.
+
+## Validated HTTP Contracts
+
+`HttpClient.execute(contract, input, options?)` infers input and result types from
+`HttpContract` decoders. Each decoder accepts `unknown` and must reject invalid
+values. A TypeBox, Zod, or application decoder can be used without a new runtime
+dependency.
+
+```ts
+import type { HttpContract } from "@supacloud/app";
+
+const saveItem: HttpContract<{ name: string }, { id: string }> = {
+  input: decodeItemInput,
+  result: decodeItemReceipt,
+  request: (input) => ({ method: "POST", url: "/items", body: input }),
+};
+const receipt = await http.execute(saveItem, { name: "Example" }, {
+  headers: { "Idempotency-Key": requestId },
+  signal: abortController.signal,
+});
+```
+
+Input decoding happens before transport. JSON parsing and receipt decoding happen
+after transport; invalid/empty successful responses reject with
+`HttpContractError` (`boundary: "request" | "response"`), without decoder causes or
+payloads. HTTP errors remain `HttpErrorResponse`. Contract execution does not
+retry; existing interceptors still control transport and must not replay an
+unknown-result write. This is opt-in and does not validate legacy generic calls.

--- a/packages/app/src/http_client.ts
+++ b/packages/app/src/http_client.ts
@@ -6,6 +6,7 @@ import { type HttpInterceptorFn, type HttpRequestPayload } from "./interceptor";
 import { InjectionToken } from "./token";
 import { inject, injectAll } from "./inject";
 import { makeEnvironmentProviders, type EnvironmentProviders, type Provider } from "./provider";
+import { decodeHttpContract, HttpContractError, type HttpContract } from "./http_contract";
 
 export interface HttpClientConfig {
   baseUrl?: string;
@@ -144,6 +145,34 @@ export class HttpClient {
 
   patch<T = unknown>(url: string, body?: unknown, options?: HttpRequestOptions): Promise<T> {
     return this.request<T>("PATCH", url, { ...options, body });
+  }
+
+  /** Decoders own the input/result types; this entry never retries a failed command. */
+  async execute<Input, Result>(
+    contract: HttpContract<Input, Result>,
+    input: NoInfer<Input>,
+    options?: Omit<HttpRequestOptions, "body" | "observe" | "responseType">,
+  ): Promise<Result> {
+    const request = contract.request(decodeHttpContract(contract.input, input, "request"));
+    const response = await this.request<Response>(request.method, request.url, {
+      ...options, body: request.body, observe: "response",
+    });
+    if (!response.ok) {
+      throw new HttpErrorResponse({
+        url: response.url || request.url,
+        status: response.status,
+        statusText: response.statusText,
+        error: await response.json().catch(() => null),
+      });
+    }
+    let value: unknown;
+    try {
+      value = await response.json();
+    } catch {
+      // A successful HTTP status does not establish a valid JSON receipt.
+      throw new HttpContractError("response");
+    }
+    return decodeHttpContract(contract.result, value, "response");
   }
 
   async request<T = unknown>(method: string, url: string, options?: HttpRequestOptions): Promise<T> {

--- a/packages/app/src/http_contract.test.ts
+++ b/packages/app/src/http_contract.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { HttpClient } from "./http_client";
+import { HttpContractError, type HttpContract } from "./http_contract";
+
+const contract: HttpContract<{ name: string }, { version: number }> = {
+  input(value) {
+    if (!value || typeof value !== "object" || !("name" in value)
+      || typeof value.name !== "string" || !value.name.trim()) throw new Error("private input");
+    return { name: value.name.trim() };
+  },
+  result(value) {
+    if (!value || typeof value !== "object" || !("version" in value)
+      || !Number.isSafeInteger(value.version) || Number(value.version) < 1) throw new Error("private result");
+    return value as { version: number };
+  },
+  request: (input) => ({ method: "POST", url: "/items", body: input }),
+};
+
+describe("HttpClient contract execution", () => {
+  test("validates before transport and preserves interceptors and headers", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const client = new HttpClient({
+      baseUrl: "https://example.test",
+      fetch: (async (url, init) => {
+        calls.push({ url: String(url), init });
+        return Response.json({ version: 2 });
+      }) as typeof fetch,
+    }, [async (req, next) => next({ ...req, headers: { ...req.headers, traced: "yes" } })]);
+    await expect(client.execute(contract, { name: "" })).rejects.toMatchObject({ boundary: "request" });
+    expect(calls).toHaveLength(0);
+    expect(await client.execute(contract, { name: " item " }, { headers: { "Idempotency-Key": "same" } }))
+      .toEqual({ version: 2 });
+    expect(calls[0]?.url).toBe("https://example.test/items");
+    expect(calls[0]?.init?.body).toBe('{"name":"item"}');
+    expect(calls[0]?.init?.headers).toMatchObject({ "Idempotency-Key": "same", traced: "yes" });
+  });
+
+  test("invalid receipts are sanitized and never replayed", async () => {
+    let calls = 0;
+    const client = new HttpClient({ fetch: (async () => {
+      calls++;
+      return Response.json({ version: "private result" });
+    }) as unknown as typeof fetch });
+    const error = await client.execute(contract, { name: "item" }).catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(HttpContractError);
+    expect(error).toMatchObject({ boundary: "response" });
+    expect(String(error)).not.toContain("private result");
+    expect(calls).toBe(1);
+  });
+
+  test("HTTP failures are not reclassified as schema errors", async () => {
+    const client = new HttpClient({ fetch: (async () => Response.json({ code: "denied" }, { status: 403 })) as unknown as typeof fetch });
+    await expect(client.execute(contract, { name: "item" })).rejects.toMatchObject({ status: 403 });
+  });
+
+  test("JSON receipts reject empty and malformed bodies without replay", async () => {
+    for (const response of [
+      new Response(null, { status: 204 }),
+      new Response("{broken", { headers: { "content-type": "application/json" } }),
+    ]) {
+      let calls = 0;
+      const client = new HttpClient({ fetch: (async () => { calls++; return response; }) as unknown as typeof fetch });
+      await expect(client.execute(contract, { name: "item" })).rejects.toMatchObject({ boundary: "response" });
+      expect(calls).toBe(1);
+    }
+  });
+});
+
+// Checked by typecheck:test; never executed at runtime.
+function contractTypes(client: HttpClient) {
+  const result: Promise<{ version: number }> = client.execute(contract, { name: "item" });
+  // @ts-expect-error Input must be inferred from the contract, not widened by the argument.
+  client.execute(contract, { name: 1 });
+  // @ts-expect-error Contract owns the request body.
+  client.execute(contract, { name: "item" }, { body: {} });
+  return result;
+}

--- a/packages/app/src/http_contract.ts
+++ b/packages/app/src/http_contract.ts
@@ -1,0 +1,33 @@
+export type ContractDecoder<T> = (value: unknown) => T;
+
+export interface HttpContract<Input, Result> {
+  input: ContractDecoder<Input>;
+  result: ContractDecoder<Result>;
+  request: (input: Input) => {
+    method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+    url: string;
+    body?: unknown;
+  };
+}
+
+export class HttpContractError extends Error {
+  readonly code = "HTTP_CONTRACT_INVALID";
+
+  constructor(readonly boundary: "request" | "response") {
+    // Decoder errors may contain submitted credentials or response data.
+    super(`HTTP ${boundary} contract invalid`);
+    this.name = "HttpContractError";
+  }
+}
+
+export function decodeHttpContract<T>(
+  decode: ContractDecoder<T>,
+  value: unknown,
+  boundary: "request" | "response",
+): T {
+  try {
+    return decode(value);
+  } catch {
+    throw new HttpContractError(boundary);
+  }
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -285,3 +285,5 @@ export type {
   PipeMetadata,
   PipeTransform,
 } from "./pipe";
+export { HttpContractError, decodeHttpContract } from "./http_contract";
+export type { ContractDecoder, HttpContract } from "./http_contract";

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -257,6 +257,24 @@ bun test
 bun run build
 ```
 
+## Route Contract Policy
+
+Enable `requireRouteContracts: true` in `defineSupacloudConfig(...)` or
+`CompileOptions` to report `route-contract-required` errors in both compile and
+check (including JSON diagnostics). Changing this option invalidates incremental
+results. Combine it with `writeOnError: false` when programmatic compilation must
+not emit files on errors.
+
+`inspectRouteContracts(graph)` lists each route and its missing body, params,
+query, and response declarations. Required inputs are detected from handler
+bindings and controller/route path parameters. Responses always require an
+explicit declaration, including intentional void contracts.
+
+This checks declaration coverage only, not schema quality, handler/schema type
+equivalence, or database authorization. It deliberately does not auto-fix missing
+schemas with `unknown` placeholders. Consumers must define the actual contracts
+and test decoding separately. The policy defaults to false for existing projects.
+
 ## License
 
 MIT

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -5,6 +5,7 @@ import { validateGraph } from "./validate";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { scanGeneratedArtifacts, scanProductionSource } from "./type-safety";
+import { validateRouteContracts } from "./route-contracts";
 
 /**
  * Complete compilation pipeline: AST analysis -> validation -> generate static factory code and manifest.
@@ -30,6 +31,7 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
     }
   }
   const typeSafety = resolveTypeSafety(options);
+  if (options.requireRouteContracts) diagnostics.push(...validateRouteContracts(graph));
   const rendered = renderApplication(graph, {
     rootDir: options.rootDir,
     outDir: options.outDir,
@@ -103,6 +105,7 @@ export async function checkProject(options: CompileOptions): Promise<CheckProjec
   }
 
   const typeSafety = resolveTypeSafety(options);
+  if (options.requireRouteContracts) diagnostics.push(...validateRouteContracts(graph));
   const rendered = renderApplication(graph, {
     rootDir: options.rootDir,
     outDir: options.outDir,

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -12,6 +12,7 @@ export interface SupaCloudConfig {
   outDir?: string;
   include?: string[];
   strict?: boolean;
+  requireRouteContracts?: boolean;
   generateClient?: boolean;
   generatePermissions?: boolean;
   moduleBoundaryPreset?: ModuleBoundaryPresetName;
@@ -30,6 +31,7 @@ export const DEFAULT_SUPACLOUD_CONFIG: Required<Omit<
   outDir: "generated",
   include: ["**/*.module.ts", "**/*.ts"],
   strict: true,
+  requireRouteContracts: false,
   generateClient: true,
   generatePermissions: true,
   treeShakeUnusedProviders: true,
@@ -52,6 +54,7 @@ export function resolveSupacloudConfig(
   outDir: string;
   include: string[];
   strict: boolean;
+  requireRouteContracts: boolean;
   generateClient: boolean;
   generatePermissions: boolean;
   moduleBoundaryPreset: ModuleBoundaryPresetName;
@@ -64,6 +67,7 @@ export function resolveSupacloudConfig(
     outDir: resolve(cwd, resolved.outDir ?? DEFAULT_SUPACLOUD_CONFIG.outDir),
     include: resolved.include ?? [...DEFAULT_SUPACLOUD_CONFIG.include],
     strict: resolved.strict ?? DEFAULT_SUPACLOUD_CONFIG.strict,
+    requireRouteContracts: resolved.requireRouteContracts ?? DEFAULT_SUPACLOUD_CONFIG.requireRouteContracts,
     generateClient: resolved.generateClient ?? DEFAULT_SUPACLOUD_CONFIG.generateClient,
     generatePermissions: resolved.generatePermissions ?? DEFAULT_SUPACLOUD_CONFIG.generatePermissions,
     moduleBoundaryPreset: resolved.moduleBoundaryPreset ?? DEFAULT_SUPACLOUD_CONFIG.moduleBoundaryPreset,
@@ -97,6 +101,7 @@ export function compileOptionsFromConfig(
     outDir: resolved.outDir,
     include: resolved.include,
     strict: resolved.strict,
+    requireRouteContracts: resolved.requireRouteContracts,
     generateClient: resolved.generateClient,
     generatePermissions: resolved.generatePermissions,
     moduleBoundaryPreset: resolved.moduleBoundaryPreset,

--- a/packages/compiler/src/incremental.ts
+++ b/packages/compiler/src/incremental.ts
@@ -159,6 +159,7 @@ function optionsKeyOf(options: CompileOptions): string {
     allowRouteCommandBindings: options.allowRouteCommandBindings,
     commandCapabilities: options.commandCapabilities,
     disallowControllerDirectDb: options.disallowControllerDirectDb,
+    requireRouteContracts: options.requireRouteContracts,
     detectOrphanModules: options.detectOrphanModules,
     generateClient: options.generateClient,
     generatePermissions: options.generatePermissions,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -78,3 +78,4 @@ export type {
   FeatureSpecNode,
   FeatureTransitionNode,
 } from "./types";
+export { inspectRouteContracts, validateRouteContracts } from "./route-contracts";

--- a/packages/compiler/src/route-contracts.test.ts
+++ b/packages/compiler/src/route-contracts.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { inspectRouteContracts, validateRouteContracts } from "./route-contracts";
+import type { ApplicationGraph } from "./types";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { compileProject, checkProject } from "./compile";
+import { compileOptionsFromConfig } from "./config";
+import { createIncrementalCompiler } from "./incremental";
+import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
+import { writeFixtureProject } from "./fixtures/helpers";
+
+const graph: ApplicationGraph = {
+  externalTokens: [],
+  modules: [{
+    name: "items", className: "ItemsModule", file: "items.ts", line: 1,
+    imports: [], providers: [], commands: [], queries: [], exports: [],
+    controllers: [{
+      className: "ItemsController", path: "/items/:id", scope: "request",
+      deps: [], file: "items.ts", importPath: "./items",
+      routes: [{
+        method: "POST", path: "", handler: "save",
+        handlerParams: [{ name: "dto", kind: "body" }, { name: "filter", kind: "query" }],
+      }],
+    }],
+  }],
+};
+
+test("lists missing declarations including inherited path and handler bindings", () => {
+  expect(inspectRouteContracts(graph)[0]?.missing).toEqual(["body", "params", "query", "response"]);
+  expect(validateRouteContracts(graph)[0]).toMatchObject({ severity: "error", code: "route-contract-required", file: "items.ts" });
+});
+
+test("declared contracts have no missing-schema diagnostic without claiming runtime coverage", () => {
+  const declared = structuredClone(graph);
+  Object.assign(declared.modules[0]!.controllers[0]!.routes[0]!, {
+    body: "Input", params: "Params", query: "Query", response: "Result",
+  });
+  expect(validateRouteContracts(declared)).toEqual([]);
+  expect(inspectRouteContracts(declared)[0]).not.toHaveProperty("runtimeValidated");
+});
+
+test("config policy reaches compile/check and invalidates a prior incremental result", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "supacloud-route-contracts-"));
+  try {
+    await writeFixtureProject(rootDir, {
+      ...GOOD_PROJECT_FILES,
+      "src/features/case/case.controller.ts": GOOD_PROJECT_FILES["src/features/case/case.controller.ts"]!
+        .replace("    response: AcceptResult,\n", ""),
+    });
+    const options = compileOptionsFromConfig({
+      root: ".", outDir: "generated", strict: false, requireRouteContracts: true,
+    }, rootDir);
+    const compiled = await compileProject({ ...options, writeOnError: false });
+    expect(compiled.diagnostics.some((item) => item.code === "route-contract-required")).toBe(true);
+    expect(compiled.written).toEqual([]);
+    const checked = await checkProject(options);
+    expect(checked.diagnostics.filter((item) => item.code === "route-contract-required"))
+      .toEqual(compiled.diagnostics.filter((item) => item.code === "route-contract-required"));
+    const incremental = createIncrementalCompiler();
+    await incremental.compile({ ...options, requireRouteContracts: false });
+    const strict = await incremental.compile(options, []);
+    expect(strict.stats.cacheHit).toBe(false);
+    expect(strict.diagnostics.some((item) => item.code === "route-contract-required")).toBe(true);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/compiler/src/route-contracts.ts
+++ b/packages/compiler/src/route-contracts.ts
@@ -1,0 +1,31 @@
+import type { ApplicationGraph, Diagnostic } from "./types";
+
+/** Declaration coverage only; runtime decoding and database behavior require separate tests. */
+export function inspectRouteContracts(graph: ApplicationGraph) {
+  return graph.modules.flatMap((module) => module.controllers.flatMap((controller) =>
+    controller.routes.map((route) => {
+      const missing: Array<"body" | "params" | "query" | "response"> = [];
+      if ((route.hasBodyBinding || route.handlerParams?.some((param) => param.kind === "body")) && !route.body) missing.push("body");
+      if ((route.pathParams?.length || route.paramBindings?.length
+        || route.handlerParams?.some((param) => param.kind === "param")
+        || /:[^/]+/.test(`${controller.path}/${route.path}`)) && !route.params) missing.push("params");
+      if ((route.queryBindings?.length || route.handlerParams?.some((param) => param.kind === "query")) && !route.query) missing.push("query");
+      if (!route.response) missing.push("response");
+      return {
+        module: module.name, controller: controller.className, handler: route.handler,
+        method: route.method, path: `${controller.path}${route.path}`, file: controller.file,
+        missing,
+      };
+    }),
+  ));
+}
+
+export function validateRouteContracts(graph: ApplicationGraph): Diagnostic[] {
+  return inspectRouteContracts(graph).filter((route) => route.missing.length).map((route) => ({
+    severity: "error",
+    code: "route-contract-required",
+    file: route.file,
+    message: `${route.controller}.${route.handler} (${route.method} ${route.path}) is missing contract declarations: ${route.missing.join(", ")}.`,
+    suggestion: "Declare the missing schemas and test actual request/response decoding. An opaque schema is not proof of validation.",
+  }));
+}

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -317,6 +317,8 @@ export interface ApplicationGraph {
 }
 
 export interface CompileOptions {
+  /** Require schemas for bound route inputs and responses. Does not prove runtime validation. */
+  requireRouteContracts?: boolean;
   /** Project root directory (containing tsconfig). */
   rootDir: string;
   /** Glob patterns, defaults to ['**\/*.module.ts', '**\/*.ts']. */


### PR DESCRIPTION
## Summary
- Add HttpClient.execute with decoder-inferred request/result types, sanitized boundary errors, strict JSON receipt parsing, and existing interceptor/header/signal support. No automatic replay.
- Add inspectRouteContracts and opt-in requireRouteContracts through config, compile, check, and incremental cache invalidation.
- Missing declarations produce route-contract-required diagnostics. This is declaration coverage, not schema quality, handler compatibility, or runtime authorization proof. No placeholder auto-fix.

## Local validation
- app: 135 tests passed; compiler: 155 tests passed.
- Both packages: typecheck, typecheck:test, build passed.
- git diff --check passed.
- No remote CI polling, merge, release, or deployment performed.

## Adoption
- Additive opt-in APIs; existing generic calls are not represented as migrated.
- Supports FA schema migration while business commands and database authorization stay in FA.