### PR TITLE
feat(functions): publish atomic project release manifests

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -518,12 +518,13 @@ Version `0` is reserved for a listed legacy Function's active-version CAS token.
 The public CLI and Management API accept it only as the expected active version;
 immutable source reads and activation targets still require positive versions.
 
-Multi-Function atomic deployment is not currently available. Release runners
-must deploy each Function with its observed version and activation identity,
-stop on `OUTCOME_UNKNOWN`, and reconcile with `edge_functions list` plus an
-immutable `source --version <N>` read before retrying or applying reverse-order
-CAS compensation. The `edge_functions deploy_manifest --atomic` interface in
-the release-control automation specification is a proposed contract.
+Multi-Function release units are available through the opt-in Management
+`function-releases` API; see [project release manifests](project-release-manifest.md)
+for staging, atomic authority switching, recovery and in-flight semantics.
+The CLI `edge_functions deploy_manifest --atomic` interface remains proposed.
+Existing per-function runners must still stop on `OUTCOME_UNKNOWN` and
+reconcile with `edge_functions list` plus immutable version reads. They cannot
+mutate members already enrolled in a project release individually.
 
 The readback contract stays simple for automation: `edge_functions list`
 prints a JSON array whose entries have a string `slug` and a non-negative safe

--- a/docs/project-release-manifest.md
+++ b/docs/project-release-manifest.md
@@ -1,0 +1,72 @@
+# Multi-function release units
+
+## Acceptance contract
+
+```gherkin
+Scenario: All candidates are ready before a generation is visible
+  Given two immutable function versions and the expected project release ID
+  When either foreground or background preheat fails
+  Then the active project manifest is unchanged
+
+Scenario: One publication wins a concurrent compare-and-swap
+  Given two publishers use the same expected release ID
+  When both publish
+  Then exactly one replaces the project authority
+  And the other receives a conflict without changing any member
+
+Scenario: Interruption and lost responses do not repeat a publication
+  Given a durable mutation and immutable release generation
+  When the process stops before or after the authority rename
+  Then status identifies the current authoritative release
+  And replay with the same mutation reads back or resumes that generation
+
+Scenario: A release cannot be bypassed with individual activation
+  Given functions belong to an active release unit
+  When a single-function deploy, config update, activation or delete is requested
+  Then it is rejected and staging a new immutable version remains available
+```
+
+The release authority is a single fsync-backed `.project-release.json` rename.
+It references immutable function versions and includes the complete previously
+enrolled member set. Additional functions can be enrolled. Removing enrolled
+members is not supported. Use a new release containing previous versions to
+roll back; do not edit history or remove the authority file.
+
+Requests resolved before a switch may finish on their selected immutable
+version. A request racing the final authority check may fail with the existing
+runtime-changed response. Separate HTTP requests are not a cross-request
+transaction. Pinned background tasks retain their original immutable version.
+Runtime restart reloads the durable authority, not a memory-only switch.
+
+Preheat runs for every immutable candidate in both runtime pools before
+publication. It validates the existing artifact/environment attestation.
+It does not promise that every subsequent worker is hot: eviction, scaling,
+runtime restart and the new activation cache identity can require re-import.
+Function module initialization must be side-effect free, as for existing preheat.
+
+This is opt-in for a shared trusted functions filesystem, not a distributed
+transaction across independent runtime hosts or filesystems. Deploy a runtime
+supporting the manifest before using the API. Old runtimes are rejected by
+the release-capability check. No database, queue or external side effect is
+made atomic by this mechanism.
+
+## API
+
+Authenticated project/admin APIs:
+
+- `POST /v1/projects/:ref/functions/:slug/stage`: `{code, config?}` returns
+  `version` and `artifact_sha256` without changing the active version.
+- `GET /v1/projects/:ref/function-releases`: active ID, generation and members.
+- `POST /v1/projects/:ref/function-releases`: `{mutation_id,
+  expected_release_id, functions:[{slug,version,expected_activation_id}]}`.
+  Use null for the first expected release ID; per-member IDs come from the
+  existing function state API. All previously enrolled members are required.
+- `GET /v1/projects/:ref/function-releases/:mutationId`: active authority and
+  durable mutation status. A lost response is not a reason for a new ID.
+
+After an interrupted unpublished preparation, resubmit the exact same request
+and mutation ID after its lease expires (maximum one hour). After publication
+with an unknown receipt, the same request confirms disk durability and
+reconciles the receipt without repeating publication. No background retry loop
+automatically publishes a release. Unresolved mutations block other release
+mutations for the project.

