### PR TITLE
feat(elysia): add validated native JSON responses

### DIFF
--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -91,8 +91,9 @@ write retry. Confirm the outcome using the application's durable receipt or
 read-back protocol. A custom `errorMapper` can override this public envelope.
 
 Native `Response` objects are passed through by Elysia, including JSON responses.
-Handlers returning a native `Response` must validate their JSON payload before
-constructing it. The adapter does not consume or parse binary/streaming responses.
+Use `validatedJsonResponse` to opt into validation when constructing a native
+JSON response. Otherwise handlers must validate their JSON payload themselves.
+The adapter does not consume or parse binary/streaming responses.
 
 Jobs are executed explicitly with `executeJob(compiledModule, services, job,
 input, requestContext)`. The asynchronous compiler-generated job scope is
@@ -100,6 +101,39 @@ destroyed after execution, including when the job throws or scope construction
 fails partway through.
 
 ## API
+
+### `validatedJsonResponse(validate, value, init?): Response`
+
+Constructs a native JSON response after a synchronous, caller-owned type guard
+validates the actual serialized JSON snapshot. The value type is inferred from
+the guard; compatible extra fields are preserved. For a TypeBox contract, the
+guard can delegate to `Value.Check(schema, value)` or a compiled validator.
+No additional schema dependency is required by the adapter.
+
+```ts
+import { validatedJsonResponse } from "@supacloud/elysia";
+import { isReportReceipt } from "./contracts";
+
+return validatedJsonResponse(isReportReceipt, receipt, {
+  status: 201,
+  headers: { "x-request-id": requestId },
+});
+```
+
+The helper serializes once, validates that wire snapshot, and sends those same
+bytes. Validation cannot mutate the outgoing body; it is not a transform or
+coercion hook. Guards must be synchronous and side-effect free. Serialization
+failures and invalid receipts throw a sanitized `ApplicationError` with HTTP 500
+and `RESPONSE_VALIDATION_ERROR`, without retaining payloads or validator causes.
+The application's `errorMapper` can map this to its outcome-confirmation
+protocol. The helper never retries a command or implies rollback.
+
+`init` uses native `Response` options. The helper explicitly rejects null-body
+statuses 204, 205 and 304, including on runtimes that otherwise accept a body
+with those statuses. The default content type is
+`application/json`, and explicitly supplied headers are preserved. This helper
+is for bounded JSON payloads, not files or streams. Existing native `Response`
+passthrough is unchanged.
 
 ### `createApplication(options: ApplicationOptions): Elysia`
 

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -253,6 +253,40 @@ export class ApplicationError extends Error implements PublicApplicationError {
   }
 }
 
