### PR TITLE
fix(gateway): preserve custom route CORS during reconciliation

### DIFF
--- a/docs/gateway-customization.md
+++ b/docs/gateway-customization.md
@@ -286,6 +286,8 @@ curl -X PUT "$HOST/v1/projects/$REF/gateway/custom-rate-limits" \
 SupaCloud 会自动为每个项目生成多个域名：API 主域（`<ref>.<base_domain>`）、Auth 域、Studio 域，并为这些域名构建租户级 CORS origins（`buildTenantCorsOrigins`）。自定义路由与这套自动 CORS 体系是**正交**的：
 
 - 自定义路由的 `cors` 字段只作用于该路由本身，不会影响系统路由的 CORS。
+  项目级 CORS 更新、前端部署和共享认证入口重建均保留该策略；
+  未配置 `cors` 的自定义路由也不会自动继承项目的来源列表。
 - `gateway/config` 的 `cors_origins` 会更新该项目所有系统路由的 CORS。
 - `addCorsOriginsForHosts`（内部接口）会把自定义域名并入租户 CORS 计算，用于绑定自定义前端域名时。
 

--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -418,6 +418,9 @@ export function routePreservesUpstreamCors(route: CaddyRoute): boolean {
 }
 
 export function setRouteCors(route: CaddyRoute, origins: string[]): void {
+    // Custom routes own their policy, including deliberately omitting CORS.
+    // Tenant/frontend reconciliation must not replace that persisted policy.
+    if (String(route["@id"] || "").startsWith("route-custom-gateway-")) return;
     // Routes that preserve upstream CORS (functions, storage) answer preflight
     // themselves; never re-attach the gateway CORS subroute to them.
     if (routePreservesUpstreamCors(route)) return;

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -1476,6 +1476,47 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test.each(["tenant-cors", "frontend", "dependent-frontend"])(
+        "%s reconciliation preserves custom route CORS ownership",
+        async (operation) => {
+            const calls: Array<{ url: string; method: string; body: any }> = [];
+            const restore = captureFetch(calls);
+            const originalOwner = config.authRuntimeOwnerRef;
+            try {
+                const provider = new CaddyGatewayProvider();
+                config.authRuntimeOwnerRef = operation === "dependent-frontend" ? "proj123" : "";
+                expect((await provider.setupUpstream("proj123", 3000, 9999)).success).toBe(true);
+                expect((await provider.configureCustomGatewayRoutes("proj123", [
+                    { id: "public-font", hosts: ["static.example.com"], path: "/font.woff2", static_root: "/srv/fonts", cors: ["*"] },
+                    { id: "private-docs", hosts: ["docs.example.com"], path: "/*", static_root: "/srv/docs", cors: ["https://reader.example.com"] },
+                    { id: "no-cors", hosts: ["download.example.com"], path: "/*", static_root: "/srv/download" },
+                ])).success).toBe(true);
+                const loadedRoutes = () => calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"))
+                    .at(-1)?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+                const customRoutes = () => loadedRoutes().filter((route: any) =>
+                    route["@id"].startsWith("route-custom-gateway-proj123-"));
+                const before = structuredClone(customRoutes());
+                expect(before).toHaveLength(3);
+                if (operation === "tenant-cors") {
+                    await provider.setCors("proj123", ["https://tenant.example.com"]);
+                } else {
+                    await provider.configureFrontendRoute({
+                        projectRef: operation === "dependent-frontend" ? "dependent" : "proj123",
+                        deploymentId: "web", hosts: ["new-app.example.com"], mode: "static", root: "/srv/app",
+                    });
+                }
+                expect(customRoutes()).toEqual(before);
+                const rest = loadedRoutes().find((route: any) => route["@id"] === "route-project-proj123-rest");
+                const cors = JSON.stringify(findCorsSubroute(rest));
+                expect(cors).toContain(operation === "tenant-cors" ? "https://tenant.example.com" : "new-app.example.com");
+                expect(cors).not.toContain('"Origin":["*"]');
+            } finally {
+                config.authRuntimeOwnerRef = originalOwner;
+                restore();
+            }
+        },
+    );
+
     test("configureCustomGatewayRoutes resolves managed functions on every reconcile", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restoreFetch = captureFetch(calls);


### PR DESCRIPTION
## Summary

- Preserve custom gateway routes' own CORS policy during tenant CORS updates, frontend registration, and shared auth-owner frontend reconciliation.
- Keep both explicit policies (including public static `cors: ["*"]`) and intentionally absent CORS unchanged.
- Continue updating system routes' tenant CORS; do not widen business API origins.

## Reproduction

Register a custom static font route with `cors: ["*"]`, then call `setCors` or register a frontend for the same project (or an application using it as the shared auth owner).

Previously, `projectRouteIds()` included custom routes and `setRouteCors()` replaced their persisted policy with the tenant frontend origins. Custom routes with no CORS also silently acquired a policy. This can occur during canonical gateway reconciliation after an apparently successful route update.

The fix makes the tenant-level CORS setter leave controlled custom routes alone. Custom route changes continue to be rendered through `configureCustomGatewayRoutes`.

## Verification

- Three new reconciliation regressions fail before the fix and pass afterward.
- `bun --no-env-file test tests/unit/gateway.service.test.ts tests/unit/gateway-route-builders.test.ts tests/unit/gateway-custom-routes.api.test.ts`: 109 pass, 0 fail.
- Management API `typecheck` passes.
- `git diff --check` passes.

No Management API runtime has been deployed from this branch. The related FA static-font operational configuration is separate from this source fix.
