### PR TITLE
feat(observability): trace request and background function execution

### DIFF
--- a/docs/request-task-tracing.md
+++ b/docs/request-task-tracing.md
@@ -1,0 +1,85 @@
+# Request and background task tracing
+
+The platform preserves W3C version-00 `traceparent` across Management API,
+persisted background-function tasks, each retry, Edge execution and outbound
+`fetch`. Task envelope project identity is compared against the authoritative
+task row. Trace identifiers are correlation metadata, never authorization.
+Legacy tasks without an envelope get a stable project/task-scoped trace.
+
+Set `SUPACLOUD_TRACE_SAMPLE_RATE` on Management and Edge hosts (0 to 1, default
+0.1). Invalid settings disable sampling. Unsampled parents remain unsampled.
+The Edge host captures its setting before tenant environment injection. Each
+function has at most 64 emitted outbound spans; propagation continues beyond
+that limit. Async-local scopes isolate concurrent calls and close after response
+consumption and `waitUntil` completion. Cached fetch references do not capture
+another request's identity.
+
+Sampled spans use `supacloud.trace-span.v1` and the existing structured log
+pipeline. They contain identifiers, project, operation, status and timing only.
+Bodies, tokens, URL paths/queries, arbitrary headers and error causes are never
+included. Unapproved `baggage` and `tracestate` are dropped. Private task/auth
+payloads remain under the existing encryption and access-control contract.
+
+This instruments platform background-function tasks. Arbitrary PGMQ JSON and
+external workflow engines keep their own payload contract; producers must
+explicitly carry `traceparent`, consumers must validate their tenant binding,
+and independent job attempts must create a fresh span. Do not silently wrap
+existing business messages or use tracing as a second execution ledger.
+
+## Local acceptance
+
+```gherkin
+Scenario: Retry correlation survives persisted task replay
+  Given a tenant-bound trace envelope is persisted with a background task
+  When the task is dispatched twice
+  Then both attempts retain the trace ID and have distinct span IDs
+  And the Edge child spans link to their respective attempt
+
+Scenario: Concurrent tenants remain isolated
+  Given two tenants execute concurrent asynchronous handlers
+  When both issue outbound fetches
+  Then each request carries its own trace and emits its authoritative project
+  And a trace envelope bound to another project is rejected
+
+Scenario: Tracing is safe under failure and delayed work
+  Given requests contain secrets and delayed asynchronous work
+  When a fetch fails or the request scope closes
+  Then spans contain only the approved fields
+  And closed scopes cannot leak identifiers into subsequent requests
+```
+
+## SLO rule installation
+
+Load `infrastructure/monitoring/supacloud-slo.rules.yml` through the existing
+Prometheus/VictoriaMetrics rule loader, verify it with `promtool check rules`,
+and route its alerts to the platform on-call owner. Metrics come from the
+authenticated Management `/metrics` scrape endpoint. No telemetry collector,
+public port or database log table is introduced. This PR does not install rules
+on a server or claim that alert delivery has been exercised there.
+
+Background counters describe dispatched attempts, not unique jobs. Queue wait
+is age since original task creation, including prior retries. Sampling affects
+logs, not these counters. Silent/stalled queues with no dispatched attempts
+require a separate queue inventory/dead-man alert.
+
+## Management errors
+
+Owner: platform on-call. Correlate the request/trace ID with the tenant and
+component health. Check recent release receipts and database connectivity.
+Do not retry mutations whose outcome is unknown; read their authoritative state.
+
+## Management latency
+
+Owner: platform on-call. Compare database saturation, runtime pool pressure and
+recent changes. Inspect sampled spans without exporting tenant payloads.
+
+## Background failures
+
+Owner: platform on-call with application owner. Compare task attempts, runtime
+status and authorization failures. Reconcile durable command receipts before
+retrying a job with external side effects.
+
+## Queue delay
+
+Owner: platform on-call. Check worker liveness, tenant concurrency limits and
+retry storms. Increase capacity only after confirming shared-resource headroom.

--- a/infrastructure/monitoring/supacloud-slo.rules.yml
+++ b/infrastructure/monitoring/supacloud-slo.rules.yml
@@ -1,0 +1,43 @@
+groups:
+  - name: supacloud-service-objectives
+    rules:
+      - alert: SupaCloudManagementErrorBudget
+        expr: |
+          (sum(rate(supacloud_management_http_errors_total[5m])) / clamp_min(sum(rate(supacloud_management_http_requests_total[5m])), 0.001) > 0.01)
+          and (sum(increase(supacloud_management_http_requests_total[5m])) >= 20)
+        for: 5m
+        labels:
+          severity: warning
+          service: management-api
+        annotations:
+          summary: Management API error ratio exceeds one percent
+          runbook: docs/request-task-tracing.md#management-errors
+      - alert: SupaCloudManagementLatency
+        expr: histogram_quantile(0.95, sum by (le) (rate(supacloud_management_http_request_duration_ms_bucket[5m]))) > 500
+        for: 10m
+        labels:
+          severity: warning
+          service: management-api
+        annotations:
+          summary: Management API p95 exceeds 500 milliseconds
+          runbook: docs/request-task-tracing.md#management-latency
+      - alert: SupaCloudBackgroundFailures
+        expr: |
+          (sum(rate(supacloud_background_failures_total[5m])) / clamp_min(sum(rate(supacloud_background_attempts_total[5m])), 0.001) > 0.02)
+          and (sum(increase(supacloud_background_attempts_total[5m])) >= 20)
+        for: 5m
+        labels:
+          severity: warning
+          service: background-worker
+        annotations:
+          summary: Background function attempt failure ratio exceeds two percent
+          runbook: docs/request-task-tracing.md#background-failures
+      - alert: SupaCloudBackgroundQueueDelay
+        expr: histogram_quantile(0.95, sum by (le) (rate(supacloud_background_queue_wait_seconds_bucket[15m]))) > 300
+        for: 10m
+        labels:
+          severity: warning
+          service: background-worker
+        annotations:
+          summary: Dispatched background task p95 age exceeds five minutes
+          runbook: docs/request-task-tracing.md#queue-delay

