### PR TITLE
feat(db): target-bound migration bindings for Drizzle v1 deployment adapters

### DIFF
--- a/packages/db/MIGRATION_BINDINGS.md
+++ b/packages/db/MIGRATION_BINDINGS.md
@@ -1,0 +1,138 @@
+# Controlled Migration Bindings
+
+This is a deployment-time API for **public environment bindings**, not a general
+SQL template language or another migration engine. Use identical migrations for
+schema, indexes, business functions and state machines. Explicitly register only
+SQL that must bind to a target-specific application ID, HTTPS URL or resource
+name. One-off account transfers and production data cleanup remain separately
+reviewed operations.
+
+## Drizzle v1 Boundary
+
+Reviewed against the Drizzle v1 PostgreSQL documentation on 2026-09-08:
+official documentation repository commit
+`dae09afd99baa6362ece434cfa7bab60ef4b8692`.
+
+- [Upgrade to v1](https://orm.drizzle.team/docs/upgrade-v1):
+  v1 removes the journal file and groups SQL and snapshots in migration folders.
+  Do not run `drizzle-kit up` automatically on an application's existing history.
+- [Custom migrations](https://orm.drizzle.team/docs/kit-custom-migrations):
+  `drizzle-kit generate --custom` is the extension point for custom SQL.
+- [Migrate](https://orm.drizzle.team/docs/drizzle-kit-migrate):
+  migration execution reads applied history and supports separate configuration
+  files for different deployment targets.
+
+Those documents do not define this parameter-rendering API. This is a SupaCloud
+extension, not a claim that Drizzle automatically reconciles account changes.
+The renderer accepts `20260908100000_binding/migration.sql` as well as legacy
+flat SQL filenames. It neither discovers nor changes snapshots, migration
+identities, order, or metadata. Call it on a deployment copy, never write its
+output over generated source SQL. When SupaCloud is the executor, continue using
+its canonical applied-migration ledger; do not additionally execute
+`drizzle-kit migrate` against that same migration stream.
+
+## Usage
+
+Commit a manifest containing explicit target pairs and reviewed source hashes.
+`templateSha256` is the SHA-256 of the exact UTF-8 source, including whitespace.
+An author obtains and reviews it once when adding a template; do not recompute
+and accept a changed source hash automatically during deployment.
+
+```ts
+import { renderMigrationBindings } from '@supacloud/db';
+
+const result = renderMigrationBindings({
+  manifest: {
+    schema: 'supacloud.migration-bindings.v1',
+    targets: [
+      { environment: 'test', projectRef: 'test-project' },
+      { environment: 'production', projectRef: 'production-project' },
+    ],
+    templates: [{
+      file: '20260908100000_binding/migration.sql',
+      templateSha256: reviewedSourceSha256,
+      parameters: [{
+        placeholder: '__SC_BINDING_APPLICATION_ID__',
+        variable: 'APPLICATION_ID',
+        type: 'uuid',
+        occurrences: 1,
+      }],
+    }],
+  },
+  target: selectedTarget,
+  migrations: sourceFiles,
+  values: selectedEnvironment,
+});
+// Send result.migrations to the existing dry-run/apply pipeline.
+// Persist result.attestation in the existing release artifacts.
+```
+
+Example source:
+
+```sql
+SELECT '__SC_BINDING_APPLICATION_ID__'::uuid;
+```
+
+The caller must select and verify the environment before invoking this API.
+Values are explicitly passed; the API does not read `process.env`, env files,
+SSH configuration, or another target's fallback values. The target pair must
+match the manifest. The full set of declared template sources must be supplied.
+Plain SQL sources pass through byte-for-byte.
+
+Only complete single-quoted placeholder literals are supported, including
+literals in dollar-quoted PostgreSQL function bodies. `uuid`, `https-url`, and
+`resource-name` have restricted alphabets excluding quotes, dollar delimiters,
+backslashes and control characters. HTTPS URLs must not contain userinfo.
+Do not put credentials, tokens, secrets or arbitrary text in these bindings.
+Object identifiers, SQL fragments and arbitrary string interpolation are
+intentionally unsupported.
+
+`__SC_BINDING_*__` is reserved. Undeclared reserved tokens, stray declared
+legacy tokens, duplicate definitions, missing inputs, changed source bytes,
+wrong occurrence counts, unknown fields and unknown types fail closed.
+Legacy tokens such as `__FA_SUPAUTH_CLIENT_ID__` can be explicitly declared
+without editing historical SQL.
+
+## Evidence And Changes
+
+The attestation includes the target pair, manifest digest, source digest,
+rendered digest and parameter names/types. It excludes SQL and parameter values.
+The returned `migrations` contain SQL and must not be logged as an attestation.
+This is reproducibility evidence, not a signature or proof of the database's
+current state. Store it in an existing access-controlled release receipt or
+artifact, and separately read back the target's applied migration inventory.
+
+The renderer never marks a migration as applied and has no database access.
+Compare the rendered SQL with the existing executor's inventory. A changed
+environment value is **not** permission to rewrite an applied migration or its
+ledger row. Add a forward binding migration and retain the old release artifact;
+historical reconciliation must use target-specific reviewed evidence.
+
+The CLI does not automatically enable this API. An application deployment
+adapter must supply the selected sources and target, then use its existing
+executor. In particular, this API does not add recursive Drizzle-folder discovery
+to the CLI's legacy flat-directory `push_migrations` command.
+
+## Acceptance
+
+```gherkin
+Scenario: Same template, separate targets
+  Given a reviewed template and explicit test and production project bindings
+  When each target provides its own valid parameters
+  Then source digests match and rendered digests differ without changing source files
+
+Scenario: Missing or unsafe parameter
+  Given a missing value, injected SQL fragment or secret-bearing URL
+  When rendering begins
+  Then it fails without echoing the supplied value or requesting any database mutation
+
+Scenario: Undeclared or changed SQL
+  Given a changed template, unexpected token or unregistered target
+  When rendering begins
+  Then deployment preparation fails before SQL is returned
+
+Scenario: Applied parameter changes
+  Given an already-applied binding migration and a changed parameter
+  When rendering again
+  Then a different digest is produced, not an automatic replay or ledger repair
+```

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,5 +1,9 @@
 # @supacloud/db
 
+For reviewed deployment-time public SQL parameters, see
+[Controlled Migration Bindings](./MIGRATION_BINDINGS.md). This opt-in API preserves
+Drizzle v1 source/snapshot ownership and the existing executor's migration ledger.
+
 SupaCloud 的数据库治理层：把 RLS 策略、RPC 函数、触发器、授权（grant）作为**一等资源**做声明式管理，并与 PostgreSQL 真实 Catalog 对账。
 
 定位：它是 Drizzle（schema/迁移）之上的治理层 —— Drizzle 负责表结构，本包负责表结构之外的安全与业务对象（策略、函数、权限）的声明、静态检查与漂移检测。**driver 无关**：所有 Catalog 读取都通过注入的 `QueryExecutor` 完成，不依赖任何数据库客户端，也不 import drizzle-orm（仅类型层兼容 drizzle Table 的内部形状）。

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "MIGRATION_BINDINGS.md"
   ],
   "scripts": {
     "build": "bun run clean && bun run build:js && bun run build:types",

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37,6 +37,18 @@ export { planModule, type ModulePlan, type PlanStep } from './plan.js';
 export { applyModulePlan, type ApplyResult } from './apply.js';
 
 export {
+  migrationBindingSha256,
+  parseMigrationBindingManifest,
+  renderMigrationBindings,
+  type MigrationBindingManifest,
+  type MigrationBindingParameter,
+  type MigrationBindingSource,
+  type MigrationBindingTarget,
+  type MigrationBindingTemplate,
+  type MigrationBindingType,
+} from './migration-bindings.js';
+
+export {
   buildDatabaseManifest,
   explainObject,
   type DatabaseManifest,

--- a/packages/db/src/migration-bindings.test.ts
+++ b/packages/db/src/migration-bindings.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import { migrationBindingSha256, parseMigrationBindingManifest, renderMigrationBindings } from './migration-bindings.js';
+
+const sql = "SELECT '__SC_BINDING_APP_ID__'::uuid;";
+const file = '20260908100000_binding/migration.sql';
+const testId = '11111111-1111-4111-8111-111111111111';
+const productionId = '22222222-2222-4222-8222-222222222222';
+function input(type = 'uuid', value = testId) {
+  return {
+    manifest: {
+      schema: 'supacloud.migration-bindings.v1',
+      targets: [{ environment: 'test', projectRef: 'test-project' }, { environment: 'production', projectRef: 'prod-project' }],
+      templates: [{
+        file, templateSha256: migrationBindingSha256(sql),
+        parameters: [{ placeholder: '__SC_BINDING_APP_ID__', variable: 'APP_ID', type, occurrences: 1 }],
+      }],
+    },
+    target: { environment: 'test', projectRef: 'test-project' },
+    migrations: [{ file, sql }],
+    values: { APP_ID: value },
+  };
+}
+
+describe('controlled migration bindings', () => {
+  test('supports Drizzle v1 migration.sql paths without rewriting sources or snapshots', () => {
+    const options = input();
+    const before = JSON.stringify(options);
+    const result = renderMigrationBindings(options);
+    expect(result.migrations).toEqual([{ file, sql: `SELECT '${testId}'::uuid;` }]);
+    expect(JSON.stringify(options)).toBe(before);
+    expect(result.attestation.files[0]!.templateSha256).toBe(migrationBindingSha256(sql));
+    expect(result.attestation.files[0]!.renderedSqlSha256).toBe(migrationBindingSha256(result.migrations[0]!.sql));
+    expect(JSON.stringify(result.attestation)).not.toContain(testId);
+    expect(JSON.stringify(result.attestation)).not.toContain('SELECT');
+  });
+
+  test('same source renders differently only for explicitly selected targets', () => {
+    const dev = renderMigrationBindings(input());
+    const prod = renderMigrationBindings({ ...input('uuid', productionId), target: { environment: 'production', projectRef: 'prod-project' } });
+    expect(dev.attestation.files[0]!.templateSha256).toBe(prod.attestation.files[0]!.templateSha256);
+    expect(dev.attestation.files[0]!.renderedSqlSha256).not.toBe(prod.attestation.files[0]!.renderedSqlSha256);
+    expect(() => renderMigrationBindings({ ...input(), target: { environment: 'test', projectRef: 'prod-project' } })).toThrow('target');
+  });
+
+  test.each([
+    ['uuid', "x'; DROP TABLE users;--"],
+    ['uuid', '00000000-0000-0000-0000-000000000000'],
+    ['resource-name', '$body$'],
+    ['resource-name', 'a\\b'],
+    ['resource-name', '__SC_BINDING_OTHER__'],
+    ['https-url', 'http://example.com'],
+    ['https-url', 'https://user:password@example.com'],
+    ['https-url', "https://example.com/a'b"],
+    ['https-url', 'https://example.com/$$'],
+  ])('rejects unsafe %s values without echoing them', (type, value) => {
+    try {
+      renderMigrationBindings(input(type, value));
+      throw new Error('accepted unsafe value');
+    } catch (error) {
+      expect(String(error)).toContain('migration binding');
+      expect(String(error)).not.toContain(value);
+    }
+  });
+
+  test.each([['resource-name', 'reports/archive'], ['https-url', 'https://static.example.com/fonts/font.woff2']])('accepts public %s bindings', (type, value) => {
+    expect(renderMigrationBindings(input(type, value)).migrations[0]!.sql).toContain(value);
+  });
+
+  test('does not use ambient environment values or inherited object properties', () => {
+    expect(() => renderMigrationBindings({ ...input(), values: {} })).toThrow('Missing');
+    expect(() => renderMigrationBindings({ ...input(), values: Object.create({ APP_ID: testId }) })).toThrow('Missing');
+  });
+
+  test('pins source bytes, placeholder count and literal placement', () => {
+    expect(() => renderMigrationBindings({ ...input(), migrations: [{ file, sql: `${sql}\n` }] })).toThrow('checksum');
+    const options = input();
+    options.manifest.templates[0]!.parameters[0]!.occurrences = 2;
+    expect(() => renderMigrationBindings(options)).toThrow('occurrence');
+    const unsafe = input();
+    unsafe.migrations[0]!.sql = 'SELECT __SC_BINDING_APP_ID__;';
+    unsafe.manifest.templates[0]!.templateSha256 = migrationBindingSha256(unsafe.migrations[0]!.sql);
+    expect(() => renderMigrationBindings(unsafe)).toThrow('complete SQL string literal');
+  });
+
+  test('plain migrations are unchanged and undeclared reserved placeholders fail', () => {
+    const options = input();
+    options.migrations.push({ file: '20260908000000_schema.sql', sql: 'CREATE TABLE sample(id int);' });
+    expect(renderMigrationBindings(options).migrations[1]).toEqual(options.migrations[1]);
+    options.migrations[1]!.sql = "SELECT '__SC_BINDING_UNKNOWN__';";
+    expect(() => renderMigrationBindings(options)).toThrow('Undeclared');
+  });
+
+  test('rejects stale, duplicate, traversal, unknown-type and wildcard manifests', () => {
+    const missing = input();
+    missing.migrations = [];
+    expect(() => renderMigrationBindings(missing)).toThrow('missing source');
+    const duplicate = input();
+    duplicate.manifest.templates.push(duplicate.manifest.templates[0]!);
+    expect(() => renderMigrationBindings(duplicate)).toThrow('duplicate');
+    const traversal = input();
+    traversal.manifest.templates[0]!.file = '../escape.sql';
+    expect(() => parseMigrationBindingManifest(traversal.manifest)).toThrow();
+    expect(() => renderMigrationBindings(input('raw-sql'))).toThrow();
+    const wildcard = input();
+    wildcard.manifest.targets[0]!.projectRef = '*';
+    expect(() => renderMigrationBindings(wildcard)).toThrow();
+    expect(() => parseMigrationBindingManifest({ ...input().manifest, allowMissing: true })).toThrow('Unexpected');
+  });
+
+  test('supports restricted literals in dollar-quoted SQL function bodies and legacy tokens', () => {
+    const options = input();
+    options.migrations[0]!.sql = "DO $body$ BEGIN PERFORM '__FA_CLIENT_ID__'::uuid; END $body$;";
+    options.manifest.templates[0]!.templateSha256 = migrationBindingSha256(options.migrations[0]!.sql);
+    options.manifest.templates[0]!.parameters[0]!.placeholder = '__FA_CLIENT_ID__';
+    expect(renderMigrationBindings(options).migrations[0]!.sql).toContain(`'${testId}'`);
+  });
+});

--- a/packages/db/src/migration-bindings.ts
+++ b/packages/db/src/migration-bindings.ts
@@ -1,0 +1,206 @@
+import { createHash } from 'node:crypto';
+
+export type MigrationBindingType = 'uuid' | 'https-url' | 'resource-name';
+
+export interface MigrationBindingTarget {
+  environment: string;
+  projectRef: string;
+}
+
+export interface MigrationBindingParameter {
+  placeholder: string;
+  variable: string;
+  type: MigrationBindingType;
+  occurrences: number;
+}
+
+export interface MigrationBindingTemplate {
+  file: string;
+  templateSha256: string;
+  parameters: MigrationBindingParameter[];
+}
+
+export interface MigrationBindingManifest {
+  schema: 'supacloud.migration-bindings.v1';
+  targets: MigrationBindingTarget[];
+  templates: MigrationBindingTemplate[];
+}
+
+export interface MigrationBindingSource {
+  file: string;
+  sql: string;
+}
+
+const TOKEN = /__[A-Z][A-Z0-9_]*__/g;
+const RESERVED_TOKEN = /__SC_BINDING_[A-Z0-9_]+__/;
+const HASH = /^[a-f0-9]{64}$/;
+
+export function migrationBindingSha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid migration binding object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function keys(row: Record<string, unknown>, expected: string[]): void {
+  if (Object.keys(row).sort().join(',') !== expected.sort().join(',')) {
+    throw new Error('Unexpected migration binding fields');
+  }
+}
+
+function validTarget(value: unknown): MigrationBindingTarget {
+  const target = record(value);
+  keys(target, ['environment', 'projectRef']);
+  if (typeof target.environment !== 'string' || !/^[a-z][a-z0-9-]{0,62}$/.test(target.environment)
+    || typeof target.projectRef !== 'string' || !/^[a-z0-9][a-z0-9_-]{0,62}$/.test(target.projectRef)) {
+    throw new Error('Invalid migration binding target');
+  }
+  return target as unknown as MigrationBindingTarget;
+}
+
+function validFile(file: unknown): file is string {
+  return typeof file === 'string' && /^[a-zA-Z0-9_./-]+\.sql$/.test(file)
+    && !file.startsWith('/') && file.split('/').every((part) => part && part !== '.' && part !== '..');
+}
+
+export function parseMigrationBindingManifest(value: unknown): MigrationBindingManifest {
+  const manifest = record(value);
+  keys(manifest, ['schema', 'targets', 'templates']);
+  if (manifest.schema !== 'supacloud.migration-bindings.v1'
+    || !Array.isArray(manifest.targets) || !manifest.targets.length || !Array.isArray(manifest.templates)) {
+    throw new Error('Invalid migration binding manifest');
+  }
+  const targets = manifest.targets.map(validTarget);
+  if (new Set(targets.map((target) => target.environment)).size !== targets.length) {
+    throw new Error('Duplicate migration binding environment');
+  }
+  const files = new Set<string>();
+  const templates = manifest.templates.map((value) => {
+    const template = record(value);
+    keys(template, ['file', 'templateSha256', 'parameters']);
+    if (!validFile(template.file) || files.has(template.file)
+      || typeof template.templateSha256 !== 'string' || !HASH.test(template.templateSha256)
+      || !Array.isArray(template.parameters) || !template.parameters.length) {
+      throw new Error('Invalid or duplicate migration binding template');
+    }
+    files.add(template.file);
+    const placeholders = new Set<string>();
+    const parameters = template.parameters.map((value) => {
+      const parameter = record(value);
+      keys(parameter, ['placeholder', 'variable', 'type', 'occurrences']);
+      if (typeof parameter.placeholder !== 'string' || !/^__[A-Z][A-Z0-9_]*__$/.test(parameter.placeholder)
+        || placeholders.has(parameter.placeholder) || typeof parameter.variable !== 'string'
+        || !/^[A-Z][A-Z0-9_]*$/.test(parameter.variable)
+        || !['uuid', 'https-url', 'resource-name'].includes(String(parameter.type))
+        || !Number.isSafeInteger(parameter.occurrences) || Number(parameter.occurrences) < 1) {
+        throw new Error('Invalid or duplicate migration binding parameter');
+      }
+      placeholders.add(parameter.placeholder);
+      return parameter as unknown as MigrationBindingParameter;
+    });
+    return { file: template.file, templateSha256: template.templateSha256, parameters };
+  });
+  return { schema: 'supacloud.migration-bindings.v1', targets, templates };
+}
+
+function bindingValue(parameter: MigrationBindingParameter, values: Readonly<Record<string, string | undefined>>): string {
+  const value = Object.hasOwn(values, parameter.variable) ? values[parameter.variable] : undefined;
+  if (typeof value !== 'string' || !value || value.trim() !== value) {
+    throw new Error(`Missing or invalid migration binding variable: ${parameter.variable}`);
+  }
+  let valid = false;
+  if (parameter.type === 'uuid') {
+    valid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+  } else if (parameter.type === 'resource-name') {
+    valid = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$/.test(value);
+  } else if (/^https:\/\/[A-Za-z0-9._~:/?#[\]@!&()*+,;=%-]+$/.test(value)) {
+    try {
+      const url = new URL(value);
+      valid = url.protocol === 'https:' && Boolean(url.hostname) && !url.username && !url.password;
+    } catch { /* Invalid URL; never echo the value. */ }
+  }
+  // Only public, restricted-alphabet values are supported. No quotes, dollar
+  // delimiters, backslashes, raw SQL, secrets, or arbitrary text interpolation.
+  if (!valid || value.includes('__')) throw new Error(`Invalid ${parameter.type} migration binding: ${parameter.variable}`);
+  return value;
+}
+
+/**
+ * Pure rendering of explicitly declared SQL literals. The caller supplies an
+ * already-selected environment; this module never reads files or process.env.
+ */
+export function renderMigrationBindings(options: {
+  manifest: unknown;
+  target: MigrationBindingTarget;
+  migrations: readonly MigrationBindingSource[];
+  values: Readonly<Record<string, string | undefined>>;
+}) {
+  const manifest = parseMigrationBindingManifest(options.manifest);
+  const target = validTarget(options.target);
+  if (!manifest.targets.some((candidate) => candidate.environment === target.environment && candidate.projectRef === target.projectRef)) {
+    throw new Error('Migration binding target is not registered in the manifest');
+  }
+  const sources = new Map<string, MigrationBindingSource>();
+  for (const migration of options.migrations) {
+    if (!validFile(migration.file) || sources.has(migration.file) || typeof migration.sql !== 'string' || !migration.sql.trim()) {
+      throw new Error('Invalid, empty, or duplicate migration binding source');
+    }
+    sources.set(migration.file, migration);
+  }
+  if (manifest.templates.some((template) => !sources.has(template.file))) {
+    throw new Error('Migration binding manifest references a missing source');
+  }
+  const templates = new Map(manifest.templates.map((template) => [template.file, template]));
+  const declaredTokens = new Set(manifest.templates.flatMap((template) => template.parameters.map((parameter) => parameter.placeholder)));
+  const files: Array<{
+    file: string; templateSha256: string; renderedSqlSha256: string;
+    parameters: Array<{ variable: string; type: MigrationBindingType }>;
+  }> = [];
+  const migrations = options.migrations.map((migration) => {
+    const template = templates.get(migration.file);
+    const templateSha256 = migrationBindingSha256(migration.sql);
+    if (template && templateSha256 !== template.templateSha256) {
+      throw new Error(`Migration binding template checksum mismatch: ${migration.file}`);
+    }
+    const parameters = new Map(template?.parameters.map((parameter) => [parameter.placeholder, parameter]));
+    const counts = new Map<string, number>();
+    // One pass: replacement values cannot introduce a second interpolation.
+    const sql = migration.sql.replace(TOKEN, (token, offset: number) => {
+      const parameter = parameters.get(token);
+      if (!parameter) {
+        if (RESERVED_TOKEN.test(token) || declaredTokens.has(token)) {
+          throw new Error(`Undeclared migration binding placeholder: ${migration.file}`);
+        }
+        return token;
+      }
+      if (migration.sql[offset - 1] !== "'" || migration.sql[offset + token.length] !== "'") {
+        throw new Error(`Migration bindings must occupy a complete SQL string literal: ${migration.file}`);
+      }
+      counts.set(token, (counts.get(token) || 0) + 1);
+      return bindingValue(parameter, options.values);
+    });
+    for (const parameter of parameters.values()) {
+      if (counts.get(parameter.placeholder) !== parameter.occurrences) {
+        throw new Error(`Migration binding occurrence mismatch: ${migration.file}`);
+      }
+    }
+    files.push({
+      file: migration.file, templateSha256, renderedSqlSha256: migrationBindingSha256(sql),
+      parameters: [...parameters.values()].map(({ variable, type }) => ({ variable, type })),
+    });
+    return { file: migration.file, sql };
+  });
+  return {
+    migrations,
+    attestation: {
+      schema: 'supacloud.migration-binding-attestation.v1' as const,
+      ...target,
+      manifestSha256: migrationBindingSha256(JSON.stringify(manifest)),
+      files: files.sort((left, right) => left.file.localeCompare(right.file)),
+    },
+  };
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["bun"],
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true


### PR DESCRIPTION
## Summary

- Add `@supacloud/db`'s opt-in `renderMigrationBindings` API and strict versioned manifest parser.
- Bind public UUID, HTTPS URL and resource-name parameters to explicit environment/project pairs, exact template SHA-256 and placeholder counts.
- Return rendered SQL separately from a value-free attestation containing target, manifest, template and rendered digests.
- Preserve Drizzle v1 source/snapshot ownership and the existing executor's applied-migration ledger. Accept v1 `directory/migration.sql` paths and legacy flat filenames without changing either.

## Safety And Scope

- No database connection, remote mutation, ambient env loading, cross-environment fallback, migration replay or ledger modification.
- Reject undeclared reserved placeholders, changed source bytes, missing sources/parameters, wildcard targets, duplicate definitions, unsupported types and unsafe values without echoing the values.
- No arbitrary text, identifiers, SQL fragments, credentials or secret-bearing URLs.
- Parameter changes produce changed SQL/digests; callers must use forward migrations and target-specific historical evidence rather than overwriting applied history.
- This PR exposes a deployment-adapter API, not automatic CLI activation or recursive folder discovery. No second ledger or automatic Drizzle directory upgrade is introduced.

## Drizzle v1 Reference

Reviewed the official PostgreSQL v1 upgrade, custom migrations and migrate documentation at `drizzle-team/drizzle-orm-docs@dae09afd99baa6362ece434cfa7bab60ef4b8692`. Implementation boundaries, usage and Gherkin scenarios are in `packages/db/MIGRATION_BINDINGS.md`.

## Validation

- `bun test` in `packages/db`: 98 passed.
- `bun run typecheck:test`: passed.
- `bun run build`: passed, including declaration generation.
- `git diff --check`: passed.

No remote CI polling or production deployment was performed.