--- a/packages/edge-runtime/project-release.ts
+++ b/packages/edge-runtime/project-release.ts
@@ -1,0 +1,59 @@
+import { basename, join } from "node:path";
+import { createHash } from "node:crypto";
+import { readFunctionFile } from "./trusted-function-files";
+import { parseEdgeFunctionActivationManifest } from "./function-activation";
+
+const PROJECT_RELEASE_FILE = ".project-release.json";
+const UUID = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) =>
+    `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`).join(",")}}`;
+}
+
+function releaseMembers(raw: string, projectRef: string) {
+  if (Buffer.byteLength(raw) > 1024 * 1024) throw new Error("Release manifest exceeds 1 MiB");
+  const document = JSON.parse(raw);
+  if (!document || typeof document !== "object" || Array.isArray(document)) throw new Error("Invalid release manifest");
+  const { _supacloud_activation: authority, ...release } = document;
+  const parsed = parseEdgeFunctionActivationManifest(JSON.stringify({ version: "1", _supacloud_activation: authority }));
+  if (!parsed.authority || parsed.authority.target_state !== "active"
+    || release.schema !== "supacloud.project-function-release.v1" || release.project_ref !== projectRef
+    || !UUID.test(release.mutation_id) || release.mutation_id !== parsed.authority.activation_id
+    || typeof release.request_fingerprint !== "string" || !/^[a-f0-9]{64}$/.test(release.request_fingerprint)
+    || createHash("sha256").update(canonicalJson(release)).digest("hex") !== parsed.authority.artifact_sha256
+    || !release.members || typeof release.members !== "object" || Array.isArray(release.members)) {
+    throw new Error("Release manifest identity or digest is invalid");
+  }
+  const entries = Object.entries(release.members);
+  if (entries.length < 1 || entries.length > 128) throw new Error("Invalid release member count");
+  const members = new Map<string, ReturnType<typeof parseEdgeFunctionActivationManifest>>();
+  for (const [slug, rawMember] of entries) {
+    const member = rawMember as { config?: Record<string, unknown>; authority?: unknown } | null;
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(slug) || slug === "_project-release" || !member?.config || !member.authority) {
+      throw new Error("Invalid release member");
+    }
+    const manifest = parseEdgeFunctionActivationManifest(JSON.stringify({
+      ...member.config, _supacloud_activation: member.authority,
+    }));
+    if (manifest.authority?.target_state !== "active" || !manifest.config.version
+      || !/^[1-9]\d*$/.test(manifest.config.version) || !Number.isSafeInteger(Number(manifest.config.version))) {
+      throw new Error("Release member must identify an immutable positive version");
+    }
+    members.set(slug, manifest);
+  }
+  return members;
+}
+
+export async function projectReleaseFunctionManifest(projectRoot: string, slug: string) {
+  let bytes: Buffer;
+  try {
+    bytes = (await readFunctionFile(join(projectRoot, PROJECT_RELEASE_FILE))).bytes;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  return releaseMembers(bytes.toString("utf8"), basename(projectRoot)).get(slug) ?? null;
+}

--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -10,6 +10,8 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { releaseAuthority, PROJECT_RELEASE_FILE, type ProjectRelease } from "../management-api/src/services/project-release-contract";
+import { replaceEdgeFunctionActivationManifest } from "../management-api/src/services/edge-function-activation-manifest";
 
 setDefaultTimeout(30_000);
 
@@ -424,6 +426,42 @@ afterAll(async () => {
 });
 
 describe("Edge Runtime function config boundary", () => {
+  test("advertises project release capability and fails closed on corrupt project authority", async () => {
+    const capability = await fetch(`${edgeBaseUrl}/internal/runtime-activation-epoch`, {
+      headers: { "x-supacloud-internal-auth": INTERNAL_TOKEN },
+    });
+    expect((await capability.json()).project_release_schema).toBe("supacloud.project-function-release.v1");
+    await writeLegacyFunction("release_corrupt", "must-not-run");
+    await writeFile(join(projectRoot, PROJECT_RELEASE_FILE), "{invalid");
+    try { await expectActivationFailsClosed("release_corrupt", "must-not-run"); }
+    finally { await rm(join(projectRoot, PROJECT_RELEASE_FILE)); }
+  });
+
+  test.skipIf(process.platform !== "linux")("resolves both release members after one authority rename and runtime restart", async () => {
+    const first = await installActivationCandidate({ slug: "release_first", version: "1", source: functionSource("first") });
+    const second = await installActivationCandidate({ slug: "release_second", version: "1", source: functionSource("second") });
+    const members = Object.fromEntries([["release_first", first], ["release_second", second]].map(([slug, entry]) => {
+      const raw = JSON.parse((entry as ActivationCandidate).manifest);
+      const { _supacloud_activation: authority, ...config } = raw;
+      return [slug, { config, authority }];
+    }));
+    const release: ProjectRelease = {
+      schema: "supacloud.project-function-release.v1", project_ref: PROJECT_REF,
+      mutation_id: randomUUID(), request_fingerprint: "a".repeat(64), members,
+    };
+    const manifestPath = join(projectRoot, PROJECT_RELEASE_FILE);
+    await replaceEdgeFunctionActivationManifest({ manifestPath, config: release, authority: releaseAuthority(release, null) });
+    try {
+      await expectValidFunctionResponse("release_first", "first", "1");
+      await expectValidFunctionResponse("release_second", "second", "1");
+      await stopEdgeRuntime();
+      await Promise.all([edgeStdout, edgeStderr]);
+      startEdgeRuntime(managementServer!.port);
+      await waitForEdgeRuntime();
+      await expectValidFunctionResponse("release_first", "first", "1");
+      await expectValidFunctionResponse("release_second", "second", "1");
+    } finally { await rm(manifestPath); }
+  });
   test("fails closed for malformed config without executing stale aliases", async () => {
     const invalidConfigs = [
       ["numeric", '{"verify_jwt":false,"version":1}'],

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -1,4 +1,5 @@
 import "./url-import-plugin";
+import { projectReleaseFunctionManifest } from "./project-release";
 import { Elysia } from "elysia";
 import cors from "@elysiajs/cors";
 import {
@@ -772,6 +773,9 @@ async function getFunctionConfig(
   projectRoot: string,
 ): Promise<FunctionConfig> {
   const key = `${projectRef}/${functionName}`;
+  if (await projectReleaseFunctionManifest(projectRoot, functionName)) {
+    return activeFunctionConfig(projectRoot, functionName);
+  }
   const cached = configCache.get(key);
   if (cached && cached.expiresAt > Date.now()) {
     return {
@@ -978,6 +982,8 @@ async function activeActivationManifest(
   projectRoot: string,
   functionName: string,
 ): Promise<EdgeFunctionActivationManifest> {
+  const releaseMember = await projectReleaseFunctionManifest(projectRoot, functionName);
+  if (releaseMember) return releaseMember;
   const configPath = path.resolve(projectRoot, `${functionName}.config.json`);
   return await readFunctionActivationManifest(configPath, projectRoot)
     ?? parseEdgeFunctionActivationManifest("{}");
@@ -1582,6 +1588,7 @@ const app = new Elysia()
     const authError = requireInternalAuth(c.request);
     if (authError) return authError;
     return {
+      project_release_schema: "supacloud.project-function-release.v1",
       runtime_instance_id: RUNTIME_INSTANCE_ID,
       foreground_generation: pool.generation,
       background_generation: backgroundPool.generation,

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -232,12 +232,16 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     if (denied) return denied;
     const { projectReleaseService } = await import("../services/project-release.service");
     return projectReleaseService.status(params.ref);
+  }, {
+    detail: { tags: ["frontend"], summary: "Get the current function release status for a project" },
   })
   .get("/:ref/function-releases/:mutationId", async ({ params, request }) => {
     const denied = await requireFunctionManagementAuth(request, params.ref);
     if (denied) return denied;
     const { projectReleaseService } = await import("../services/project-release.service");
     return projectReleaseService.status(params.ref, params.mutationId);
+  }, {
+    detail: { tags: ["frontend"], summary: "Get a specific function release mutation status" },
   })
   .post("/:ref/function-releases", async ({ params, request, body }) => {
     const denied = await requireFunctionManagementAuth(request, params.ref);

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -1,6 +1,6 @@
 import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
-import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { requireProjectOrAdminAuth, getVerifiedRequestPrincipal } from "../middleware/auth";
 import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
 import {
   activeFunctionVersionNumber,
@@ -227,6 +227,57 @@ function activationConflict(error: unknown) {
 }
 
 export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
+  .get("/:ref/function-releases", async ({ params, request }) => {
+    const denied = await requireFunctionManagementAuth(request, params.ref);
+    if (denied) return denied;
+    const { projectReleaseService } = await import("../services/project-release.service");
+    return projectReleaseService.status(params.ref);
+  })
+  .get("/:ref/function-releases/:mutationId", async ({ params, request }) => {
+    const denied = await requireFunctionManagementAuth(request, params.ref);
+    if (denied) return denied;
+    const { projectReleaseService } = await import("../services/project-release.service");
+    return projectReleaseService.status(params.ref, params.mutationId);
+  })
+  .post("/:ref/function-releases", async ({ params, request, body }) => {
+    const denied = await requireFunctionManagementAuth(request, params.ref);
+    if (denied) return denied;
+    const principal = await getVerifiedRequestPrincipal(request);
+    if (!principal) return status(401, { error: "Verified release principal is required" });
+    const { projectReleaseService } = await import("../services/project-release.service");
+    return projectReleaseService.publish({
+      projectRef: params.ref, mutationId: body.mutation_id,
+      expectedReleaseId: body.expected_release_id, functions: body.functions, principal,
+    });
+  }, {
+    body: t.Object({
+      mutation_id: t.String({ format: "uuid" }),
+      expected_release_id: t.Union([t.Null(), t.String({ format: "uuid" })]),
+      functions: t.Array(t.Object({
+        slug: t.String({ pattern: "^[A-Za-z0-9_-]{1,128}$" }),
+        version: functionVersionSchema, expected_activation_id: expectedActivationIdSchema,
+      }, { additionalProperties: false }), { minItems: 1, maxItems: 128 }),
+    }, { additionalProperties: false }),
+    detail: { tags: ["frontend"], summary: "Publish an atomic multi-function release manifest" },
+  })
+  .post("/:ref/functions/:slug/stage", async ({ params, request, body }) => {
+    const denied = await requireFunctionManagementAuth(request, params.ref);
+    if (denied) return denied;
+    const { edgeFunctionService } = await import("../services/edge-function.service");
+    return edgeFunctionService.stageVersion({
+      ref: params.ref, slug: params.slug, code: body.code, config: body.config,
+    });
+  }, {
+    body: t.Object({
+      code: t.String({ minLength: 1, maxLength: 10 * 1024 * 1024 }),
+      config: t.Optional(t.Object({
+        verify_jwt: t.Optional(t.Boolean()), framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+        background_routes: t.Optional(t.Array(t.String(), { maxItems: 128 })),
+        capabilities: t.Optional(functionCapabilitiesSchema), limits: t.Optional(functionLimitsSchema),
+      }, { additionalProperties: false })),
+    }, { additionalProperties: false }),
+    detail: { tags: ["frontend"], summary: "Stage an immutable function version without activation" },
+  })
   .get(
     "/:ref/functions",
     async ({ params, request }) => {

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1,11 +1,15 @@
 import { logger } from "../utils/logger";
 import { config } from "../config";
-import { ServiceUnavailableError } from "../utils/errors";
+import { ConflictError, ServiceUnavailableError } from "../utils/errors";
 import { normalizeEdgeRuntimeBundle } from "./edge-runtime-bundle";
 import path from "path";
 import fs from "fs/promises";
 import type { Dirent } from "node:fs";
 import { acquireSupaCloudUpgradeLock, type SupaCloudUpgradeLock } from "../upgrade-lock";
+import {
+  parseProjectRelease, PROJECT_RELEASE_FILE, PROJECT_RELEASE_SLUG,
+  type ProjectReleaseSnapshot, type ReleaseMember,
+} from "./project-release-contract";
 import { isSystemManagedProjectSecretName } from "../utils/project-secret-visibility";
 import {
   validateEdgeRuntimePreheat,
@@ -424,7 +428,17 @@ async function preflightAndAcquireFunctionDeployLock(
   slug: string,
 ): Promise<() => void> {
   await preflightFunctionMutation(ref, slug);
-  return acquireFunctionDeployLock(ref, slug);
+  const release = await acquireFunctionDeployLock(ref, slug);
+  try {
+    const manifest = await readProjectFunctionRelease(ref);
+    if (manifest && Object.hasOwn(manifest.release.members, slug)) {
+      throw new ConflictError("Function belongs to a project release; stage a version and publish a release manifest");
+    }
+    return release;
+  } catch (error) {
+    release();
+    throw error;
+  }
 }
 
 function getFunctionsRoot(): string {
@@ -771,6 +785,11 @@ async function readFunctionManifestState(
   slug: string,
 ): Promise<FunctionManifestState> {
   try {
+    const release = await readProjectFunctionRelease(ref);
+    const member = release && Object.hasOwn(release.release.members, slug) ? release.release.members[slug] : undefined;
+    if (member) return {
+      config: validatedFunctionConfig(member.config), authority: member.authority, hadManifest: true,
+    };
     const raw = await Bun.file(getConfigPath(ref, slug)).text();
     const manifest = parseEdgeFunctionActivationManifest(raw);
     return {
@@ -2631,7 +2650,99 @@ async function deployLatestFunctionRelease(
   }
 }
 
+export async function readProjectFunctionRelease(ref: string): Promise<ProjectReleaseSnapshot | null> {
+  const manifestPath = path.join(getFuncDir(ref), PROJECT_RELEASE_FILE);
+  try {
+    const metadata = await fs.lstat(manifestPath);
+    if (!metadata.isFile() || metadata.nlink !== 1 || (metadata.mode & 0o022) !== 0) {
+      throw new Error("Project release authority must be a trusted regular file");
+    }
+    return parseProjectRelease(await fs.readFile(manifestPath, "utf8"), ref);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export function projectFunctionDirectory(ref: string): string { return getFuncDir(ref); }
+
+export async function withProjectFunctionReleaseLock<T>(
+  ref: string, slugs: string[], operation: () => Promise<T>,
+): Promise<T> {
+  const releases: Array<() => void> = [];
+  try {
+    for (const slug of [PROJECT_RELEASE_SLUG, ...[...new Set(slugs)].sort()]) {
+      await preflightFunctionMutation(ref, slug);
+      releases.push(await acquireFunctionDeployLock(ref, slug));
+    }
+    return await operation();
+  } finally {
+    for (const release of releases.reverse()) release();
+  }
+}
+
+export async function prepareProjectReleaseMembers(
+  ref: string,
+  functions: Array<{ slug: string; version: string; expected_activation_id: string }>,
+): Promise<Record<string, ReleaseMember>> {
+  const epoch = async () => {
+    const response = await fetch(`http://${config.edgeRuntimeInternal}/internal/runtime-activation-epoch`, {
+      headers: runtimeInternalHeaders(), redirect: "error", signal: AbortSignal.timeout(5000),
+    });
+    const body = await readRuntimeControlBody(response);
+    if (!response.ok || body.project_release_schema !== "supacloud.project-function-release.v1") {
+      throw new Error("Edge Runtime does not support project release manifests");
+    }
+    return body;
+  };
+  const before = await epoch();
+  const members: Record<string, ReleaseMember> = Object.create(null);
+  for (const entry of functions) {
+    const state = await readFunctionManifestState(ref, entry.slug);
+    if (publicActivationId(state.authority) !== entry.expected_activation_id) {
+      throw new ConflictError("Release member activation CAS conflict");
+    }
+    await settleRuntimeFunctionActivation(ref, entry.slug, state);
+    const metadata = await readFunctionVersionMetadata(ref, entry.slug, entry.version);
+    const bundle = await readVersionedFunctionCode(ref, entry.slug, entry.version);
+    if (bundle === null || await sha256Hex(bundle) !== metadata.artifact_sha256) {
+      throw new Error("Release artifact does not match immutable metadata");
+    }
+    const nextConfig = validatedFunctionConfig({ ...restoredFunctionConfig({ verify_jwt: true }, metadata) });
+    const readiness = await preheatRuntimeFunction({
+      projectRef: ref, functionSlug: entry.slug, requestedVersion: entry.version,
+      resolvedVersion: entry.version, artifactSha256: metadata.artifact_sha256,
+      verifyJwt: nextConfig.verify_jwt, activationId: null,
+    });
+    const proof = requiredPreheatAttestation(readiness, "project release readiness");
+    if (proof.identity.runtimeInstanceId !== before.runtime_instance_id) {
+      throw new Error("Runtime restarted during project release preheat");
+    }
+    members[entry.slug] = {
+      config: activationConfigRecord(nextConfig),
+      authority: nextFunctionActivationAuthority(state, metadata.artifact_sha256),
+    };
+  }
+  const after = await epoch();
+  if (after.runtime_instance_id !== before.runtime_instance_id
+    || after.foreground_generation !== before.foreground_generation
+    || after.background_generation !== before.background_generation) {
+    throw new Error("Runtime pools changed during project release preheat");
+  }
+  return members;
+}
+
 export const edgeFunctionService = {
+  async stageVersion(request: EdgeFunctionReleaseRequest) {
+    await preflightFunctionMutation(request.ref, request.slug);
+    const unlock = await acquireFunctionDeployLock(request.ref, request.slug);
+    try {
+      const state = await readFunctionManifestState(request.ref, request.slug);
+      const version = await computeNextFunctionVersion(request.ref, request.slug);
+      const staged = await immutableFunctionVersion(request, version, state.config);
+      return { version, artifact_sha256: staged.prepared.artifactSha256 };
+    } finally { unlock(); }
+  },
   async getActiveVersion(ref: string, slug: string): Promise<EdgeFunctionActiveVersion> {
     return activeFunctionVersion(ref, slug);
   },

--- a/packages/management-api/src/services/project-release-contract.ts
+++ b/packages/management-api/src/services/project-release-contract.ts
@@ -1,0 +1,56 @@
+import { stableSha256 } from "../utils/stable-json";
+import {
+  EDGE_FUNCTION_ACTIVATION_SCHEMA, parseEdgeFunctionActivationManifest,
+  type EdgeFunctionActivationAuthority,
+} from "./edge-function-activation-manifest";
+
+export const PROJECT_RELEASE_SCHEMA = "supacloud.project-function-release.v1";
+export const PROJECT_RELEASE_FILE = ".project-release.json";
+export const PROJECT_RELEASE_SLUG = "_project-release";
+export const RELEASE_ID = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
+export type ReleaseMember = { config: Record<string, unknown>; authority: EdgeFunctionActivationAuthority };
+export type ProjectRelease = {
+  schema: typeof PROJECT_RELEASE_SCHEMA;
+  project_ref: string;
+  mutation_id: string;
+  request_fingerprint: string;
+  members: Record<string, ReleaseMember>;
+};
+export type ProjectReleaseSnapshot = { release: ProjectRelease; authority: EdgeFunctionActivationAuthority };
+
+export function releaseAuthority(release: ProjectRelease, previous: ProjectReleaseSnapshot | null): EdgeFunctionActivationAuthority {
+  return {
+    schema: EDGE_FUNCTION_ACTIVATION_SCHEMA, activation_id: release.mutation_id,
+    activation_generation: (previous?.authority.activation_generation ?? 0) + 1,
+    previous_activation_id: previous?.authority.activation_id ?? null,
+    target_state: "active", artifact_sha256: stableSha256(release),
+  };
+}
+
+export function parseProjectRelease(raw: string, projectRef: string): ProjectReleaseSnapshot {
+  if (Buffer.byteLength(raw) > 1024 * 1024) throw new Error("Release manifest exceeds 1 MiB");
+  const { config, authority } = parseEdgeFunctionActivationManifest(raw);
+  if (!authority || config.schema !== PROJECT_RELEASE_SCHEMA || config.project_ref !== projectRef
+    || config.mutation_id !== authority.activation_id || !RELEASE_ID.test(String(config.mutation_id))
+    || !/^[a-f0-9]{64}$/.test(String(config.request_fingerprint))
+    || !config.members || typeof config.members !== "object" || Array.isArray(config.members)
+    || stableSha256(config) !== authority.artifact_sha256 || authority.target_state !== "active") {
+    throw new Error("Release manifest identity or digest is invalid");
+  }
+  const entries = Object.entries(config.members);
+  if (entries.length < 1 || entries.length > 128) throw new Error("Release must contain 1-128 functions");
+  for (const [slug, member] of entries) {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(slug) || slug === PROJECT_RELEASE_SLUG
+      || !member || typeof member !== "object" || !member.config || !member.authority) {
+      throw new Error("Release member is invalid");
+    }
+    const parsed = parseEdgeFunctionActivationManifest(JSON.stringify({
+      ...member.config, _supacloud_activation: member.authority,
+    }));
+    if (parsed.authority?.target_state !== "active" || typeof parsed.config.version !== "string"
+      || !/^[1-9]\d*$/.test(parsed.config.version) || !Number.isSafeInteger(Number(parsed.config.version))) {
+      throw new Error("Release member must identify an immutable positive version");
+    }
+  }
+  return { release: config as ProjectRelease, authority };
+}