--- a/packages/edge-runtime/tracing.test.ts
+++ b/packages/edge-runtime/tracing.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import {
+  createFunctionTrace, createTracedFetch, parseTraceparent, runFunctionTrace,
+  traceHeaders, traceSampleRate,
+} from "./tracing";
+
+const parent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+afterEach(() => mock.restore());
+
+test("only valid version-00 nonzero identifiers are accepted", () => {
+  expect(parseTraceparent(parent)?.sampled).toBe(true);
+  for (const value of [null, "", parent.toUpperCase(), parent.replace("00-", "ff-"),
+    parent.replace("0123456789abcdef0123456789abcdef", "0".repeat(32)),
+    parent.replace("-0123456789abcdef-", `-${"0".repeat(16)}-`), parent + "-extra"]) {
+    expect(parseTraceparent(value)).toBeNull();
+  }
+  expect(traceSampleRate()).toBe(0.1);
+  for (const value of ["", "bad", "-1", "2", "Infinity"]) expect(traceSampleRate(value)).toBe(0);
+});
+
+test("scoped concurrent fetches preserve headers but never borrow tenant traces", async () => {
+  const logs = spyOn(console, "info").mockImplementation(() => {});
+  const seen: Headers[] = [];
+  const fetcher = createTracedFetch((async (_input, init) => {
+    await Promise.resolve();
+    seen.push(new Headers(init?.headers));
+    return new Response("ok");
+  }) as typeof fetch);
+  const contexts = ["tenant_a", "tenant_b"].map((project, index) =>
+    createFunctionTrace(project, new Headers({
+      traceparent: index ? parent.replace("0123456789abcdef0123456789abcdef", "1".repeat(32)) : parent,
+    }), 1));
+  await Promise.all(contexts.map((trace) => runFunctionTrace(trace, async () => {
+    await Promise.resolve();
+    return fetcher(new Request("https://example.test/private?token=secret", {
+      headers: { authorization: "Bearer private", baggage: "token=secret", tracestate: "private", "x-test": trace.projectRef },
+    }));
+  })));
+  for (const trace of contexts) {
+    const headers = seen.find((headers) => headers.get("x-test") === trace.projectRef)!;
+    expect(parseTraceparent(headers.get("traceparent"))?.traceId).toBe(trace.traceId);
+    expect(headers.get("authorization")).toBe("Bearer private");
+    expect(headers.has("baggage")).toBe(false);
+    expect(headers.has("tracestate")).toBe(false);
+  }
+  const serialized = JSON.stringify(logs.mock.calls);
+  expect(serialized).not.toContain("private");
+  expect(serialized).not.toContain("secret");
+  expect(logs.mock.calls.length).toBe(4);
+});
+
+test("closed async scopes no longer attach request identity", async () => {
+  spyOn(console, "info").mockImplementation(() => {});
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => { release = resolve; });
+  let delayed!: Promise<Response>;
+  let seen: Headers | undefined;
+  const fetcher = createTracedFetch((async (_input, init) => {
+    seen = new Headers(init?.headers);
+    return new Response("ok");
+  }) as typeof fetch);
+  await runFunctionTrace(createFunctionTrace("tenant_a", new Headers({ traceparent: parent }), 1), async () => {
+    delayed = ready.then(() => fetcher("https://example.test/"));
+  });
+  release();
+  await delayed;
+  expect(seen!.has("traceparent")).toBe(false);
+});
+
+test("unsampled parents propagate without producing spans and span volume is bounded", async () => {
+  const logs = spyOn(console, "info").mockImplementation(() => {});
+  const fetcher = createTracedFetch((async () => new Response("ok")) as typeof fetch);
+  const unsampled = createFunctionTrace("tenant_a", new Headers({ traceparent: parent.slice(0, -2) + "00" }), 1);
+  await runFunctionTrace(unsampled, () => fetcher("https://example.test/"));
+  expect(logs).not.toHaveBeenCalled();
+  await runFunctionTrace(createFunctionTrace("tenant_a", new Headers({ traceparent: parent }), 1), async () => {
+    for (let index = 0; index < 100; index++) await fetcher("https://example.test/");
+  });
+  expect(logs.mock.calls.length).toBe(65);
+});
+
+test("failed fetch emits only approved metadata and preserves the original error", async () => {
+  const logs = spyOn(console, "info").mockImplementation(() => {});
+  const failure = new Error("token=private");
+  const fetcher = createTracedFetch((async () => { throw failure; }) as unknown as typeof fetch);
+  const trace = createFunctionTrace("tenant_a", new Headers({ traceparent: parent }), 1);
+  await expect(runFunctionTrace(trace, () => fetcher("https://example.test/"))).rejects.toBe(failure);
+  expect(JSON.stringify(logs.mock.calls)).not.toContain("private");
+  expect(JSON.parse(String(logs.mock.calls[0]![0])).status).toBe(500);
+  expect(parseTraceparent(traceHeaders(trace).get("traceparent"))?.spanId).toBe(trace.spanId);
+});

