### PR TITLE
test(observability): verify SLO alert firing and healthy traffic

### DIFF
--- a/docs/request-task-tracing.md
+++ b/docs/request-task-tracing.md
@@ -57,6 +57,9 @@ authenticated Management `/metrics` scrape endpoint. No telemetry collector,
 public port or database log table is introduced. This PR does not install rules
 on a server or claim that alert delivery has been exercised there.
 
+Run `promtool test rules infrastructure/monitoring/supacloud-slo.rules.test.yml`
+to verify all four sustained-failure alerts and their healthy non-firing cases.
+
 Background counters describe dispatched attempts, not unique jobs. Queue wait
 is age since original task creation, including prior retries. Sampling affects
 logs, not these counters. Silent/stalled queues with no dispatched attempts

--- a/infrastructure/monitoring/supacloud-slo.rules.test.yml
+++ b/infrastructure/monitoring/supacloud-slo.rules.test.yml
@@ -1,0 +1,78 @@
+rule_files:
+  - supacloud-slo.rules.yml
+evaluation_interval: 1m
+tests:
+  - interval: 1m
+    input_series:
+      - series: supacloud_management_http_requests_total
+        values: 0+100x20
+      - series: supacloud_management_http_errors_total
+        values: 0+10x20
+      - series: supacloud_management_http_request_duration_ms_bucket{le="500"}
+        values: 0+0x20
+      - series: supacloud_management_http_request_duration_ms_bucket{le="1000"}
+        values: 0+100x20
+      - series: supacloud_management_http_request_duration_ms_bucket{le="+Inf"}
+        values: 0+100x20
+      - series: supacloud_background_attempts_total
+        values: 0+100x20
+      - series: supacloud_background_failures_total
+        values: 0+10x20
+      - series: supacloud_background_queue_wait_seconds_bucket{le="300"}
+        values: 0+0x20
+      - series: supacloud_background_queue_wait_seconds_bucket{le="600"}
+        values: 0+100x20
+      - series: supacloud_background_queue_wait_seconds_bucket{le="+Inf"}
+        values: 0+100x20
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: SupaCloudManagementErrorBudget
+        exp_alerts:
+          - exp_labels: {severity: warning, service: management-api}
+            exp_annotations:
+              summary: Management API error ratio exceeds one percent
+              runbook: docs/request-task-tracing.md#management-errors
+      - eval_time: 15m
+        alertname: SupaCloudManagementLatency
+        exp_alerts:
+          - exp_labels: {severity: warning, service: management-api}
+            exp_annotations:
+              summary: Management API p95 exceeds 500 milliseconds
+              runbook: docs/request-task-tracing.md#management-latency
+      - eval_time: 15m
+        alertname: SupaCloudBackgroundFailures
+        exp_alerts:
+          - exp_labels: {severity: warning, service: background-worker}
+            exp_annotations:
+              summary: Background function attempt failure ratio exceeds two percent
+              runbook: docs/request-task-tracing.md#background-failures
+      - eval_time: 15m
+        alertname: SupaCloudBackgroundQueueDelay
+        exp_alerts:
+          - exp_labels: {severity: warning, service: background-worker}
+            exp_annotations:
+              summary: Dispatched background task p95 age exceeds five minutes
+              runbook: docs/request-task-tracing.md#queue-delay
+  - interval: 1m
+    input_series:
+      - series: supacloud_management_http_requests_total
+        values: 0+100x20
+      - series: supacloud_management_http_errors_total
+        values: 0+0x20
+      - series: supacloud_management_http_request_duration_ms_bucket{le="100"}
+        values: 0+100x20
+      - series: supacloud_management_http_request_duration_ms_bucket{le="+Inf"}
+        values: 0+100x20
+      - series: supacloud_background_attempts_total
+        values: 0+100x20
+      - series: supacloud_background_failures_total
+        values: 0+0x20
+      - series: supacloud_background_queue_wait_seconds_bucket{le="10"}
+        values: 0+100x20
+      - series: supacloud_background_queue_wait_seconds_bucket{le="+Inf"}
+        values: 0+100x20
+    alert_rule_test:
+      - {eval_time: 15m, alertname: SupaCloudManagementErrorBudget, exp_alerts: []}
+      - {eval_time: 15m, alertname: SupaCloudManagementLatency, exp_alerts: []}
+      - {eval_time: 15m, alertname: SupaCloudBackgroundFailures, exp_alerts: []}
+      - {eval_time: 15m, alertname: SupaCloudBackgroundQueueDelay, exp_alerts: []}


### PR DESCRIPTION
## Summary
- Add executable Prometheus rule tests for all four SLO alerts introduced in #1212.
- Verify sustained error, latency, background failure and queue-delay conditions fire, while healthy traffic does not.
- Document the local `promtool test rules` entry point.

## Validation
- `promtool check rules`: all four rules valid.
- `promtool test rules`: all alert assertions passed using local Prometheus 3.5.3.
- Follow-up Linux validation of #1212: tracing and real WorkerPool suites passed all 97 tests with 498 assertions, no skips.
- `git diff --check`.

## Boundaries
- Tests and documentation only. No production rule installation, alert delivery, remote CI polling or server access.
- Follow-up to the already merged #1212; no runtime code duplicated.