--- a/packages/management-api/src/services/project-release-mutation.ts
+++ b/packages/management-api/src/services/project-release-mutation.ts
@@ -1,0 +1,63 @@
+import { sql } from "../db";
+import { ConflictError } from "../utils/errors";
+import {
+  beginProjectMutation, claimOrResumeProjectMutation, completeProjectMutationFailure,
+  completeProjectMutationSuccess, readProjectMutation, reconcileProjectMutation, withProjectMutationLease,
+  type BeginProjectMutationInput, type MutationLeaseInput, type ProjectMutationState,
+} from "./project-mutation.service";
+
+export interface ReleaseMutationStore {
+  begin(input: BeginProjectMutationInput): Promise<{ state: ProjectMutationState; lease?: MutationLeaseInput }>;
+  protect(lease: MutationLeaseInput, action: () => Promise<void>): Promise<void>;
+  success(lease: MutationLeaseInput, receipt: Record<string, unknown>): Promise<void>;
+  failure(lease: MutationLeaseInput, uncertain: boolean, terminal?: boolean): Promise<void>;
+  recover(state: ProjectMutationState, fingerprint: string): Promise<void>;
+  read(projectRef: string, mutationId: string): Promise<ProjectMutationState | null>;
+}
+
+export const projectReleaseMutations: ReleaseMutationStore = {
+  begin: (input) => sql.begin(async (db) => {
+    const begun = await beginProjectMutation(db, input);
+    if (begun.kind !== "started" && begun.kind !== "replay") throw new ConflictError(`Release mutation ${begun.kind}`);
+    if (["succeeded", "outcome_unknown", "failed_terminal"].includes(begun.mutation.status)) {
+      return { state: begun.mutation };
+    }
+    const leaseToken = crypto.randomUUID();
+    const claim = await claimOrResumeProjectMutation(db, {
+      projectRef: input.projectRef, mutationId: input.mutationId,
+      leaseOwner: `project-release-${process.pid}`, leaseToken, leaseSeconds: 3600,
+    });
+    if (claim.kind !== "claimed") throw new ConflictError("Release mutation is busy");
+    return { state: claim.mutation, lease: {
+      projectRef: input.projectRef, mutationId: input.mutationId,
+      leaseToken, fencingEpoch: claim.mutation.fencingEpoch,
+    } };
+  }),
+  protect: async (lease, action) => {
+    const result = await sql.begin((db) => withProjectMutationLease(db, lease, action));
+    if (result.kind !== "executed") throw new Error("Release mutation lease lost");
+  },
+  success: async (lease, receipt) => {
+    const result = await sql.begin((db) => completeProjectMutationSuccess(db, { ...lease, receipt, responseStatus: 200 }));
+    if (result !== "updated") throw new Error("Release success receipt lease lost");
+  },
+  failure: async (lease, uncertain, terminal) => {
+    const result = await sql.begin((db) => completeProjectMutationFailure(db, {
+      ...lease, status: uncertain ? "outcome_unknown" : terminal ? "failed_terminal" : "failed_retryable",
+      failureCode: uncertain ? "RELEASE_OUTCOME_UNKNOWN" : "RELEASE_PREPARE_FAILED", responseStatus: 503,
+    }));
+    if (result !== "updated") throw new Error("Release failure receipt lease lost");
+  },
+  recover: async (state, fingerprint) => {
+    const result = await sql.begin((db) => reconcileProjectMutation(db, state.principal, {
+      projectRef: state.projectRef, mutationId: state.mutationId,
+      expectedFencingEpoch: state.fencingEpoch, status: "succeeded", responseStatus: 200,
+      evidence: {
+        source: "project.release.authority", observedAt: new Date().toISOString(),
+        evidenceCode: "RELEASE_AUTHORITY_CONFIRMED", evidenceFingerprint: fingerprint,
+      },
+    }));
+    if (result.kind !== "updated") throw new Error("Release recovery receipt was not confirmed");
+  },
+  read: (projectRef, mutationId) => readProjectMutation({ projectRef, mutationId }),
+};