--- a/packages/edge-runtime/tracing.ts
+++ b/packages/edge-runtime/tracing.ts
@@ -1,0 +1,116 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+
+export interface FunctionTrace {
+  projectRef: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  sampled: boolean;
+}
+
+export interface TraceSpan extends FunctionTrace {
+  schema: "supacloud.trace-span.v1";
+  operation: "function" | "http.client";
+  durationMs: number;
+  status: number;
+}
+
+type TraceScope = { trace: FunctionTrace; active: boolean; emitted: number };
+const scopes = new AsyncLocalStorage<TraceScope>();
+const hostSampleRate = traceSampleRate(process.env.SUPACLOUD_TRACE_SAMPLE_RATE);
+const MAX_CLIENT_SPANS = 64;
+
+export function traceSampleRate(value?: string): number {
+  if (value === undefined) return 0.1;
+  const rate = Number(value);
+  return value.trim() && Number.isFinite(rate) && rate >= 0 && rate <= 1 ? rate : 0;
+}
+
+export function parseTraceparent(value: string | null) {
+  const match = value?.match(/^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/);
+  if (!match || /^0+$/.test(match[1]!) || /^0+$/.test(match[2]!)) return null;
+  return { traceId: match[1]!, spanId: match[2]!, sampled: (parseInt(match[3]!, 16) & 1) === 1 };
+}
+
+export function createFunctionTrace(
+  projectRef: string,
+  headers: Headers,
+  sampleRate = hostSampleRate,
+): FunctionTrace {
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(projectRef)) throw new Error("Invalid trace project");
+  const parent = parseTraceparent(headers.get("traceparent"));
+  const traceId = parent?.traceId ?? randomBytes(16).toString("hex");
+  const selected = Number.isFinite(sampleRate) && sampleRate >= 0 && sampleRate <= 1
+    && parseInt(traceId.slice(0, 8), 16) / 0x1_0000_0000 < sampleRate;
+  return Object.freeze({
+    projectRef, traceId, spanId: randomBytes(8).toString("hex"),
+    parentSpanId: parent?.spanId ?? null,
+    sampled: selected && (parent?.sampled ?? true),
+  });
+}
+
+export function traceHeaders(trace: FunctionTrace, original?: HeadersInit): Headers {
+  const headers = new Headers(original);
+  headers.set("traceparent", `00-${trace.traceId}-${trace.spanId}-${trace.sampled ? "01" : "00"}`);
+  headers.set("x-supacloud-trace-id", trace.traceId);
+  // Vendor baggage is not an approved carrier for tenant identity or secrets.
+  headers.delete("tracestate");
+  headers.delete("baggage");
+  return headers;
+}
+
+function emitSpan(trace: FunctionTrace, operation: TraceSpan["operation"], started: number, status: number) {
+  if (!trace.sampled) return;
+  console.info(JSON.stringify({
+    schema: "supacloud.trace-span.v1", ...trace, operation,
+    durationMs: Math.max(0, performance.now() - started), status,
+  } satisfies TraceSpan));
+}
+
+export async function runFunctionTrace<T>(
+  trace: FunctionTrace | undefined,
+  operation: () => Promise<T>,
+  responseStatus: (result: T) => number = () => 200,
+): Promise<T> {
+  if (!trace) return operation();
+  const scope: TraceScope = { trace, active: true, emitted: 0 };
+  return scopes.run(scope, async () => {
+    const started = performance.now();
+    let status = 500;
+    try {
+      const result = await operation();
+      status = responseStatus(result);
+      return result;
+    } finally {
+      scope.active = false;
+      emitSpan(trace, "function", started, status);
+    }
+  });
+}
+
+export function createTracedFetch(original: typeof fetch): typeof fetch {
+  return (async (input, init) => {
+    const scope = scopes.getStore();
+    if (!scope?.active) return original(input, init);
+    const trace: FunctionTrace = {
+      ...scope.trace, parentSpanId: scope.trace.spanId, spanId: randomBytes(8).toString("hex"),
+      sampled: scope.trace.sampled && scope.emitted++ < MAX_CLIENT_SPANS,
+    };
+    const originalHeaders = init?.headers ?? (input instanceof Request ? input.headers : undefined);
+    const headers = traceHeaders(trace, originalHeaders);
+    const started = performance.now();
+    let status = 500;
+    try {
+      const response = await original(input, { ...init, headers });
+      status = response.status;
+      return response;
+    } finally {
+      emitSpan(trace, "http.client", started, status);
+    }
+  }) as typeof fetch;
+}
+
+export function installFunctionTracingFetch(): void {
+  globalThis.fetch = createTracedFetch(globalThis.fetch);
+}

