### PR TITLE
fix(management-api): keep request latency histogram cumulative

### DIFF
--- a/packages/management-api/src/utils/observability.ts
+++ b/packages/management-api/src/utils/observability.ts
@@ -4,6 +4,7 @@ const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
 const SLOW_REQUEST_MS = 1000;
 const latencyBuckets = [10, 50, 100, 250, 500, 1000, 5000];
+const durationMetric = "supacloud_management_http_request_duration_ms";
 
 export interface RequestObservabilityContext {
   requestId: string;
@@ -15,7 +16,8 @@ export interface RequestObservabilityContext {
 interface RequestMetricState {
   requests: number;
   errors: number;
-  durations: number[];
+  durationBuckets: number[];
+  durationSum: number;
   status: Map<number, number>;
 }
 
@@ -23,7 +25,8 @@ const requestContexts = new WeakMap<Request, RequestObservabilityContext>();
 const metricState: RequestMetricState = {
   requests: 0,
   errors: 0,
-  durations: [],
+  durationBuckets: latencyBuckets.map(() => 0),
+  durationSum: 0,
   status: new Map(),
 };
 
@@ -77,8 +80,10 @@ export function recordRequestObservation(
   metricState.requests += 1;
   if (status >= 500) metricState.errors += 1;
   metricState.status.set(status, (metricState.status.get(status) ?? 0) + 1);
-  metricState.durations.push(durationMs);
-  if (metricState.durations.length > 10_000) metricState.durations.shift();
+  metricState.durationSum += durationMs;
+  for (const [index, bucket] of latencyBuckets.entries()) {
+    if (durationMs <= bucket) metricState.durationBuckets[index]! += 1;
+  }
   return { context, durationMs, slow: durationMs >= SLOW_REQUEST_MS };
 }
 
@@ -94,14 +99,19 @@ export function renderRequestMetrics(): string {
   for (const [status, count] of metricState.status) {
     lines.push(`supacloud_management_http_responses_total{status="${status}"} ${count}`);
   }
-  for (const bucket of latencyBuckets) {
+  lines.push(
+    `# HELP ${durationMetric} Management API request duration in milliseconds.`,
+    `# TYPE ${durationMetric} histogram`,
+  );
+  for (const [index, bucket] of latencyBuckets.entries()) {
     lines.push(
-      `supacloud_management_http_request_duration_ms_bucket{le="${bucket}"} `
-      + `${metricState.durations.filter((duration) => duration <= bucket).length}`,
+      `${durationMetric}_bucket{le="${bucket}"} ${metricState.durationBuckets[index]}`,
     );
   }
   lines.push(
-    `supacloud_management_http_request_duration_ms_bucket{le="+Inf"} ${metricState.durations.length}`,
+    `${durationMetric}_bucket{le="+Inf"} ${metricState.requests}`,
+    `${durationMetric}_sum ${metricState.durationSum}`,
+    `${durationMetric}_count ${metricState.requests}`,
   );
   return `${lines.join("\n")}\n`;
 }
@@ -109,6 +119,7 @@ export function renderRequestMetrics(): string {
 export function resetRequestMetricsForTests(): void {
   metricState.requests = 0;
   metricState.errors = 0;
-  metricState.durations = [];
+  metricState.durationBuckets.fill(0);
+  metricState.durationSum = 0;
   metricState.status.clear();
 }

--- a/packages/management-api/tests/unit/observability.test.ts
+++ b/packages/management-api/tests/unit/observability.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import {
   applyObservabilityHeaders,
   beginRequestObservability,
@@ -8,8 +8,24 @@ import {
 } from "../../src/utils/observability";
 
 afterEach(() => {
+  mock.restore();
   resetRequestMetricsForTests();
 });
+
+const durationMetric = "supacloud_management_http_request_duration_ms";
+const bucketLimits = [10, 50, 100, 250, 500, 1000, 5000];
+
+function metricValue(metrics: string, name: string): number {
+  const line = metrics.split("\n").find((line) => line.startsWith(`${name} `));
+  if (!line) throw new Error(`Missing metric: ${name}`);
+  return Number(line.slice(name.length + 1));
+}
+
+function observeDuration(durationMs: number, status = 200): void {
+  const request = new Request("http://localhost/health");
+  beginRequestObservability(request).startedAt = performance.now() - durationMs;
+  recordRequestObservation(request, status);
+}
 
 describe("request observability", () => {
   test("preserves a valid inbound request and trace identity", () => {
@@ -51,5 +67,79 @@ describe("request observability", () => {
     expect(metrics).toContain("supacloud_management_http_requests_total 1");
     expect(metrics).toContain("supacloud_management_http_errors_total 1");
     expect(metrics).toContain('supacloud_management_http_responses_total{status="503"} 1');
+  });
+
+  test("exposes a complete empty histogram before the first observation", () => {
+    const metrics = renderRequestMetrics();
+
+    expect(metrics).toContain(`# HELP ${durationMetric} Management API request duration in milliseconds.`);
+    expect(metrics).toContain(`# TYPE ${durationMetric} histogram`);
+    for (const bucket of [...bucketLimits, "+Inf"]) {
+      expect(metricValue(metrics, `${durationMetric}_bucket{le="${bucket}"}`)).toBe(0);
+    }
+    expect(metricValue(metrics, `${durationMetric}_sum`)).toBe(0);
+    expect(metricValue(metrics, `${durationMetric}_count`)).toBe(0);
+  });
+
+  test("records inclusive cumulative buckets, sum and count for all responses", () => {
+    spyOn(performance, "now").mockReturnValue(100_000);
+    const durations = [0, 0.5, ...bucketLimits, 5000.5, 10_000];
+    for (const [index, duration] of durations.entries()) {
+      observeDuration(duration, index === durations.length - 1 ? 503 : 200);
+    }
+
+    const metrics = renderRequestMetrics();
+    for (const bucket of bucketLimits) {
+      expect(metricValue(metrics, `${durationMetric}_bucket{le="${bucket}"}`))
+        .toBe(durations.filter((duration) => duration <= bucket).length);
+    }
+    expect(metricValue(metrics, `${durationMetric}_bucket{le="+Inf"}`)).toBe(durations.length);
+    expect(metricValue(metrics, `${durationMetric}_count`)).toBe(durations.length);
+    expect(metricValue(metrics, `${durationMetric}_sum`))
+      .toBe(durations.reduce((sum, duration) => sum + duration, 0));
+    expect(metricValue(metrics, "supacloud_management_http_requests_total")).toBe(durations.length);
+    expect(metricValue(metrics, "supacloud_management_http_errors_total")).toBe(1);
+    expect(metricValue(metrics, 'supacloud_management_http_responses_total{status="200"}'))
+      .toBe(durations.length - 1);
+    expect(metricValue(metrics, 'supacloud_management_http_responses_total{status="503"}')).toBe(1);
+    expect(renderRequestMetrics()).toBe(metrics);
+  });
+
+  test("never evicts histogram observations after ten thousand requests", () => {
+    spyOn(performance, "now").mockReturnValue(100_000);
+    for (let index = 0; index < 10_000; index++) observeDuration(1);
+    const before = renderRequestMetrics();
+
+    observeDuration(10_000, 503);
+    const after = renderRequestMetrics();
+
+    for (const bucket of bucketLimits) {
+      const name = `${durationMetric}_bucket{le="${bucket}"}`;
+      expect(metricValue(before, name)).toBe(10_000);
+      expect(metricValue(after, name)).toBe(10_000);
+    }
+    expect(metricValue(after, `${durationMetric}_bucket{le="+Inf"}`)).toBe(10_001);
+    expect(metricValue(after, `${durationMetric}_count`)).toBe(10_001);
+    expect(metricValue(after, `${durationMetric}_sum`)).toBe(20_000);
+    expect(metricValue(after, "supacloud_management_http_requests_total")).toBe(10_001);
+  });
+
+  test("reset clears every accumulator and subsequent observations start from zero", () => {
+    spyOn(performance, "now").mockReturnValue(100_000);
+    const emptyMetrics = renderRequestMetrics();
+    observeDuration(5000, 503);
+
+    resetRequestMetricsForTests();
+
+    expect(renderRequestMetrics()).toBe(emptyMetrics);
+    observeDuration(5);
+    const metrics = renderRequestMetrics();
+    for (const bucket of [...bucketLimits, "+Inf"]) {
+      expect(metricValue(metrics, `${durationMetric}_bucket{le="${bucket}"}`)).toBe(1);
+    }
+    expect(metricValue(metrics, `${durationMetric}_sum`)).toBe(5);
+    expect(metricValue(metrics, `${durationMetric}_count`)).toBe(1);
+    expect(metricValue(metrics, "supacloud_management_http_errors_total")).toBe(0);
+    expect(metrics).not.toContain('status="503"');
   });
 });


### PR DESCRIPTION
## Summary
- Replace the last-10,000-request latency sample window with fixed-size cumulative bucket counters and a duration sum.
- Preserve the existing metric name, millisecond unit and bucket limits; add histogram HELP/TYPE, `_sum` and `_count`, with `+Inf` equal to the total observation count.
- Keep identity handling, response status counters and request lifecycle hooks unchanged. No dependency, schema or deployment changes.

## Reproduction
After 10,000 requests of 1 ms, recording one 10,000 ms request previously reduced the finite bucket count from 10,000 to 9,999 while the request total increased to 10,001. The new regression fails on the original implementation and passes after the fix.

## Validation
- Before the implementation: focused suite had 2 pass / 4 fail, including the 10,001-request reproduction and missing histogram fields.
- `bun --no-env-file test packages/management-api/tests/unit/observability.test.ts packages/management-api/tests/unit/observability-install.test.ts`: 9 pass / 0 fail, 101 assertions.
- Covers empty output, inclusive bucket boundaries, fractional and overflow durations, mixed HTTP statuses, stable repeated scrapes, cumulative count beyond 10,000 requests, and reset behavior.
- `git diff --check`: passed.

## Scope and Rollback
This is the cumulative-histogram fix from the enterprise-readiness assessment, not a claim that end-to-end tracing, SLO alerting or production readiness is complete. Only the metrics utility and its tests change. Rollback is a normal code revert. No production probes, deployment, merge or remote-CI polling were performed.