+export type JsonResponseValidator<T> = (value: unknown) => value is T;
+
+/**
+ * Validate the serialized JSON snapshot before creating a native Response.
+ * Validators must be synchronous and side-effect free; response failures do not
+ * imply that application writes were rolled back.
+ */
+export function validatedJsonResponse<T>(
+  validate: JsonResponseValidator<T>,
+  value: NoInfer<T>,
+  init?: ResponseInit,
+): Response {
+  if (init?.status === 204 || init?.status === 205 || init?.status === 304) {
+    throw new TypeError("JSON responses cannot use a null-body status");
+  }
+  let body: string;
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined || validate(JSON.parse(serialized)) !== true) {
+      throw new Error("Invalid JSON response");
+    }
+    body = serialized;
+  } catch {
+    throw new ApplicationError("Response validation failed", {
+      status: 500,
+      code: "RESPONSE_VALIDATION_ERROR",
+    });
+  }
+
+  const headers = new Headers(init?.headers);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  return new Response(body, { ...init, headers });
+}
+
 export interface ErrorContext {
   request: Request;
   requestContext: unknown;

--- a/packages/elysia/src/json-response.test.ts
+++ b/packages/elysia/src/json-response.test.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "bun:test";
+import Elysia, { t } from "elysia";
+import {
+  ApplicationError,
+  createApplication,
+  createModulePlugin,
+  validatedJsonResponse,
+  type CompiledModule,
+} from "./index";
+
+interface Receipt {
+  id: string;
+}
+
+function isReceipt(value: unknown): value is Receipt {
+  return typeof value === "object" && value !== null
+    && "id" in value && typeof value.id === "string";
+}
+
+function receiptModule(write: () => unknown): CompiledModule {
+  return {
+    name: "receipt",
+    createServices: () => ({ controller: { write } }),
+    controllers: [{
+      path: "/receipt",
+      serviceKey: "controller",
+      scope: "application",
+      routes: [{
+        method: "POST",
+        path: "",
+        handler: "write",
+        response: t.Object({ id: t.String() }),
+        command: "WriteCommand",
+      }],
+    }],
+    commands: [{ className: "WriteCommand", name: "receipt.write" }],
+  };
+}
+
+test("validated JSON preserves payload, status and headers without mutating options", async () => {
+  const payload = { id: "receipt-1", compatibleField: "preserved" };
+  const headers = new Headers({ "x-receipt": "receipt-1" });
+  const response = validatedJsonResponse(isReceipt, payload, {
+    status: 201, statusText: "Created", headers,
+  });
+
+  expect(response.status).toBe(201);
+  expect(response.statusText).toBe("Created");
+  expect(response.headers.get("x-receipt")).toBe("receipt-1");
+  expect(response.headers.get("content-type")).toBe("application/json");
+  expect(headers.has("content-type")).toBe(false);
+  expect(await response.json()).toEqual(payload);
+});
+
+test("validated JSON preserves an explicitly supplied content type", async () => {
+  const response = validatedJsonResponse(isReceipt, { id: "receipt-1" }, {
+    headers: { "content-type": "application/vnd.example.receipt+json" },
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("application/vnd.example.receipt+json");
+  expect(await response.json()).toEqual({ id: "receipt-1" });
+});
+
+test("validated JSON supports primitive JSON values and null", async () => {
+  const isNullableString = (value: unknown): value is string | null => (
+    value === null || typeof value === "string"
+  );
+  for (const value of [null, "receipt-1"]) {
+    expect(await validatedJsonResponse(isNullableString, value).json()).toBe(value);
+  }
+});
+
+test("invalid and null-body statuses reject a JSON body", () => {
+  for (const status of [99, 204, 205, 304, 600]) {
+    expect(() => validatedJsonResponse(isReceipt, { id: "receipt-1" }, { status }))
+      .toThrow();
+  }
+});
+
+test("validators must return literal true even when runtime callers bypass types", () => {
+  for (const result of [undefined, "true", 1, Promise.resolve(true)]) {
+    const invalidGuard = (() => result) as unknown as typeof isReceipt;
+    expect(() => validatedJsonResponse(invalidGuard, { id: "receipt-1" }))
+      .toThrow(ApplicationError);
+  }
+});
+
+test("validation examines the serialized snapshot and serializes only once", async () => {
+  let serializations = 0;
+  let validations = 0;
+  const payload = {
+    id: "original",
+    toJSON() {
+      serializations++;
+      return { id: "wire-value" };
+    },
+  };
+  const response = validatedJsonResponse((value): value is Receipt => {
+    validations++;
+    expect(value).toEqual({ id: "wire-value" });
+    return isReceipt(value);
+  }, payload);
+
+  expect(serializations).toBe(1);
+  expect(validations).toBe(1);
+  expect(await response.json()).toEqual({ id: "wire-value" });
+});
+
+test("JSON transformations cannot silently bypass the receipt validator", () => {
+  const payload = {
+    id: "original",
+    toJSON: () => ({ id: 42 }),
+  };
+  expect(() => validatedJsonResponse(isReceipt, payload)).toThrow(ApplicationError);
+});
+
+test("serialization and validator errors are sanitized without causes or payloads", () => {
+  const cyclic: Receipt & { self?: unknown } = { id: "private receipt" };
+  cyclic.self = cyclic;
+  const invalidValues: unknown[] = [
+    undefined, { id: 42 }, { id: 1n }, cyclic,
+    { id: "private receipt", toJSON() { throw new Error("private serialization details"); } },
+  ];
+  for (const value of invalidValues) {
+    let error: unknown;
+    try {
+      validatedJsonResponse(isReceipt, value as Receipt);
+    } catch (cause) {
+      error = cause;
+    }
+    expect(error).toBeInstanceOf(ApplicationError);
+    expect(error).toMatchObject({
+      status: 500, code: "RESPONSE_VALIDATION_ERROR", message: "Response validation failed",
+    });
+    expect(error).not.toHaveProperty("cause");
+    expect(JSON.stringify(error)).not.toContain("private");
+  }
+
+  const throwingValidator = (_value: unknown): _value is Receipt => {
+    throw new Error("private validator details");
+  };
+  expect(() => validatedJsonResponse(throwingValidator, { id: "private receipt" }))
+    .toThrow("Response validation failed");
+});
+
+test("invalid receipt after a write returns 500 and never replays the command", async () => {
+  let writes = 0;
+  const app = createApplication({
+    modules: [receiptModule(() => {
+      writes++;
+      return validatedJsonResponse(isReceipt, { id: 42 } as unknown as Receipt);
+    })],
+    commandExecutor: (_invocation, next) => next(),
+  });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+
+  expect(response.status).toBe(500);
+  expect(await response.json()).toEqual({
+    ok: false, code: "RESPONSE_VALIDATION_ERROR", message: "Response validation failed",
+  });
+  expect(writes).toBe(1);
+});
+
+test("custom error mapping keeps request context and can require outcome confirmation", async () => {
+  let observed: unknown;
+  const app = createApplication({
+    modules: [receiptModule(() => validatedJsonResponse(isReceipt, {} as Receipt))],
+    commandExecutor: (_invocation, next) => next(),
+    requestContext: () => ({ requestId: "request-1" }),
+    errorMapper: (error, context) => {
+      observed = { error, context };
+      return Response.json({ code: "OUTCOME_UNKNOWN" }, { status: 503 });
+    },
+  });
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+
+  expect(response.status).toBe(503);
+  expect(await response.json()).toEqual({ code: "OUTCOME_UNKNOWN" });
+  expect(observed).toMatchObject({
+    error: { code: "RESPONSE_VALIDATION_ERROR", status: 500 },
+    context: { requestContext: { requestId: "request-1" } },
+  });
+});
+
+test("standalone plugins map explicit response contract errors to server failures", async () => {
+  const compiled = receiptModule(() => validatedJsonResponse(isReceipt, {} as Receipt));
+  const app = new Elysia().use(createModulePlugin(
+    compiled, compiled.createServices({}, {}), undefined, {
+      commandExecutor: (_invocation, next) => next(),
+    },
+  ));
+  const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+
+  expect(response.status).toBe(500);
+  expect((await response.json()).code).toBe("RESPONSE_VALIDATION_ERROR");
+});
+
+test("binary and streaming native responses still bypass JSON validation", async () => {
+  const bytes = new Uint8Array([0, 255, 1, 128]);
+  for (const body of [
+    bytes,
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    }),
+  ]) {
+    const app = createApplication({
+      modules: [receiptModule(() => new Response(body, {
+        status: 202, headers: { "content-type": "application/octet-stream" },
+      }))],
+      commandExecutor: (_invocation, next) => next(),
+    });
+    const response = await app.handle(new Request("http://localhost/receipt", { method: "POST" }));
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-type")).toBe("application/octet-stream");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(bytes);
+  }
+});
+
+// These calls are checked by typecheck:test and are never executed.
+function checkResponseTypes() {
+  validatedJsonResponse(isReceipt, { id: "receipt-1" });
+  // @ts-expect-error Input must match the type inferred from the validator.
+  validatedJsonResponse(isReceipt, { id: 42 });
+  // @ts-expect-error Async validators cannot establish a synchronous contract.
+  validatedJsonResponse(async () => true, { id: "receipt-1" });
+}


### PR DESCRIPTION
## Goal and Scope

Applications returning native JSON Responses need an explicit runtime contract
boundary without changing Elysia's native Response passthrough. Add an opt-in
`validatedJsonResponse` helper, using a caller-owned synchronous type guard.
Keep application authorization, durable receipts and transaction ownership
unchanged. Do not introduce a new schema dependency or parse streaming/binary
Responses globally.

## Acceptance Criteria

```gherkin
Feature: Explicit validation of native JSON responses

  Scenario: Valid receipt keeps its HTTP contract
    Given a synchronous receipt validator and a valid receipt
    When a handler constructs a validated JSON response
    Then the serialized JSON snapshot is validated
    And its status and headers are preserved

  Scenario: Invalid committed receipt is not replayed
    Given a command has executed once and returned a malformed receipt
    When the handler validates its JSON response
    Then the application returns a sanitized server contract error
    And the command is not executed again
    And no rollback is implied

  Scenario: Serialization cannot silently invalidate the receipt
    Given a payload whose JSON representation violates the receipt contract
    When a handler constructs a validated JSON response
    Then validation rejects the actual wire snapshot
    And private payload or validator details are not exposed

  Scenario: Native binary and streaming behavior stays compatible
    Given a handler returns a native binary or streaming Response
    When the compiled application serves the response
    Then its bytes, status and headers pass through unchanged
    And the opt-in JSON helper is not invoked
```

## Validation

- `bun --no-env-file test` in `packages/elysia`: 57 pass / 0 fail, 201 assertions.
- `bun --no-env-file run typecheck`: passed.
- `bun --no-env-file run typecheck:test`: passed, including negative input-type
  and asynchronous-validator examples.
- `bun --no-env-file run build`: passed for JavaScript and declarations.
- Built-package Node.js smoke: passed for successful responses, malformed
  receipts and null-body statuses.
- `git diff --check`: passed.

Tests cover status and header preservation, primitive JSON values, serialization
exactly once, `toJSON` drift, cyclic/BigInt payloads, validator failures without
private causes, literal-true guards, custom error mapping, single command
execution, standalone plugins and unchanged binary/streaming passthrough.

## Implementation Notes

- Keep the caller's schema library: the synchronous type guard can delegate to
  TypeBox `Value.Check` or a compiled validator. No runtime dependency is added.
- Serialize once, validate the wire snapshot, then send those exact bytes.
  Guards must be side-effect free; this is not a transform/coercion hook.
- Invalid receipts and serialization failures use the existing sanitized
  `ApplicationError` / `RESPONSE_VALIDATION_ERROR` path.
- Explicitly reject null-body statuses 204, 205 and 304. A local regression
  demonstrated that Bun otherwise accepts a JSON body with status 204.
- The helper is opt-in and intended for bounded JSON responses. It does not
  change existing native Response passthrough or globally consume streams.

## Boundaries and Rollback

This PR does not imply rollback after a committed write, retry commands, add a
receipt ledger, or migrate FA consumers. FA adoption requires a separately
released compatible package and application changes. Existing native Response
users remain unchanged; reverting the helper/export/docs reverts this additive
feature. No production probes, package publication, deployment, merge or
remote-CI polling were performed.