--- a/packages/management-api/src/services/project-release.service.ts
+++ b/packages/management-api/src/services/project-release.service.ts
@@ -1,0 +1,162 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  edgeFunctionActivationGenerationPath, writeEdgeFunctionActivationGeneration,
+  replaceEdgeFunctionActivationManifest, confirmEdgeFunctionActivationManifestDurable,
+} from "./edge-function-activation-manifest";
+import {
+  PROJECT_RELEASE_FILE, PROJECT_RELEASE_SCHEMA, PROJECT_RELEASE_SLUG, RELEASE_ID,
+  parseProjectRelease, releaseAuthority, type ProjectRelease, type ProjectReleaseSnapshot,
+} from "./project-release-contract";
+import {
+  prepareProjectReleaseMembers, projectFunctionDirectory, readProjectFunctionRelease,
+  withProjectFunctionReleaseLock,
+} from "./edge-function.service";
+import { projectMutationFingerprint, type MutationPrincipal } from "./project-mutation.service";
+import { projectReleaseMutations, type ReleaseMutationStore } from "./project-release-mutation";
+import { ConflictError, ValidationError } from "../utils/errors";
+
+export interface PublishProjectReleaseInput {
+  projectRef: string;
+  mutationId: string;
+  expectedReleaseId: string | null;
+  functions: Array<{ slug: string; version: string; expected_activation_id: string }>;
+  principal: MutationPrincipal;
+}
+
+function normalize(input: PublishProjectReleaseInput): PublishProjectReleaseInput {
+  if (!/^[A-Za-z0-9_-]{1,20}$/.test(input.projectRef) || !RELEASE_ID.test(input.mutationId)
+    || (input.expectedReleaseId !== null && !RELEASE_ID.test(input.expectedReleaseId))
+    || !Array.isArray(input.functions) || input.functions.length < 1 || input.functions.length > 128) {
+    throw new ValidationError("Invalid release identity or member count");
+  }
+  const functions = input.functions.map(({ slug, version, expected_activation_id }) => {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(slug) || slug === PROJECT_RELEASE_SLUG
+      || !/^[1-9]\d*$/.test(version) || !Number.isSafeInteger(Number(version))
+      || (expected_activation_id !== "legacy" && !RELEASE_ID.test(expected_activation_id))) {
+      throw new ValidationError("Invalid release member");
+    }
+    return { slug, version, expected_activation_id };
+  }).sort((a, b) => a.slug.localeCompare(b.slug));
+  if (new Set(functions.map((entry) => entry.slug)).size !== functions.length) throw new ValidationError("Duplicate release function");
+  return { ...input, functions };
+}
+
+interface ReleaseDependencies {
+  directory: typeof projectFunctionDirectory;
+  current: typeof readProjectFunctionRelease;
+  lock: typeof withProjectFunctionReleaseLock;
+  prepare: typeof prepareProjectReleaseMembers;
+  mutations: ReleaseMutationStore;
+  interruption?: (phase: "prepared" | "published") => void;
+}
+
+export class ProjectReleaseService {
+  constructor(private readonly deps: ReleaseDependencies = {
+    directory: projectFunctionDirectory, current: readProjectFunctionRelease,
+    lock: withProjectFunctionReleaseLock, prepare: prepareProjectReleaseMembers, mutations: projectReleaseMutations,
+  }) {}
+
+  async status(projectRef: string, mutationId?: string) {
+    if (!/^[A-Za-z0-9_-]{1,20}$/.test(projectRef) || (mutationId && !RELEASE_ID.test(mutationId))) {
+      throw new Error("Invalid release status identity");
+    }
+    const active = await this.deps.current(projectRef);
+    const mutation = mutationId ? await this.deps.mutations.read(projectRef, mutationId) : null;
+    return {
+      project_ref: projectRef, active_release_id: active?.release.mutation_id ?? null,
+      generation: active?.authority.activation_generation ?? 0,
+      functions: active ? Object.entries(active.release.members).map(([slug, member]) => ({
+        slug, version: member.config.version, activation_id: member.authority.activation_id,
+      })) : [],
+      mutation: mutation ? { mutation_id: mutation.mutationId, status: mutation.status, failure_code: mutation.failureCode } : null,
+    };
+  }
+
+  async publish(raw: PublishProjectReleaseInput) {
+    const input = normalize(raw);
+    const fingerprint = projectMutationFingerprint({
+      project_ref: input.projectRef, expected_release_id: input.expectedReleaseId, functions: input.functions,
+    });
+    return this.deps.lock(input.projectRef, input.functions.map((entry) => entry.slug), async () => {
+      const { state, lease } = await this.deps.mutations.begin({
+        projectRef: input.projectRef, mutationId: input.mutationId,
+        operation: "functions.release.publish", resource: { type: "function_release", id: "project" },
+        requestFingerprint: fingerprint, principal: input.principal,
+      });
+      const directory = this.deps.directory(input.projectRef);
+      const manifestPath = join(directory, PROJECT_RELEASE_FILE);
+      let publishAttempted = false;
+      try {
+        const current = await this.deps.current(input.projectRef);
+        if (state.status === "succeeded") return { ...(await this.status(input.projectRef, input.mutationId)), replayed: true };
+        // 响应丢失后只回读、确认持久化并补回执，不重新执行发布。
+        if (current?.release.mutation_id === input.mutationId) {
+          publishAttempted = true;
+          if (current.release.request_fingerprint !== fingerprint) throw new Error("Release authority fingerprint conflict");
+          await confirmEdgeFunctionActivationManifestDurable(manifestPath, input.mutationId);
+          if (state.status === "outcome_unknown") await this.deps.mutations.recover(state, fingerprint);
+          else if (lease) await this.deps.mutations.success(lease, this.receipt(current));
+          else throw new Error("Release mutation cannot be reconciled");
+          return { ...(await this.status(input.projectRef, input.mutationId)), replayed: true };
+        }
+        if (!lease || state.status === "outcome_unknown") throw new Error("Release outcome requires authoritative reconciliation");
+        if ((current?.release.mutation_id ?? null) !== input.expectedReleaseId) throw new ConflictError("Release CAS conflict");
+        const requested = new Set(input.functions.map((entry) => entry.slug));
+        if (current && Object.keys(current.release.members).some((slug) => !requested.has(slug))) {
+          throw new ConflictError("Release must include all previously enrolled functions");
+        }
+        let candidate: ProjectReleaseSnapshot | null = null;
+        const generationPath = edgeFunctionActivationGenerationPath(directory, PROJECT_RELEASE_SLUG, input.mutationId);
+        try { candidate = parseProjectRelease(await readFile(generationPath, "utf8"), input.projectRef); }
+        catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+        // 重启后重新核验版本、租户环境和预热；已有候选的身份不得重写。
+        const prepared = await this.deps.prepare(input.projectRef, input.functions);
+        if (candidate) {
+          if (candidate.release.request_fingerprint !== fingerprint
+            || candidate.authority.previous_activation_id !== input.expectedReleaseId
+            || candidate.authority.activation_generation !== (current?.authority.activation_generation ?? 0) + 1
+            || projectMutationFingerprint(Object.fromEntries(Object.entries(prepared).map(([slug, member]) => [slug, { config: member.config, digest: member.authority.artifact_sha256 }])))
+              !== projectMutationFingerprint(Object.fromEntries(Object.entries(candidate.release.members).map(([slug, member]) => [slug, { config: member.config, digest: member.authority.artifact_sha256 }])))) {
+            throw new Error("Release candidate does not match recovered request");
+          }
+        } else {
+          const release: ProjectRelease = {
+            schema: PROJECT_RELEASE_SCHEMA, project_ref: input.projectRef, mutation_id: input.mutationId,
+            request_fingerprint: fingerprint, members: prepared,
+          };
+          candidate = { release, authority: releaseAuthority(release, current) };
+          await writeEdgeFunctionActivationGeneration({
+            projectDirectory: directory, functionSlug: PROJECT_RELEASE_SLUG,
+            config: release, authority: candidate.authority,
+          });
+        }
+        this.deps.interruption?.("prepared");
+        await this.deps.mutations.protect(lease, async () => {
+          if (((await this.deps.current(input.projectRef))?.release.mutation_id ?? null) !== input.expectedReleaseId) {
+            throw new ConflictError("Release CAS conflict at publication");
+          }
+          publishAttempted = true;
+          await replaceEdgeFunctionActivationManifest({
+            manifestPath, config: candidate!.release, authority: candidate!.authority,
+          });
+        });
+        this.deps.interruption?.("published");
+        await this.deps.mutations.success(lease, this.receipt(candidate));
+        return { ...(await this.status(input.projectRef, input.mutationId)), replayed: false };
+      } catch (error) {
+        if (lease) await this.deps.mutations.failure(lease, publishAttempted, error instanceof ConflictError);
+        throw error;
+      }
+    });
+  }
+
+  private receipt(snapshot: ProjectReleaseSnapshot) {
+    return {
+      schema: PROJECT_RELEASE_SCHEMA, release_id: snapshot.release.mutation_id,
+      generation: snapshot.authority.activation_generation, manifest_sha256: snapshot.authority.artifact_sha256,
+    };
+  }
+}
+
+export const projectReleaseService = new ProjectReleaseService();