--- a/packages/edge-runtime/tracing.worker.test.ts
+++ b/packages/edge-runtime/tracing.worker.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkerPool } from "./worker-pool";
+import { parseTraceparent } from "./tracing";
+
+test("real worker propagates handler and waitUntil traces across tenant reuse", async () => {
+  const seen: Array<{ tenant: string | null; trace: string | null; baggage: string | null }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1", port: 0,
+    fetch(request) {
+      seen.push({ tenant: request.headers.get("x-test-tenant"), trace: request.headers.get("traceparent"), baggage: request.headers.get("baggage") });
+      return new Response("ok");
+    },
+  });
+  const root = await mkdtemp(join(tmpdir(), "supacloud-trace-worker-"));
+  const path = join(root, "function.ts");
+  await Bun.write(path, `
+    const cachedFetch = globalThis.fetch;
+    export default async (request) => {
+      const headers = { "x-test-tenant": request.headers.get("x-test-tenant"), baggage: "secret" };
+      await cachedFetch("http://127.0.0.1:${server.port}/sync", { headers });
+      EdgeRuntime.waitUntil(Promise.resolve().then(() =>
+        cachedFetch("http://127.0.0.1:${server.port}/background", { headers })));
+      return Response.json({ trace: request.headers.get("traceparent") });
+    };
+  `);
+  const pool = new WorkerPool({ size: 1, requestTimeout: 5000 });
+  try {
+    for (const [index, tenant] of ["tenant_a", "tenant_b"].entries()) {
+      const traceId = String(index + 1).repeat(32);
+      const response = await pool.dispatch({
+        functionId: `${tenant}_trace`, projectRef: tenant, functionPath: path,
+        projectRoot: root, env: {},
+        request: new Request("http://edge.local/functions/v1/trace", {
+          headers: { traceparent: `00-${traceId}-${"a".repeat(16)}-00`, "x-test-tenant": tenant },
+        }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { trace: string };
+      expect(parseTraceparent(body.trace)?.traceId).toBe(traceId);
+      expect(response.headers.get("traceparent")).toBe(body.trace);
+    }
+    // 等待已登记的后台工作结束后再检查全部出站请求。
+    await pool.shutdown();
+    expect(seen.length).toBe(4);
+    for (const [index, tenant] of ["tenant_a", "tenant_b"].entries()) {
+      const calls = seen.filter((call) => call.tenant === tenant);
+      expect(calls.length).toBe(2);
+      for (const call of calls) {
+        expect(parseTraceparent(call.trace)?.traceId).toBe(String(index + 1).repeat(32));
+        expect(call.baggage).toBeNull();
+      }
+      expect(calls[0]!.trace).not.toBe(calls[1]!.trace);
+    }
+  } finally {
+    await pool.shutdown();
+    server.stop(true);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -23,6 +23,9 @@ import {
   tenantBuiltinSpecifier,
 } from "./deno-compat";
 import { installEdgeFetchTlsPolicy, resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
+import { createFunctionTrace, installFunctionTracingFetch, runFunctionTrace, traceHeaders } from "./tracing";
+
+installFunctionTracingFetch();
 import type { EdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import { runWithPgredisBinding } from "./internal-bindings";
 import {
@@ -787,7 +790,9 @@ async function onParentMessage(msg: unknown): Promise<void> {
     }
     postToParent({ type: "execution_started", functionId });
     const handler = moduleLoad.handler;
-    await runWithPgredisBinding(internalBindings
+    const trace = projectRef ? createFunctionTrace(projectRef, new Headers(headers as Record<string, string>)) : undefined;
+    let traceStatus = 500;
+    await runFunctionTrace(trace, () => runWithPgredisBinding(internalBindings
       ? { ...internalBindings, signal: requestAbortController.signal }
       : undefined, async () => {
         const handlerUrl = (msg.framework && msg.framework !== "fetch") || isFrameworkRouterHandler(handler)
@@ -795,12 +800,17 @@ async function onParentMessage(msg: unknown): Promise<void> {
           : url;
         const req = new Request(handlerUrl, {
           method,
-          headers: new Headers(headers as Record<string, string>),
+          headers: trace ? traceHeaders(trace, headers as Record<string, string>) : new Headers(headers as Record<string, string>),
           body: body ? Buffer.from(body) : undefined,
           signal: requestAbortController.signal,
         });
 
-        const response = await executeFunction(handler, req);
+        const result = await executeFunction(handler, req);
+        const response = trace ? new Response(result.body, {
+          status: result.status, statusText: result.statusText,
+          headers: traceHeaders(trace, result.headers),
+        }) : result;
+        traceStatus = response.status;
         const maxResponseBody = msg.limits?.max_response_body_bytes;
 
         if (
@@ -843,6 +853,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
               });
             }
           } catch (err: any) {
+            traceStatus = 500;
             postToParent({
               type: "stream_chunk",
               streamId,
@@ -851,6 +862,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
             });
           }
 
+          await flushWaitUntilTasks(functionId);
           return;
         }
 
@@ -882,7 +894,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
           moduleCacheSize: moduleLoad.moduleCacheSize,
         });
         await flushWaitUntilTasks(functionId);
-      });
+      }), () => traceStatus);
   } catch (err: any) {
     const aborted = currentAbortController?.signal.aborted || err?.name === "AbortError";
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -288,9 +288,8 @@ const app = new Elysia({ strictPath: false })
     applyObservabilityHeaders(set.headers, context);
   })
   .onError({ as: "global" }, ({ request, code, error, set }) => {
-    const observation = recordRequestObservation(request, Number(set.status || 500));
     set.headers ??= {};
-    applyObservabilityHeaders(set.headers, observation.context);
+    applyObservabilityHeaders(set.headers, beginRequestObservability(request));
     if (code === "VALIDATION") {
       return validationErrorResponse(set);
     }
@@ -392,15 +391,19 @@ const app = new Elysia({ strictPath: false })
 
   // Rate limit headers + API version (Studio compatibility)
   .onAfterHandle(({ request, set }) => {
-    const observation = recordRequestObservation(request, Number(set.status || 200));
     set.headers ??= {};
-    applyObservabilityHeaders(set.headers, observation.context);
+    applyObservabilityHeaders(set.headers, beginRequestObservability(request));
     set.headers["x-ratelimit-limit"] ??= "1000";
     set.headers["x-ratelimit-remaining"] ??= "999";
     set.headers["x-ratelimit-reset"] ??= String(
       Math.ceil(Date.now() / 60000) * 60,
     );
     set.headers["x-supabase-api-version"] = "2024-01-01";
+  })
+  .onAfterResponse({ as: "global" }, ({ request, response, set }) => {
+    const observation = recordRequestObservation(
+      request, response instanceof Response ? response.status : Number(set.status || 200),
+    );
     if (observation.slow) {
       logger.warn("[Observability] Slow Management API request", {
         requestId: observation.context.requestId,

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -17,6 +17,7 @@ import { verifyProjectJwtPayload } from "../utils/project-jwt";
 import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 import { GOTRUE_USER_ID_PATTERN } from "../utils/project-user-lifecycle";
+import { beginRequestObservability } from "../utils/observability";
 
 const MAX_ASYNC_BODY_BYTES = 256 * 1024;
 type SdkProxySql = (
@@ -268,7 +269,12 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
         headers[key] = value;
     });
 
-    const traceId = request.headers.get("x-request-id") || randomUUID();
+    const trace = beginRequestObservability(request);
+    const traceId = trace.traceId;
+    delete headers.tracestate;
+    delete headers.baggage;
+    headers.traceparent = trace.traceparent;
+    headers["x-supacloud-trace-id"] = traceId;
     const idempotencyKey = request.headers.get("x-supacloud-idempotency-key")?.trim() || null;
     const authorization = request.headers.get("authorization");
     const apikey = request.headers.get("apikey");
@@ -301,6 +307,7 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
         idempotencyKey,
         traceId,
         envelope: {
+            trace: { project_ref: ref, traceparent: trace.traceparent, request_id: trace.requestId },
             method: request.method,
             path: restPath.length > 0 ? `/${restPath.join("/")}` : "",
             query: url.search,
@@ -583,6 +590,12 @@ async function executeProxy(request: Request, targetUrl: string, interceptors: P
         const body = ["GET", "HEAD"].includes(request.method) ? undefined : request.body;
         
         const reqHeaders = new Headers(request.headers);
+        const trace = beginRequestObservability(request);
+        reqHeaders.set("traceparent", trace.traceparent);
+        reqHeaders.set("x-request-id", trace.requestId);
+        reqHeaders.set("x-supacloud-trace-id", trace.traceId);
+        reqHeaders.delete("baggage");
+        reqHeaders.delete("tracestate");
         if (!(await translateOpaqueApiKeyHeaders(
             reqHeaders,
             interceptors.ref || "",

--- a/packages/management-api/src/services/background-function-worker.ts
+++ b/packages/management-api/src/services/background-function-worker.ts
@@ -19,6 +19,8 @@ import {
   normalizedGoTrueUserId,
 } from "../utils/project-user-lifecycle";
 import { getAuthRuntimeDescriptor } from "./auth-runtime.service";
+import { parseTaskTraceparent, taskAttemptTrace } from "../utils/task-trace";
+import { recordBackgroundObservation } from "../utils/background-observability";
 
 interface InvocationEnvelope {
   method?: string;
@@ -298,7 +300,14 @@ export function buildInvocationRequest(task: ProjectTask): Request {
 
   headers.set("x-project-ref", task.project_ref);
   headers.set("x-supacloud-task-id", task.id);
-  if (task.trace_id) headers.set("x-supacloud-trace-id", task.trace_id);
+  try {
+    const trace = taskAttemptTrace(task);
+    trace.forEach((value, name) => headers.set(name, value));
+  } catch {
+    throw new NonRetryableBackgroundInvocationError("Background trace identity is inconsistent", 422);
+  }
+  headers.delete("tracestate");
+  headers.delete("baggage");
   headers.set("x-supacloud-background", "true");
   headers.set("x-supacloud-attempt", String(attempt));
   headers.set("x-supacloud-function-version", task.function_version || "1");
@@ -584,6 +593,8 @@ export class BackgroundFunctionWorker {
 
     const heartbeat = scheduleLeaseHeartbeat(task.id, leaseSeconds);
     const startedAt = Date.now();
+    let invocationRequest: Request | undefined;
+    let invocationStatus = 500;
     const logs: Array<{
       timestamp: string;
       stream: "stdout" | "stderr";
@@ -593,6 +604,7 @@ export class BackgroundFunctionWorker {
 
     try {
       const request = buildInvocationRequest(task);
+      invocationRequest = request;
       const { dispatchBackgroundFunction } = await importDispatcher();
       const response = await dispatchBackgroundFunction({
         projectRef: task.project_ref,
@@ -603,6 +615,7 @@ export class BackgroundFunctionWorker {
           if (logs.length > 200) logs.shift();
         },
       });
+      invocationStatus = response.status;
 
       const result = {
         status: response.status,
@@ -720,6 +733,22 @@ export class BackgroundFunctionWorker {
         error: message,
       });
     } finally {
+      const parent = parseTaskTraceparent(invocationRequest?.headers.get("traceparent"));
+      if (invocationRequest) {
+        recordBackgroundObservation(
+          (startedAt - new Date(task.created_at).valueOf()) / 1000,
+          invocationStatus >= 400,
+        );
+      }
+      if (parent?.flags === "01") {
+        const origin = parseTaskTraceparent((task.payload?.trace as { traceparent?: string } | undefined)?.traceparent);
+        logger.info("[Trace] background attempt", {
+          schema: "supacloud.trace-span.v1", projectRef: task.project_ref,
+          traceId: parent.traceId, spanId: parent.spanId, parentSpanId: origin?.spanId ?? null,
+          operation: "background.attempt", taskId: task.id, attempt: task.attempt || 1,
+          durationMs: Math.max(0, Date.now() - startedAt), status: invocationStatus,
+        });
+      }
       await cleanupBackgroundTaskMirrorEvidence(task);
     }
   }

--- a/packages/management-api/src/services/background-task.service.ts
+++ b/packages/management-api/src/services/background-task.service.ts
@@ -3,6 +3,7 @@ import { withRetry } from "../utils/retry";
 import { encryptSecretIfNeeded } from "../utils/secret-crypto";
 import { normalizedGoTrueUserId } from "../utils/project-user-lifecycle";
 import { getAuthRuntimeDescriptor } from "./auth-runtime.service";
+import type { TaskTraceEnvelope } from "../utils/task-trace";
 
 export interface BackgroundFunctionAuthContext {
   kind: "jwt" | "apikey" | "none";
@@ -14,6 +15,7 @@ export interface BackgroundFunctionAuthContext {
 }
 
 export interface BackgroundFunctionInvocationEnvelope {
+  trace?: TaskTraceEnvelope;
   method: string;
   path: string;
   query: string;

--- a/packages/management-api/src/utils/background-observability.ts
+++ b/packages/management-api/src/utils/background-observability.ts
@@ -1,0 +1,31 @@
+const limits = [1, 5, 30, 60, 300, 900, 3600];
+const buckets = limits.map(() => 0);
+let count = 0;
+let failures = 0;
+let sum = 0;
+
+export function recordBackgroundObservation(waitSeconds: number, failed: boolean): void {
+  const wait = Number.isFinite(waitSeconds) ? Math.max(0, waitSeconds) : 0;
+  count++;
+  if (failed) failures++;
+  sum += wait;
+  limits.forEach((limit, index) => { if (wait <= limit) buckets[index]!++; });
+}
+
+export function renderBackgroundMetrics(): string {
+  const name = "supacloud_background_queue_wait_seconds";
+  return [
+    "# TYPE supacloud_background_attempts_total counter",
+    `supacloud_background_attempts_total ${count}`,
+    "# TYPE supacloud_background_failures_total counter",
+    `supacloud_background_failures_total ${failures}`,
+    `# HELP ${name} Time from task creation to the start of a dispatched attempt.`,
+    `# TYPE ${name} histogram`,
+    ...limits.map((limit, index) => `${name}_bucket{le="${limit}"} ${buckets[index]}`),
+    `${name}_bucket{le="+Inf"} ${count}`, `${name}_sum ${sum}`, `${name}_count ${count}`,
+  ].join("\n") + "\n";
+}
+
+export function resetBackgroundMetricsForTests(): void {
+  count = 0; failures = 0; sum = 0; buckets.fill(0);
+}

--- a/packages/management-api/src/utils/observability.ts
+++ b/packages/management-api/src/utils/observability.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from "node:crypto";
+import { parseTaskTraceparent } from "./task-trace";
+import { renderBackgroundMetrics } from "./background-observability";
 
 const TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
@@ -11,6 +13,8 @@ export interface RequestObservabilityContext {
   traceId: string;
   correlationId: string;
   startedAt: number;
+  traceparent: string;
+  parentSpanId: string | null;
 }
 
 interface RequestMetricState {
@@ -22,6 +26,7 @@ interface RequestMetricState {
 }
 
 const requestContexts = new WeakMap<Request, RequestObservabilityContext>();
+const observations = new WeakMap<Request, { context: RequestObservabilityContext; durationMs: number; slow: boolean }>();
 const metricState: RequestMetricState = {
   requests: 0,
   errors: 0,
@@ -40,8 +45,7 @@ function validRequestId(value: string | null): string | undefined {
 }
 
 function traceIdFromTraceparent(value: string | null): string | undefined {
-  const match = value?.match(/^[\da-f]{2}-([\da-f]{32})-[\da-f]{16}-[\da-f]{2}$/i);
-  return match && TRACE_ID_PATTERN.test(match[1]!) ? match[1]!.toLowerCase() : undefined;
+  return parseTaskTraceparent(value)?.traceId;
 }
 
 export function beginRequestObservability(request: Request): RequestObservabilityContext {
@@ -53,11 +57,17 @@ export function beginRequestObservability(request: Request): RequestObservabilit
     ?? randomHex(16);
   const suppliedTraceId = request.headers.get("x-supacloud-trace-id");
   const traceId = traceIdFromTraceparent(request.headers.get("traceparent"))
-    ?? (suppliedTraceId && TRACE_ID_PATTERN.test(suppliedTraceId) ? suppliedTraceId.toLowerCase() : randomHex(16));
+    ?? (suppliedTraceId && TRACE_ID_PATTERN.test(suppliedTraceId) && !/^0+$/.test(suppliedTraceId) ? suppliedTraceId : randomHex(16));
   const correlationId = validRequestId(request.headers.get("x-supacloud-correlation-id"))
     ?? requestId;
 
-  const context = { requestId, traceId, correlationId, startedAt: performance.now() };
+  const parent = parseTaskTraceparent(request.headers.get("traceparent"));
+  const rate = Number(process.env.SUPACLOUD_TRACE_SAMPLE_RATE ?? "0.1");
+  const sampled = Number.isFinite(rate) && rate >= 0 && rate <= 1
+    && parseInt(traceId.slice(0, 8), 16) / 0x1_0000_0000 < rate
+    && (parent ? parent.flags === "01" : true);
+  const traceparent = `00-${traceId}-${randomHex(8)}-${sampled ? "01" : "00"}`;
+  const context = { requestId, traceId, correlationId, traceparent, parentSpanId: parent?.spanId ?? null, startedAt: performance.now() };
   requestContexts.set(request, context);
   return context;
 }
@@ -69,12 +79,15 @@ export function applyObservabilityHeaders(
   headers["x-request-id"] ??= context.requestId;
   headers["x-supacloud-trace-id"] ??= context.traceId;
   headers["x-supacloud-correlation-id"] ??= context.correlationId;
+  headers.traceparent ??= context.traceparent;
 }
 
 export function recordRequestObservation(
   request: Request,
   status: number,
 ): { context: RequestObservabilityContext; durationMs: number; slow: boolean } {
+  const existing = observations.get(request);
+  if (existing) return existing;
   const context = beginRequestObservability(request);
   const durationMs = Math.max(0, performance.now() - context.startedAt);
   metricState.requests += 1;
@@ -84,7 +97,15 @@ export function recordRequestObservation(
   for (const [index, bucket] of latencyBuckets.entries()) {
     if (durationMs <= bucket) metricState.durationBuckets[index]! += 1;
   }
-  return { context, durationMs, slow: durationMs >= SLOW_REQUEST_MS };
+  const observation = { context, durationMs, slow: durationMs >= SLOW_REQUEST_MS };
+  observations.set(request, observation);
+  const trace = parseTaskTraceparent(context.traceparent)!;
+  if (trace.flags === "01") console.info(JSON.stringify({
+    schema: "supacloud.trace-span.v1", operation: "management.request",
+    traceId: context.traceId, spanId: trace.spanId, parentSpanId: context.parentSpanId,
+    requestId: context.requestId, durationMs, status,
+  }));
+  return observation;
 }
 
 export function renderRequestMetrics(): string {
@@ -113,7 +134,7 @@ export function renderRequestMetrics(): string {
     `${durationMetric}_sum ${metricState.durationSum}`,
     `${durationMetric}_count ${metricState.requests}`,
   );
-  return `${lines.join("\n")}\n`;
+  return `${lines.join("\n")}\n${renderBackgroundMetrics()}`;
 }
 
 export function resetRequestMetricsForTests(): void {

--- a/packages/management-api/src/utils/task-trace.ts
+++ b/packages/management-api/src/utils/task-trace.ts
@@ -1,0 +1,43 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export interface TaskTraceEnvelope {
+  project_ref: string;
+  traceparent: string;
+  request_id: string;
+}
+
+export function parseTaskTraceparent(value: unknown) {
+  const match = typeof value === "string"
+    ? value.match(/^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/)
+    : null;
+  if (!match || /^0+$/.test(match[1]!) || /^0+$/.test(match[2]!)) return null;
+  return { traceId: match[1]!, spanId: match[2]!, flags: (parseInt(match[3]!, 16) & 1) ? "01" : "00" };
+}
+
+export function taskAttemptTrace(
+  task: { id: string; project_ref: string; trace_id?: string | null; payload?: Record<string, unknown> },
+): Headers {
+  const envelope = task.payload?.trace as Partial<TaskTraceEnvelope> | undefined;
+  let traceId: string;
+  let flags = "00";
+  if (envelope !== undefined) {
+    const parent = parseTaskTraceparent(envelope?.traceparent);
+    if (!parent || envelope?.project_ref !== task.project_ref
+      || typeof envelope.request_id !== "string" || !/^[A-Za-z0-9._:-]{1,256}$/.test(envelope.request_id)
+      || parent.traceId !== task.trace_id) {
+      throw new Error("Background trace identity is inconsistent");
+    }
+    traceId = parent.traceId;
+    flags = parent.flags;
+  } else {
+    // Stable fallback for legacy UUID trace IDs; never inherit payload headers.
+    traceId = createHash("sha256").update(JSON.stringify([
+      task.project_ref, task.id, task.trace_id ?? "",
+    ])).digest("hex").slice(0, 32);
+  }
+  return new Headers({
+    traceparent: `00-${traceId}-${randomBytes(8).toString("hex")}-${flags}`,
+    "x-supacloud-trace-id": traceId,
+    "x-request-id": randomBytes(16).toString("hex"),
+  });
+}

--- a/packages/management-api/tests/unit/observability.test.ts
+++ b/packages/management-api/tests/unit/observability.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
 import {
   applyObservabilityHeaders,
   beginRequestObservability,
@@ -7,6 +8,7 @@ import {
   resetRequestMetricsForTests,
 } from "../../src/utils/observability";
 
+beforeEach(() => { spyOn(console, "info").mockImplementation(() => {}); });
 afterEach(() => {
   mock.restore();
   resetRequestMetricsForTests();
@@ -28,6 +30,30 @@ function observeDuration(durationMs: number, status = 200): void {
 }
 
 describe("request observability", () => {
+  test("after-response lifecycle records native statuses and error statuses exactly once", async () => {
+    const app = new Elysia()
+      .onRequest(({ request }) => { beginRequestObservability(request); })
+      .onError(({ set }) => { set.status = 422; return { code: "REJECTED" }; })
+      .onAfterResponse(({ request, response, set }) => {
+        recordRequestObservation(request, response instanceof Response ? response.status : Number(set.status || 200));
+      })
+      .get("/native", () => new Response("unavailable", { status: 503 }))
+      .get("/error", () => { throw new Error("private"); });
+    expect((await app.handle(new Request("http://localhost/native"))).status).toBe(503);
+    expect((await app.handle(new Request("http://localhost/error"))).status).toBe(422);
+    await Bun.sleep(0);
+    const metrics = renderRequestMetrics();
+    expect(metrics).toContain("supacloud_management_http_requests_total 2\n");
+    expect(metrics).toContain('supacloud_management_http_responses_total{status="503"} 1');
+    expect(metrics).toContain('supacloud_management_http_responses_total{status="422"} 1');
+  });
+  test("rejects all-zero fallback IDs and records each request only once", () => {
+    const request = new Request("http://localhost/", { headers: { "x-supacloud-trace-id": "0".repeat(32) } });
+    expect(beginRequestObservability(request).traceId).not.toBe("0".repeat(32));
+    recordRequestObservation(request, 422);
+    recordRequestObservation(request, 422);
+    expect(renderRequestMetrics()).toContain("supacloud_management_http_requests_total 1\n");
+  });
   test("preserves a valid inbound request and trace identity", () => {
     const request = new Request("http://localhost/health", {
       headers: {
@@ -48,6 +74,7 @@ describe("request observability", () => {
       "x-request-id": "req-123",
       "x-supacloud-trace-id": "0123456789abcdef0123456789abcdef",
       "x-supacloud-correlation-id": "workflow-123",
+      traceparent: context.traceparent,
     });
   });
 

--- a/packages/management-api/tests/unit/task-trace.test.ts
+++ b/packages/management-api/tests/unit/task-trace.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, test } from "bun:test";
+import { taskAttemptTrace, parseTaskTraceparent } from "../../src/utils/task-trace";
+import { beginRequestObservability } from "../../src/utils/observability";
+import { recordBackgroundObservation, renderBackgroundMetrics, resetBackgroundMetricsForTests } from "../../src/utils/background-observability";
+
+afterEach(resetBackgroundMetricsForTests);
+test("persisted queue trace survives retry with separate attempt spans", () => {
+  const request = new Request("http://localhost/functions/v1/job", {
+    headers: { traceparent: "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01" },
+  });
+  const trace = beginRequestObservability(request);
+  const task = JSON.parse(JSON.stringify({
+    id: "task_1", project_ref: "tenant_a", trace_id: trace.traceId,
+    payload: { trace: { project_ref: "tenant_a", traceparent: trace.traceparent, request_id: trace.requestId } },
+  }));
+  const first = parseTaskTraceparent(taskAttemptTrace(task).get("traceparent"))!;
+  const retry = parseTaskTraceparent(taskAttemptTrace(task).get("traceparent"))!;
+  expect(first.traceId).toBe(trace.traceId);
+  expect(retry.traceId).toBe(first.traceId);
+  expect(retry.spanId).not.toBe(first.spanId);
+  expect(() => taskAttemptTrace({ ...task, project_ref: "tenant_b" })).toThrow("inconsistent");
+  expect(() => taskAttemptTrace({ ...task, trace_id: "f".repeat(32) })).toThrow("inconsistent");
+});
+
+test("legacy traces are stable and tenant scoped, not copied from client headers", () => {
+  const task = { id: "task_1", project_ref: "tenant_a", trace_id: "old-uuid",
+    payload: { headers: { traceparent: "malicious", baggage: "private" } } };
+  const first = taskAttemptTrace(task).get("x-supacloud-trace-id");
+  expect(taskAttemptTrace(task).get("x-supacloud-trace-id")).toBe(first);
+  expect(taskAttemptTrace({ ...task, project_ref: "tenant_b" }).get("x-supacloud-trace-id")).not.toBe(first);
+});
+
+test("background SLO counters are cumulative and independent of trace sampling", () => {
+  for (let index = 0; index < 10_001; index++) recordBackgroundObservation(2, false);
+  recordBackgroundObservation(5000, true);
+  const metrics = renderBackgroundMetrics();
+  expect(metrics).toContain("supacloud_background_attempts_total 10002");
+  expect(metrics).toContain("supacloud_background_failures_total 1");
+  expect(metrics).toContain('supacloud_background_queue_wait_seconds_bucket{le="5"} 10001');
+  expect(metrics).toContain("supacloud_background_queue_wait_seconds_sum 25002");
+});


### PR DESCRIPTION
## Summary
- Propagate strict W3C trace context through synchronous proxy, persisted background tasks/retries, Edge handlers, waitUntil and outbound fetch.
- Bind persisted carriers to authoritative task project/trace identity, isolate async scopes and bound sampled metadata without logging payloads, URLs or secrets.
- Record final Management response statuses once; add background attempt/queue-age metrics and four SLO alert rules with runbooks.

## Validation
- Edge tracing + real WorkerPool suite: 91 passed, 6 Linux-only tests skipped on macOS.
- Management observability/task-trace: 11 passed; background worker: 40 passed; SDK proxy: 41 passed.
- Edge Runtime and Management API typechecks; git diff --check.
- Four alert rules parsed with Bun YAML. promtool is not installed locally; no alert deployment/delivery acceptance claimed.

## Boundaries
- Platform background-function queues are instrumented. Arbitrary business PGMQ/workflow payloads are not silently wrapped.
- No server access, deployment, schema migration or new execution ledger.