--- a/packages/management-api/tests/unit/project-release-preheat.test.ts
+++ b/packages/management-api/tests/unit/project-release-preheat.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const root = await mkdtemp(join(homedir(), ".supacloud-release-preheat-"));
+const oldDirectory = process.env.EDGE_FUNCTIONS_DIR;
+process.env.EDGE_FUNCTIONS_DIR = root;
+const { edgeFunctionService, prepareProjectReleaseMembers } = await import("../../src/services/edge-function.service");
+afterAll(async () => {
+  if (oldDirectory === undefined) delete process.env.EDGE_FUNCTIONS_DIR;
+  else process.env.EDGE_FUNCTIONS_DIR = oldDirectory;
+  await rm(root, { recursive: true, force: true });
+});
+
+test("production preparation validates both pools against staged immutable artifacts", async () => {
+  const ref = "releasepreheat";
+  const staged = new Map<string, { version: string; artifact_sha256: string }>();
+  for (const slug of ["one", "two"]) {
+    staged.set(slug, await edgeFunctionService.stageVersion({
+      ref, slug, code: `export default () => new Response("${slug}");`,
+    }));
+    expect(await edgeFunctionService.getActiveVersion(ref, slug)).toBe("absent");
+  }
+  const originalFetch = globalThis.fetch;
+  const instance = crypto.randomUUID();
+  let corrupt = false;
+  let preheats = 0;
+  globalThis.fetch = (async (input, init) => {
+    expect(init?.redirect).toBe("error");
+    const url = new URL(String(input));
+    if (url.pathname === "/internal/runtime-activation-epoch") return Response.json({
+      project_release_schema: "supacloud.project-function-release.v1",
+      runtime_instance_id: instance, foreground_generation: 0, background_generation: 0,
+    });
+    const slug = url.pathname.split("/").at(-1)!;
+    const artifact = staged.get(slug)!;
+    expect(url.pathname).toBe(`/preheat/${ref}/${slug}`);
+    preheats++;
+    const identity = {
+      schema: "supacloud.edge-runtime-preheat-attestation.v1", project_ref: ref, function_slug: slug,
+      requested_version: artifact.version, target_version: artifact.version, resolved_version: artifact.version,
+      artifact_sha256: artifact.artifact_sha256, verify_jwt: true, activation_id: null,
+      runtime_instance_id: instance, execution_profile: "foreground",
+      module_env_proof: `hmac-sha256:${"c".repeat(64)}`, module_loaded: true,
+      tenant_env: { loaded_revision: `hmac-sha256:${"a".repeat(64)}`, env_proof: `hmac-sha256:${"b".repeat(64)}`, load_state: "loaded", load_source: "management_api" },
+    };
+    const pool = (attestation: object) => ({
+      attempted: 1, succeeded: 1, cacheHits: 0, cacheMisses: 1, durationMs: 1, attestation,
+      rotation: { generation: 0, attempted: 0, idleRetired: 0, busyTainted: 0, alreadyTainted: 0, immediateReplacements: 0 },
+    });
+    return Response.json({
+      preheated: `${ref}_${slug}_v${artifact.version}`, version: artifact.version, success: true,
+      attestation: identity, foreground: pool(identity),
+      background: pool({
+        ...identity, execution_profile: "background", module_env_proof: `hmac-sha256:${"d".repeat(64)}`,
+        project_ref: corrupt ? "foreign" : ref,
+      }),
+    });
+  }) as typeof fetch;
+  const functions = [...staged].map(([slug, artifact]) => ({ slug, version: artifact.version, expected_activation_id: "legacy" }));
+  try {
+    const prepared = await prepareProjectReleaseMembers(ref, functions);
+    expect(Object.keys(prepared)).toEqual(["one", "two"]);
+    expect(preheats).toBe(2);
+    corrupt = true;
+    await expect(prepareProjectReleaseMembers(ref, functions)).rejects.toThrow();
+    expect(await edgeFunctionService.getActiveVersion(ref, "one")).toBe("absent");
+  } finally { globalThis.fetch = originalFetch; }
+});

--- a/packages/management-api/tests/unit/project-release.test.ts
+++ b/packages/management-api/tests/unit/project-release.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ReleaseMutationStore } from "../../src/services/project-release-mutation";
+import type { ProjectMutationState } from "../../src/services/project-mutation.service";
+import { PROJECT_RELEASE_FILE, parseProjectRelease } from "../../src/services/project-release-contract";
+
+const root = await mkdtemp(join(homedir(), ".supacloud-project-release-test-"));
+const originalDirectory = process.env.EDGE_FUNCTIONS_DIR;
+process.env.EDGE_FUNCTIONS_DIR = root;
+const { ProjectReleaseService } = await import("../../src/services/project-release.service");
+const {
+  projectFunctionDirectory, readProjectFunctionRelease, withProjectFunctionReleaseLock, edgeFunctionService,
+} = await import("../../src/services/edge-function.service");
+const { projectReleaseFunctionManifest } = await import("../../../edge-runtime/project-release");
+afterAll(async () => {
+  if (originalDirectory === undefined) delete process.env.EDGE_FUNCTIONS_DIR;
+  else process.env.EDGE_FUNCTIONS_DIR = originalDirectory;
+  await rm(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const projectRef = crypto.randomUUID().replaceAll("-", "").slice(0, 20);
+  const states = new Map<string, ProjectMutationState>();
+  let preheats = 0;
+  let failPrepare = false;
+  let loseLease = false;
+  let interruption: "prepared" | "published" | null = null;
+  const mutations: ReleaseMutationStore = {
+    async begin(input) {
+      const old = states.get(input.mutationId);
+      if (old && old.requestFingerprint !== input.requestFingerprint) throw new Error("fingerprint conflict");
+      const state: ProjectMutationState = old ?? {
+        ...input, resourceKey: null, status: "pending", checkpoint: {}, receipt: null,
+        responseStatus: null, failureCode: null, leaseOwner: null, leaseExpiresAt: null,
+        fencingEpoch: 0, completedAt: null, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      };
+      states.set(input.mutationId, state);
+      if (["succeeded", "outcome_unknown", "failed_terminal"].includes(state.status)) return { state };
+      state.status = "running";
+      return { state, lease: {
+        projectRef, mutationId: input.mutationId, leaseToken: crypto.randomUUID(), fencingEpoch: ++state.fencingEpoch,
+      } };
+    },
+    async protect(_lease, action) { if (loseLease) throw new Error("lease lost"); await action(); },
+    async success(lease, receipt) { Object.assign(states.get(lease.mutationId)!, { status: "succeeded", receipt }); },
+    async failure(lease, uncertain, terminal) {
+      states.get(lease.mutationId)!.status = uncertain ? "outcome_unknown" : terminal ? "failed_terminal" : "failed_retryable";
+    },
+    async recover(state) { state.status = "succeeded"; },
+    async read(_ref, id) { return states.get(id) ?? null; },
+  };
+  const service = new ProjectReleaseService({
+    directory: projectFunctionDirectory, current: readProjectFunctionRelease,
+    lock: withProjectFunctionReleaseLock, mutations,
+    async prepare(_ref, functions) {
+      preheats++;
+      if (failPrepare) throw new Error("preheat rejected");
+      return Object.fromEntries(functions.map(({ slug, version }) => [slug, {
+        config: { version, verify_jwt: true, framework: "fetch" },
+        authority: {
+          schema: "supacloud.edge-function-activation.v1" as const,
+          activation_id: crypto.randomUUID(), activation_generation: 1, previous_activation_id: null,
+          target_state: "active" as const, artifact_sha256: "a".repeat(64),
+        },
+      }]));
+    },
+    interruption(phase) { if (interruption === phase) { interruption = null; throw new Error(`interrupted ${phase}`); } },
+  });
+  const input = {
+    projectRef, mutationId: crypto.randomUUID(), expectedReleaseId: null,
+    functions: ["first", "second"].map((slug) => ({ slug, version: "1", expected_activation_id: "legacy" })),
+    principal: { type: "master" as const, id: "test-owner" },
+  };
+  return {
+    service, input, states, prepareCalls: () => preheats,
+    fail: () => { failPrepare = true; },
+    revoke: () => { loseLease = true; },
+    interrupt: (phase: "prepared" | "published") => { interruption = phase; },
+  };
+}
+
+test("one durable authority exposes the complete unit to Management and Edge", async () => {
+  const f = fixture();
+  const result = await f.service.publish(f.input);
+  expect(result.active_release_id).toBe(f.input.mutationId);
+  expect(result.functions.map((entry) => entry.slug)).toEqual(["first", "second"]);
+  for (const entry of result.functions) {
+    const runtime = await projectReleaseFunctionManifest(join(root, f.input.projectRef), entry.slug);
+    expect(runtime?.authority?.activation_id).toBe(entry.activation_id);
+    expect((await edgeFunctionService.getState(f.input.projectRef, entry.slug)).active_version).toBe("1");
+  }
+  expect((await f.service.publish(f.input)).replayed).toBe(true);
+  expect(f.prepareCalls()).toBe(1);
+  await expect(edgeFunctionService.updateConfig(f.input.projectRef, "first", { verify_jwt: false }, result.functions[0]!.activation_id))
+    .rejects.toThrow("belongs to a project release");
+  const staged = await edgeFunctionService.stageVersion({
+    ref: f.input.projectRef, slug: "first", code: 'export default () => new Response("staged");',
+  });
+  expect(staged.artifact_sha256).toMatch(/^[a-f0-9]{64}$/);
+  expect((await f.service.status(f.input.projectRef)).active_release_id).toBe(f.input.mutationId);
+});
+
+test("preheat failure or a lost lease never publishes", async () => {
+  for (const reason of ["prepare", "lease"]) {
+    const f = fixture();
+    if (reason === "prepare") f.fail(); else f.revoke();
+    await expect(f.service.publish(f.input)).rejects.toThrow();
+    expect((await f.service.status(f.input.projectRef)).active_release_id).toBeNull();
+  }
+});
+
+test("prepared interruption revalidates without replacing immutable candidate identity", async () => {
+  const f = fixture();
+  f.interrupt("prepared");
+  await expect(f.service.publish(f.input)).rejects.toThrow("interrupted prepared");
+  const path = join(root, f.input.projectRef, ".activation-generations", "_project-release", `${f.input.mutationId}.json`);
+  const before = await readFile(path, "utf8");
+  await f.service.publish(f.input);
+  expect(await readFile(path, "utf8")).toBe(before);
+  expect(f.prepareCalls()).toBe(2);
+});
+
+test("lost publication response is reconciled without a second preheat or switch", async () => {
+  const f = fixture();
+  f.interrupt("published");
+  await expect(f.service.publish(f.input)).rejects.toThrow("interrupted published");
+  const status = await f.service.status(f.input.projectRef, f.input.mutationId);
+  expect(status.active_release_id).toBe(f.input.mutationId);
+  expect(status.mutation?.status).toBe("outcome_unknown");
+  expect((await f.service.publish(f.input)).replayed).toBe(true);
+  expect(f.prepareCalls()).toBe(1);
+  expect(f.states.get(f.input.mutationId)?.status).toBe("succeeded");
+});
+
+test("concurrent publishers on one expected generation have exactly one winner", async () => {
+  const f = fixture();
+  const results = await Promise.allSettled([
+    f.service.publish(f.input), f.service.publish({ ...f.input, mutationId: crypto.randomUUID() }),
+  ]);
+  expect(results.filter((result) => result.status === "fulfilled").length).toBe(1);
+  expect(results.filter((result) => result.status === "rejected").length).toBe(1);
+  expect([...f.states.values()].filter((state) => state.status === "failed_terminal").length).toBe(1);
+});
+
+test("foreign, tampered and malformed manifests fail closed without legacy fallback", async () => {
+  const f = fixture();
+  await f.service.publish(f.input);
+  const path = join(root, f.input.projectRef, PROJECT_RELEASE_FILE);
+  const raw = await readFile(path, "utf8");
+  expect(() => parseProjectRelease(raw, "another-tenant")).toThrow("identity");
+  const tampered = JSON.parse(raw);
+  tampered.members.first.config.version = "2";
+  await rm(path);
+  await writeFile(path, JSON.stringify(tampered));
+  await expect(projectReleaseFunctionManifest(join(root, f.input.projectRef), "first")).rejects.toThrow();
+  await expect(edgeFunctionService.getState(f.input.projectRef, "first")).rejects.toThrow();
+});
+
+test("duplicate members and incomplete subsequent units are rejected", async () => {
+  const f = fixture();
+  await expect(f.service.publish({ ...f.input, functions: [f.input.functions[0]!, f.input.functions[0]!] })).rejects.toThrow("Duplicate");
+  await f.service.publish(f.input);
+  await expect(f.service.publish({
+    ...f.input, mutationId: crypto.randomUUID(), expectedReleaseId: f.input.mutationId,
+    functions: [f.input.functions[0]!],
+  })).rejects.toThrow("all previously enrolled");
+});


### PR DESCRIPTION
## Summary
- Add immutable multi-function release manifests with one fsync-backed authority rename, complete member enrollment, project/member CAS and cross-process locking.
- Reuse immutable version staging, foreground/background preheat attestations and durable project mutation leases/receipts.
- Wire authoritative reads into Management and Edge, reject individual activation/config/delete bypass for enrolled members, provide staging/publish/status APIs and interruption recovery.
- Define in-flight and pinned-background semantics, runtime-first rollout, rollback and shared-filesystem boundaries.

## Validation
- Project release/storage tests: 14 passed.
- Production preheat adapter with actual staged artifacts: 1 passed (15 assertions).
- Existing activation service: 30 passed, 1 platform/privilege skip on macOS.
- Linux Docker, network disabled: runtime function config/activation suite, 29 passed including both release members and restart recovery.
- Management and Edge typechecks, Edge bundle, workspace boundaries and git diff --check passed.

## Operational boundaries
- Opt-in shared trusted filesystem, not a distributed transaction across independent runtime hosts.
- Runtime supporting the release schema must be installed first.
- No production deployment or CI polling. This PR does not make business/database/queue side effects atomic.
