### PR TITLE
feat(backup): add isolated project restore drills and signed evidence

### DIFF
--- a/docs/project-restore-drill.md
+++ b/docs/project-restore-drill.md
@@ -1,0 +1,146 @@
+# Isolated full-project restore drills
+
+## Acceptance
+
+```gherkin
+Scenario: Production cannot be an implicit restore target
+  Given a signed complete snapshot and a new drill ID
+  When a drill is started without network isolation or exact confirmation
+  Then no database restore command runs
+  And an existing drill directory is never reused or cleaned automatically
+
+Scenario: Every component is required
+  Given database, object files, encrypted runtime secrets and function metadata
+  When an inventory digest or decryption authentication tag fails
+  Then verification stops and no success receipt is issued
+
+Scenario: Restored state is verified instead of assuming command success
+  Given PostgreSQL has recovered into a new private cluster
+  When permission, queue, business and function canaries are executed
+  Then all expected results and the recovered snapshot marker must match
+  And the receipt contains measured RPO and RTO, not configured estimates
+
+Scenario: Interrupted execution is not replayed automatically
+  Given a durable running receipt already exists for a drill ID
+  When a process restarts or its response is lost
+  Then the same ID is refused for execution
+  And status exposes the signed receipt or an unknown outcome
+```
+
+The runner is an operator tool, not a public restore API. It only runs inside
+a Linux Docker container with no non-loopback network interfaces. The database
+cluster is always newly created under `/drill/<drill-id>`. The source project
+ref is preserved inside this isolated namespace; this is not an in-place
+restore or an automatic tenant rename. No command targets an existing stanza
+data directory or invokes `pig pitr`.
+
+The snapshot must be exported consistently by the backup operator. A manifest
+binds database backup files, the complete exported object namespace, encrypted
+runtime environment, and function/runtime files to one snapshot ID. Object
+files are restored into an isolated filesystem namespace and checked byte for
+byte. This does not provision a production S3 endpoint or claim provider-level
+S3 version/ACL recovery. Applications that require additional services must
+provide those services in a compatible isolated drill image; their canaries
+fail rather than contacting production.
+
+Both pgBackRest time-target recovery and portable logical-full fixtures are
+supported and distinctly identified in receipts. A logical fixture is never
+reported as PITR evidence. Physical restore remaps all tablespaces and uses
+new local PostgreSQL configuration, sockets and loopback ports.
+
+## Snapshot Contract
+
+`/backup/manifest.json` is a signed JSON document using the exported
+`RestoreSnapshot` TypeScript contract. Its `files` inventory covers every
+regular file under `database/`, `objects/`, `runtime/`, and `secrets/`.
+Symlinks, hardlinks, unknown files and path escapes are rejected.
+
+- pgBackRest: repository files under `database/repo/`; exact stanza, backup set,
+PostgreSQL major version and UTC recovery target are required.
+- Logical: `database/database.dump` and `database/globals.sql`.
+- Runtime files under `runtime/` become the isolated project's functions root.
+- `secrets/runtime-env.enc` uses existing `enc:v1:` AES-GCM encryption.
+  Its plaintext is `{snapshot_id, project_ref, values}`. No plaintext key is
+  stored in the manifest or receipt.
+- SQL fixtures include permissions, queues and business checks, with expected
+  JSON rows and an explicit database role. A separate marker query returns
+  exactly one `{snapshot_id, recovered_through}` row.
+- HTTP fixtures are GET-only, include an anonymous denied request and a
+  service-role successful function request, and pin response body SHA-256.
+
+Sign the manifest excluding `signature` with HMAC-SHA256 over `stableStringify`.
+The source signing key and recovery encryption key are independent inputs.
+The runner signs its receipt with an independent drill receipt key.
+For encrypted pgBackRest repositories, set `database.repo_cipher_type` to
+`aes-256-cbc` and provide `SUPACLOUD_PGBACKREST_REPO_KEY` separately. It is
+passed through the private process environment, never a command argument.
+Recovery must reach the requested target and leave standby/recovery mode
+before fixture verification can report success.
+
+## Running
+
+Build `infrastructure/restore-drill/Dockerfile` from the repository root.
+Review and pin the resulting image digest before operational use.
+Supply `SUPACLOUD_SNAPSHOT_SIGNING_KEY`, `SUPACLOUD_RESTORE_ENCRYPTION_KEY`,
+and `SUPACLOUD_DRILL_RECEIPT_KEY` through the container's secret environment.
+Never place their values on a command line or in a PR.
+
+```sh
+docker run --rm --network none --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --mount type=bind,src=/absolute/approved-snapshot,target=/backup,readonly \
+  --mount type=bind,src=/absolute/empty-drill-volume,target=/drill \
+  --env SUPACLOUD_SNAPSHOT_SIGNING_KEY \
+  --env SUPACLOUD_RESTORE_ENCRYPTION_KEY \
+  --env SUPACLOUD_DRILL_RECEIPT_KEY \
+  <approved-image-digest> run <drill-uuid> \
+  RESTORE_DRILL:<project-ref>:<snapshot-uuid>:<drill-uuid>
+```
+
+The mounted drill volume must be private and writable by the image's postgres
+user. It must not be a source/production volume. Retain the resulting
+`/drill/<id>/receipt.json` privately; cleanup is an explicit operator operation.
+Use the same image and receipt-key environment with `status <id>` to read it.
+An orphaned `running` receipt is displayed as `outcome_unknown`; start a new
+drill with a new ID only after inspecting the prior target. No automatic retry,
+overwrite, cleanup, server access or production rollout is performed.
+
+RTO covers verification, restoration and all canaries. RPO is the largest lag
+from the specified incident time to the database marker or any declared
+component recovery point. Receipts identify the source-manifest hash, target,
+checks, budgets, durations and backup method, never credentials or row data.
+Production readiness still requires running a real approved snapshot and
+retaining the signed evidence; synthetic fixtures do not establish its RPO/RTO.
+
+## Reproducible Local Acceptance
+
+The test harness uses only an explicitly selected local Docker socket. It creates
+synthetic source databases, real pgBackRest backups/WAL, an object file, encrypted
+runtime secrets and an authenticated Edge function. It runs both restore methods
+without network access and checks signed receipts, tenant RLS, queues, business
+data, function authorization and recovery markers. The PITR case also checks that
+a transaction committed after the target time is absent. Both cases reject a
+duplicate drill ID without changing its receipt, and reject a corrupted object
+before database restoration.
+
+With Edge Runtime dependencies installed locally, use a Linux Bun binary matching
+the test image's architecture and libc. The test image must contain PostgreSQL 18,
+pgBackRest and a `postgres` user:
+
+```sh
+bun --no-env-file scripts/test-project-restore-drill.ts \
+  <local-postgres-pgbackrest-image> <absolute-linux-bun-path> <local-docker-context>
+```
+
+The command prints its private artifact directory and measured results, retains
+signed receipts and synthetic snapshots there, and removes only the containers
+and volume it created. Test keys are synthetic and must never be used outside
+these fixtures. The operator runner is executed from TypeScript with Bun, not as
+a standalone compiled executable.
+
+Local acceptance on September 8, 2026 used PostgreSQL 18, pgBackRest 2.58.0
+and Bun 1.4.0 in isolated Linux ARM64 containers. Both restore methods passed;
+the logical case verified eight checks and the PITR case verified nine.
+Durations are synthetic fixture measurements, not production recovery guarantees.
+The documented operational image still requires its own build, digest pinning
+and approved production-snapshot acceptance.

--- a/infrastructure/restore-drill/Dockerfile
+++ b/infrastructure/restore-drill/Dockerfile
@@ -1,0 +1,13 @@
+FROM oven/bun:1.4.0 AS bun
+FROM postgres:18-bookworm
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+RUN apt-get update && apt-get install -y --no-install-recommends pgbackrest ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY packages/edge-runtime /app/packages/edge-runtime
+COPY packages/management-api/src /app/packages/management-api/src
+COPY scripts/project-restore-drill.ts /app/scripts/project-restore-drill.ts
+RUN cd packages/edge-runtime && bun install --frozen-lockfile --production \
+    && mkdir /drill && chown postgres:postgres /drill && chmod 700 /drill
+USER postgres
+ENTRYPOINT ["bun", "--no-env-file", "/app/scripts/project-restore-drill.ts"]

--- a/packages/management-api/src/services/project-restore-drill.ts
+++ b/packages/management-api/src/services/project-restore-drill.ts
@@ -1,0 +1,396 @@
+import { constants } from "node:fs";
+import { copyFile, lstat, mkdir, open, readFile, readdir, realpath, rename } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { networkInterfaces } from "node:os";
+import { dirname, join } from "node:path";
+import { decryptSecretWithKey, isEncryptedSecret } from "../utils/secret-crypto-core";
+import { stableStringify } from "../utils/stable-json";
+import {
+  COMPONENTS, DRILL_ID_PATTERN, DRILL_RECEIPT_SCHEMA, canonicalTime, parseRestoreSnapshot,
+  sha256, signDrillDocument, verifyDrillDocument, type RestoreFile, type RestoreSnapshot,
+} from "./restore-drill-contract";
+
+const BACKUP = "/backup";
+const DRILLS = "/drill";
+const BOOTSTRAP_ROLE = "supacloud_drill_bootstrap";
+const PG_PORT = "55432";
+const EDGE_PORT = 19005;
+type DrillPhase = "inventory" | "database" | "components" | "verification" | "complete";
+export interface DrillReceipt {
+  schema: typeof DRILL_RECEIPT_SCHEMA; drill_id: string; project_ref: string; snapshot_id: string;
+  snapshot_sha256: string; backup_method: string; target: string; status: "running" | "succeeded" | "failed";
+  phase: DrillPhase; started_at: string; completed_at: string | null;
+  rpo_ms: number | null; rto_ms: number | null; failure_code: string | null;
+  max_rpo_ms: number; max_rto_ms: number;
+  recovered_through: string | null;
+  checks: Array<{ category: string; name: string; evidence_sha256: string }>;
+  signature: string;
+}
+
+function requiredKey(name: string): string {
+  const key = process.env[name] ?? "";
+  if (key.length < 32) throw new Error(`${name} is required`);
+  return key;
+}
+
+export async function assertDrillIsolation(): Promise<void> {
+  if (process.platform !== "linux" || process.getuid?.() === 0) {
+    throw new Error("Restore drills require a non-root Linux container");
+  }
+  await lstat("/.dockerenv");
+  if (Object.values(networkInterfaces()).flat().some((entry) => entry && !entry.internal)) {
+    throw new Error("Restore drill networking must be disabled");
+  }
+  const mounts = await readFile("/proc/self/mountinfo", "utf8");
+  if (!mounts.split("\n").some((line) => {
+    const fields = line.split(" ");
+    return fields[4] === BACKUP && fields[5]?.split(",").includes("ro");
+  })) throw new Error("Backup must be a read-only mount");
+  for (const root of [BACKUP, DRILLS]) {
+    if (await realpath(root) !== root || !(await lstat(root)).isDirectory()) throw new Error("Drill roots must be canonical directories");
+  }
+  const target = await lstat(DRILLS);
+  if (target.uid !== process.getuid?.() || (target.mode & 0o077) !== 0) throw new Error("Drill root must be private and owned by the runner");
+}
+
+async function syncFile(path: string, value: string, mode = 0o600): Promise<void> {
+  const file = await open(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW, mode);
+  try { await file.writeFile(value); await file.sync(); } finally { await file.close(); }
+}
+
+async function writeReceipt(directory: string, receipt: DrillReceipt, key: string): Promise<void> {
+  receipt.signature = signDrillDocument(receipt as unknown as Record<string, unknown>, key);
+  const pending = join(directory, `.receipt-${randomUUID()}.tmp`);
+  await syncFile(pending, JSON.stringify(receipt) + "\n");
+  await rename(pending, join(directory, "receipt.json"));
+  const parent = await open(directory, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try { await parent.sync(); } finally { await parent.close(); }
+}
+
+async function inventoryPaths(root: string, prefix = ""): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(join(root, prefix), { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) files.push(...await inventoryPaths(root, relative));
+    else if (entry.isFile()) files.push(relative);
+    else throw new Error("Snapshot contains a symlink or non-regular entry");
+  }
+  return files.sort();
+}
+
+async function verifyFile(root: string, entry: RestoreFile): Promise<void> {
+  const file = await open(join(root, entry.path), constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const before = await file.stat();
+    if (!before.isFile() || before.nlink !== 1 || before.size !== entry.bytes) throw new Error("Snapshot file identity mismatch");
+    const hash = createHash("sha256");
+    const buffer = Buffer.alloc(1024 * 1024);
+    for (let offset = 0; offset < before.size;) {
+      const { bytesRead } = await file.read(buffer, 0, Math.min(buffer.length, before.size - offset), offset);
+      if (!bytesRead) throw new Error("Snapshot file was truncated");
+      hash.update(buffer.subarray(0, bytesRead)); offset += bytesRead;
+    }
+    const after = await file.stat();
+    if (hash.digest("hex") !== entry.sha256 || before.mtimeMs !== after.mtimeMs || before.ctimeMs !== after.ctimeMs) {
+      throw new Error("Snapshot file digest mismatch");
+    }
+  } finally { await file.close(); }
+}
+
+export async function verifyRestoreInventory(root: string, snapshot: RestoreSnapshot): Promise<void> {
+  const actual: string[] = [];
+  for (const component of COMPONENTS) {
+    const metadata = await lstat(join(root, component));
+    if (!metadata.isDirectory()) throw new Error("Snapshot component must be a directory");
+    actual.push(...(await inventoryPaths(join(root, component))).map((path) => `${component}/${path}`));
+  }
+  if (stableStringify(actual.sort()) !== stableStringify(snapshot.files.map((entry) => entry.path).sort())) {
+    throw new Error("Snapshot inventory is incomplete");
+  }
+  for (const entry of snapshot.files) await verifyFile(root, entry);
+}
+
+function baseEnvironment() {
+  return { PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin", HOME: "/drill", LANG: "C.UTF-8" };
+}
+
+async function run(cmd: string[], env: Record<string, string>, timeoutMs = 120_000): Promise<string> {
+  const child = Bun.spawn(cmd, { env, stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+  const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+  let output = "";
+  const decoder = new TextDecoder();
+  try {
+    const reader = child.stdout.getReader();
+    try {
+      let bytes = 0;
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        bytes += chunk.value.length;
+        if (bytes > 4 * 1024 * 1024) { child.kill("SIGKILL"); throw new Error("Drill command output limit exceeded"); }
+        output += decoder.decode(chunk.value, { stream: true });
+      }
+    } finally { reader.releaseLock(); }
+    if (await child.exited !== 0) throw new Error("Drill command failed");
+    return output.trim();
+  } finally {
+    clearTimeout(timer);
+    if (child.exitCode === null) child.kill("SIGKILL");
+    await child.exited;
+  }
+}
+
+function databaseEnvironment(snapshot: RestoreSnapshot, directory: string, bootstrap = false) {
+  return {
+    ...baseEnvironment(), PGHOST: join(directory, "socket"), PGPORT: PG_PORT,
+    PGUSER: bootstrap ? BOOTSTRAP_ROLE : snapshot.database.admin_role,
+    ...(snapshot.database.repo_cipher_type === "aes-256-cbc"
+      ? { PGBACKREST_REPO1_CIPHER_PASS: requiredKey("SUPACLOUD_PGBACKREST_REPO_KEY") } : {}),
+  };
+}
+
+export function postgresRecoveryTimestamp(value: string): string {
+  canonicalTime(value);
+  return value.replace("T", " ").replace("Z", "+00");
+}
+
+export function pgbackrestArgs(snapshot: RestoreSnapshot, directory: string): string[] {
+  return [
+    "pgbackrest", "--config=/dev/null", `--stanza=${snapshot.database.stanza}`,
+    "--repo1-type=posix", `--repo1-path=${directory}/input/database/repo`,
+    `--repo1-cipher-type=${snapshot.database.repo_cipher_type ?? "none"}`,
+    `--pg1-path=${directory}/pgdata`, `--lock-path=${directory}/lock`, `--log-path=${directory}/log`,
+  ];
+}
+
+async function restoreDatabase(snapshot: RestoreSnapshot, directory: string): Promise<void> {
+  const environment = databaseEnvironment(snapshot, directory, snapshot.database.kind === "logical-full");
+  const version = await run(["postgres", "--version"], environment);
+  if (!new RegExp(`\\b${snapshot.database.major}\\.\\d+`).test(version)) throw new Error("PostgreSQL major version mismatch");
+  await mkdir(join(directory, "socket"), { mode: 0o700 });
+  if (snapshot.database.kind === "pgbackrest") {
+    await mkdir(join(directory, "lock"), { mode: 0o700 });
+    await mkdir(join(directory, "log"), { mode: 0o700 });
+    await run([
+      ...pgbackrestArgs(snapshot, directory), `--set=${snapshot.database.backup_set}`, "--type=time",
+      `--target=${postgresRecoveryTimestamp(snapshot.database.recovery_target!)}`, "--target-action=promote", "--archive-mode=off",
+      `--tablespace-map-all=${directory}/tablespaces`, "restore",
+    ], environment, snapshot.max_rto_ms);
+  } else {
+    await run(["initdb", "-D", join(directory, "pgdata"), "-U", BOOTSTRAP_ROLE, "--auth=trust", "--no-locale", "--encoding=UTF8"], environment);
+  }
+  // 不加载生产配置；只保留显式恢复目标及只读归档读取命令。
+  const autoPath = join(directory, "pgdata", "postgresql.auto.conf");
+  const auto = await open(autoPath, constants.O_WRONLY | constants.O_TRUNC | constants.O_CREAT | constants.O_NOFOLLOW, 0o600);
+  try {
+    const recovery = snapshot.database.kind === "pgbackrest" ? [
+      `restore_command = '${[...pgbackrestArgs(snapshot, directory), "archive-get", "%f", '"%p"'].join(" ")}'`,
+      `recovery_target_time = '${postgresRecoveryTimestamp(snapshot.database.recovery_target!)}'`,
+      "recovery_target_action = 'promote'",
+    ].join("\n") : "";
+    await auto.writeFile(recovery + "\n"); await auto.sync();
+  } finally { await auto.close(); }
+  await syncFile(join(directory, "postgresql.conf"), [
+    "listen_addresses = '127.0.0.1'", `port = ${PG_PORT}`,
+    `unix_socket_directories = '${directory}/socket'`,
+    `hba_file = '${directory}/pg_hba.conf'`, "ssl = off", "archive_mode = off",
+    "shared_preload_libraries = ''", "session_preload_libraries = ''", "local_preload_libraries = ''",
+  ].join("\n") + "\n");
+  await syncFile(join(directory, "pg_hba.conf"), "local all all trust\nhost all all 127.0.0.1/32 trust\n");
+  await run([
+    "pg_ctl", "-D", join(directory, "pgdata"), "-l", join(directory, "postgres.log"), "-w", "-t", "120",
+    "-o", `-c config_file=${directory}/postgresql.conf`, "start",
+  ], environment);
+  if (snapshot.database.kind === "logical-full") {
+    await run(["psql", "-X", "-v", "ON_ERROR_STOP=1", "-d", "postgres", "-f", join(directory, "input/database/globals.sql")], environment);
+    await run(["createdb", "-O", snapshot.database.admin_role, snapshot.database.name], environment);
+    await run(["pg_restore", "--exit-on-error", "--single-transaction", "-d", snapshot.database.name, join(directory, "input/database/database.dump")], environment, snapshot.max_rto_ms);
+  }
+}
+
+async function sqlRows(snapshot: RestoreSnapshot, directory: string, query: string, role: string, claims?: Record<string, unknown>): Promise<unknown[]> {
+  const claimsClause = claims === undefined ? "" : `SET LOCAL request.jwt.claims = '${JSON.stringify(claims).replaceAll("'", "''")}';`;
+  const sql = `BEGIN READ ONLY; SET LOCAL statement_timeout = '30s'; SET LOCAL ROLE "${role}"; ${claimsClause} SELECT COALESCE(json_agg(row_to_json(check_row)), '[]'::json) FROM (${query}) check_row; ROLLBACK;`;
+  const output = await run(["psql", "-X", "-Atq", "-v", "ON_ERROR_STOP=1", "-d", snapshot.database.name, "-c", sql], databaseEnvironment(snapshot, directory), 35_000);
+  const rows = JSON.parse(output);
+  if (!Array.isArray(rows)) throw new Error("Invalid SQL fixture result");
+  return rows;
+}
+
+async function restoredRuntimeEnv(snapshot: RestoreSnapshot, directory: string, encryptionKey: string) {
+  const encrypted = await readFile(join(directory, "input/secrets/runtime-env.enc"), "utf8");
+  if (!isEncryptedSecret(encrypted)) throw new Error("Runtime environment must be encrypted");
+  const restored = JSON.parse(decryptSecretWithKey(encrypted, encryptionKey));
+  if (restored.snapshot_id !== snapshot.snapshot_id || restored.project_ref !== snapshot.project_ref
+    || !restored.values || typeof restored.values !== "object" || Array.isArray(restored.values)
+    || Object.keys(restored.values).length > 512 || Object.values(restored.values).some((value) => typeof value !== "string")) {
+    throw new Error("Restored runtime environment identity mismatch");
+  }
+  const env: Record<string, string> = { ...restored.values };
+  const databaseUrl = `postgresql://${snapshot.database.admin_role}@127.0.0.1:${PG_PORT}/${snapshot.database.name}`;
+  for (const key of ["DATABASE_URL", "SUPABASE_DB_URL", "POSTGRES_URL", ...snapshot.database_env_keys]) env[key] = databaseUrl;
+  Object.assign(env, {
+    PGHOST: "127.0.0.1", PGPORT: PG_PORT, PGUSER: snapshot.database.admin_role, PGDATABASE: snapshot.database.name,
+    SUPACLOUD_PROJECT_REF: snapshot.project_ref, X_PROJECT_REF: snapshot.project_ref,
+    SUPACLOUD_DRILL_OBJECTS_DIR: join(directory, "objects"),
+  });
+  return env;
+}
+
+async function restoreComponents(snapshot: RestoreSnapshot, directory: string) {
+  for (const entry of snapshot.files) {
+    if (!entry.path.startsWith("runtime/") && !entry.path.startsWith("objects/")) continue;
+    const target = entry.path.startsWith("runtime/")
+      ? join(directory, "functions", snapshot.project_ref, entry.path.slice("runtime/".length))
+      : join(directory, entry.path);
+    await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+    await copyFile(join(directory, "input", entry.path), target, constants.COPYFILE_EXCL);
+    await verifyFile(dirname(target), { ...entry, path: target.split("/").at(-1)! });
+  }
+}
+
+async function stopChild(child: Bun.Subprocess<"ignore", "ignore", "ignore">) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const timer = setTimeout(() => child.kill("SIGKILL"), 3000);
+  try { await child.exited; } finally { clearTimeout(timer); }
+}
+
+async function verifyFunctions(snapshot: RestoreSnapshot, directory: string, env: Record<string, string>, receipt: DrillReceipt) {
+  const token = randomUUID();
+  const management = Bun.serve({
+    hostname: "127.0.0.1", port: 0,
+    fetch(request) {
+      if (request.headers.get("authorization") !== `Bearer ${token}`
+        || new URL(request.url).pathname !== `/v1/projects/${snapshot.project_ref}/internal/runtime-env`) {
+        return new Response(null, { status: 403 });
+      }
+      return Response.json(env, { headers: { "x-supacloud-runtime-env-revision": `hmac-sha256:${receipt.snapshot_sha256}` } });
+    },
+  });
+  const edge = Bun.spawn([process.execPath, "--no-env-file", "/app/packages/edge-runtime/server.ts"], {
+    env: {
+      ...baseEnvironment(), EDGE_RUNTIME_HOST: "127.0.0.1", EDGE_RUNTIME_PORT: String(EDGE_PORT),
+      EDGE_RUNTIME_MASTER_KEY: token, MASTER_TOKEN: token, MANAGEMENT_API_URL: `http://127.0.0.1:${management.port}`,
+      EDGE_FUNCTIONS_DIR: join(directory, "functions"), EDGE_FUNCTIONS_BASE_DIR: join(directory, "functions"),
+      TENANTS_DIR: join(directory, "tenants"), WORKER_POOL_SIZE: "1", BACKGROUND_WORKER_POOL_SIZE: "1",
+    }, stdin: "ignore", stdout: "ignore", stderr: "ignore",
+  });
+  try {
+    const deadline = Date.now() + 15_000;
+    while (true) {
+      if (edge.exitCode !== null) throw new Error("Restored runtime exited");
+      try { if ((await fetch(`http://127.0.0.1:${EDGE_PORT}/health`, { signal: AbortSignal.timeout(500) })).ok) break; } catch {}
+      if (Date.now() >= deadline) throw new Error("Restored runtime did not become ready");
+      await Bun.sleep(25);
+    }
+    for (const check of snapshot.http_checks) {
+      const headers: Record<string, string> = { "x-project-ref": snapshot.project_ref };
+      if (check.auth === "service_role") {
+        if (!env.SUPABASE_SERVICE_ROLE_KEY) throw new Error("Restored runtime credential is missing");
+        headers.apikey = env.SUPABASE_SERVICE_ROLE_KEY;
+      }
+      const response = await fetch(`http://127.0.0.1:${EDGE_PORT}/functions/v1/${check.slug}${check.path}`, {
+        headers, redirect: "error", signal: AbortSignal.timeout(30_000),
+      });
+      const bodyHash = sha256(new Uint8Array(await response.arrayBuffer()));
+      if (response.status !== check.status || bodyHash !== check.sha256) throw new Error("Restored function canary mismatch");
+      receipt.checks.push({ category: check.auth === "anonymous" ? "authorization" : "functions", name: check.slug, evidence_sha256: bodyHash });
+    }
+  } finally {
+    await stopChild(edge);
+    management.stop(true);
+  }
+}
+
+export async function runProjectRestoreDrill(drillId: string, confirmation: string): Promise<DrillReceipt> {
+  if (!DRILL_ID_PATTERN.test(drillId)) throw new Error("Invalid drill ID");
+  await assertDrillIsolation();
+  const signingKey = requiredKey("SUPACLOUD_SNAPSHOT_SIGNING_KEY");
+  const encryptionKey = requiredKey("SUPACLOUD_RESTORE_ENCRYPTION_KEY");
+  const receiptKey = requiredKey("SUPACLOUD_DRILL_RECEIPT_KEY");
+  if (new Set([signingKey, encryptionKey, receiptKey]).size !== 3) throw new Error("Snapshot, encryption and receipt keys must be independent");
+  const raw = await readFile(join(BACKUP, "manifest.json"), "utf8");
+  const snapshot = parseRestoreSnapshot(raw, signingKey);
+  if (confirmation !== `RESTORE_DRILL:${snapshot.project_ref}:${snapshot.snapshot_id}:${drillId}`) throw new Error("Exact restore-drill confirmation is required");
+  const directory = join(DRILLS, drillId);
+  await mkdir(directory, { mode: 0o700 });
+  const started = performance.now();
+  const receipt: DrillReceipt = {
+    schema: DRILL_RECEIPT_SCHEMA, drill_id: drillId, project_ref: snapshot.project_ref,
+    snapshot_id: snapshot.snapshot_id, snapshot_sha256: sha256(raw), backup_method: snapshot.database.kind,
+    target: directory, status: "running", phase: "inventory", started_at: new Date().toISOString(), completed_at: null,
+    rpo_ms: null, rto_ms: null, recovered_through: null, failure_code: null, checks: [], signature: "",
+    max_rpo_ms: snapshot.max_rpo_ms, max_rto_ms: snapshot.max_rto_ms,
+  };
+  await writeReceipt(directory, receipt, receiptKey);
+  try {
+    await verifyRestoreInventory(BACKUP, snapshot);
+    // 将已签名内容复制到私有目标再复验，后续命令不再读取可能被宿主机改动的源挂载。
+    for (const entry of snapshot.files) {
+      const target = join(directory, "input", entry.path);
+      await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+      await copyFile(join(BACKUP, entry.path), target, constants.COPYFILE_EXCL);
+      await verifyFile(join(directory, "input"), entry);
+    }
+    const env = await restoredRuntimeEnv(snapshot, directory, encryptionKey);
+    receipt.checks.push({ category: "inventory", name: "complete-snapshot", evidence_sha256: sha256(stableStringify(snapshot.files)) });
+    receipt.phase = "database"; await writeReceipt(directory, receipt, receiptKey);
+    await restoreDatabase(snapshot, directory);
+    const recoveryDeadline = Date.now() + Math.min(60_000, snapshot.max_rto_ms);
+    while (true) {
+      const rows = await sqlRows(snapshot, directory, "SELECT pg_is_in_recovery() AS recovering", snapshot.database.admin_role);
+      if (stableStringify(rows) === stableStringify([{ recovering: false }])) break;
+      if (Date.now() >= recoveryDeadline) throw new Error("PITR target has not been reached and promoted");
+      await Bun.sleep(100);
+    }
+    receipt.phase = "components"; await writeReceipt(directory, receipt, receiptKey);
+    await restoreComponents(snapshot, directory);
+    receipt.phase = "verification"; await writeReceipt(directory, receipt, receiptKey);
+    for (const check of snapshot.sql_checks) {
+      if (check.category === "permissions") {
+        const roles = await sqlRows(snapshot, directory,
+          `SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = '${check.role}'`, snapshot.database.admin_role);
+        if (stableStringify(roles) !== stableStringify([{ rolsuper: false, rolbypassrls: false }])) {
+          throw new Error("Permission checks cannot use a privileged database role");
+        }
+      }
+      const rows = await sqlRows(snapshot, directory, check.query, check.role, check.claims);
+      if (stableStringify(rows) !== stableStringify(check.expected)) throw new Error("Restored SQL fixture mismatch");
+      receipt.checks.push({ category: check.category, name: check.name, evidence_sha256: sha256(stableStringify(rows)) });
+    }
+    const rows = await sqlRows(snapshot, directory, snapshot.marker_query, snapshot.database.admin_role);
+    const marker = rows[0] as { snapshot_id?: string; recovered_through?: string } | undefined;
+    if (rows.length !== 1 || marker?.snapshot_id !== snapshot.snapshot_id) throw new Error("Restored snapshot marker mismatch");
+    const recovered = canonicalTime(marker.recovered_through);
+    receipt.recovered_through = marker.recovered_through!;
+    receipt.checks.push({ category: "recovery_point", name: "database-marker", evidence_sha256: sha256(stableStringify(rows)) });
+    const incident = canonicalTime(snapshot.incident_at);
+    if (recovered > incident || (snapshot.database.kind === "pgbackrest" && recovered > canonicalTime(snapshot.database.recovery_target))) {
+      throw new Error("Invalid recovered database point");
+    }
+    await verifyFunctions(snapshot, directory, env, receipt);
+    receipt.rpo_ms = incident - Math.min(recovered, ...Object.values(snapshot.recovery_points).map(canonicalTime));
+    receipt.rto_ms = Math.round(performance.now() - started);
+    if (receipt.rpo_ms > snapshot.max_rpo_ms || receipt.rto_ms > snapshot.max_rto_ms) throw new Error("Restore budget exceeded");
+    receipt.status = "succeeded"; receipt.phase = "complete";
+  } catch {
+    receipt.status = "failed"; receipt.failure_code = `RESTORE_${receipt.phase.toUpperCase()}_FAILED`;
+    receipt.rto_ms = Math.round(performance.now() - started);
+  } finally {
+    await run(["pg_ctl", "-D", join(directory, "pgdata"), "-m", "immediate", "-w", "stop"], databaseEnvironment(snapshot, directory), 10_000).catch(() => {});
+    receipt.completed_at = new Date().toISOString();
+    await writeReceipt(directory, receipt, receiptKey);
+  }
+  return receipt;
+}
+
+export async function readProjectRestoreDrill(drillId: string) {
+  if (!DRILL_ID_PATTERN.test(drillId)) throw new Error("Invalid drill ID");
+  const receipt = JSON.parse(await readFile(join(DRILLS, drillId, "receipt.json"), "utf8")) as DrillReceipt;
+  verifyDrillDocument(receipt as unknown as Record<string, unknown>, requiredKey("SUPACLOUD_DRILL_RECEIPT_KEY"));
+  if (receipt.schema !== DRILL_RECEIPT_SCHEMA || receipt.drill_id !== drillId || receipt.target !== join(DRILLS, drillId)) {
+    throw new Error("Receipt target identity mismatch");
+  }
+  return { receipt, effective_status: receipt.status === "running" ? "outcome_unknown" : receipt.status };
+}

--- a/packages/management-api/src/services/restore-drill-contract.ts
+++ b/packages/management-api/src/services/restore-drill-contract.ts
@@ -1,0 +1,152 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { stableStringify } from "../utils/stable-json";
+
+export const RESTORE_SNAPSHOT_SCHEMA = "supacloud.project-restore-snapshot.v1";
+export const DRILL_RECEIPT_SCHEMA = "supacloud.project-restore-drill.v1";
+export const DRILL_ID_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
+export const COMPONENTS = ["database", "objects", "runtime", "secrets"] as const;
+export type RestoreComponent = typeof COMPONENTS[number];
+export type RestoreFile = { path: string; bytes: number; sha256: string };
+export type RestoreSqlCheck = {
+  name: string; category: "permissions" | "queues" | "business"; role: string;
+  query: string; claims?: Record<string, unknown>; expected: unknown[];
+};
+export type RestoreHttpCheck = {
+  slug: string; path: string; auth: "anonymous" | "service_role"; status: number; sha256: string;
+};
+export interface RestoreSnapshot {
+  schema: typeof RESTORE_SNAPSHOT_SCHEMA;
+  snapshot_id: string;
+  project_ref: string;
+  incident_at: string;
+  recovery_points: Record<RestoreComponent, string>;
+  database: {
+    kind: "pgbackrest" | "logical-full";
+    name: string; admin_role: string; major: number;
+    stanza?: string; backup_set?: string; recovery_target?: string;
+    repo_cipher_type?: "none" | "aes-256-cbc";
+  };
+  files: RestoreFile[];
+  database_env_keys: string[];
+  sql_checks: RestoreSqlCheck[];
+  marker_query: string;
+  http_checks: RestoreHttpCheck[];
+  max_rpo_ms: number;
+  max_rto_ms: number;
+  signature: string;
+}
+
+export function canonicalTime(value: unknown): number {
+  if (typeof value !== "string") throw new Error("Invalid recovery timestamp");
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) throw new Error("Invalid recovery timestamp");
+  return milliseconds;
+}
+
+export function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function signDrillDocument(value: Record<string, unknown>, key: string): string {
+  if (key.length < 32) throw new Error("Signing key requires at least 32 characters");
+  const { signature: _, ...unsigned } = value;
+  return createHmac("sha256", key).update(stableStringify(unsigned)).digest("hex");
+}
+
+export function verifyDrillDocument(value: Record<string, unknown>, key: string): void {
+  const signature = value.signature;
+  if (typeof signature !== "string" || !/^[a-f0-9]{64}$/.test(signature)
+    || !timingSafeEqual(Buffer.from(signature, "hex"), Buffer.from(signDrillDocument(value, key), "hex"))) {
+    throw new Error("Invalid drill document signature");
+  }
+}
+
+export function safeRestorePath(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 1024
+    && !value.includes("\\") && !/[\x00-\x1f\x7f]/.test(value)
+    && COMPONENTS.includes(value.split("/")[0] as RestoreComponent)
+    && value.split("/").every((part) => part !== "" && part !== "." && part !== "..");
+}
+
+export function assertRestoreQuery(query: unknown): asserts query is string {
+  if (typeof query !== "string" || query.length > 16_384 || !/^\s*SELECT\s/i.test(query)
+    || /[;\x00]/.test(query) || /--|\/\*/.test(query)) {
+    throw new Error("Restore checks require one bounded SELECT query");
+  }
+}
+
+export function parseRestoreSnapshot(raw: string, key: string, now = Date.now()): RestoreSnapshot {
+  if (Buffer.byteLength(raw) > 4 * 1024 * 1024) throw new Error("Snapshot manifest exceeds 4 MiB");
+  const doc = JSON.parse(raw) as RestoreSnapshot;
+  if (!doc || typeof doc !== "object" || Array.isArray(doc)) throw new Error("Snapshot manifest must be an object");
+  verifyDrillDocument(doc as unknown as Record<string, unknown>, key);
+  if (doc.schema !== RESTORE_SNAPSHOT_SCHEMA || !DRILL_ID_PATTERN.test(doc.snapshot_id)
+    || !/^[A-Za-z0-9_-]{1,20}$/.test(doc.project_ref)) throw new Error("Invalid snapshot identity");
+  const incident = canonicalTime(doc.incident_at);
+  if (incident > now) throw new Error("Incident time cannot be in the future");
+  for (const component of COMPONENTS) {
+    if (canonicalTime(doc.recovery_points?.[component]) > incident) throw new Error("Recovery point is after the incident");
+  }
+  if (!doc.database || !["pgbackrest", "logical-full"].includes(doc.database.kind)
+    || !/^[A-Za-z_][A-Za-z0-9_]{0,62}$/.test(doc.database.name)
+    || !/^[A-Za-z_][A-Za-z0-9_]{0,62}$/.test(doc.database.admin_role)
+    || ["postgres", "template0", "template1"].includes(doc.database.name)
+    || doc.database.admin_role === "supacloud_drill_bootstrap"
+    || !Number.isInteger(doc.database.major) || doc.database.major < 14 || doc.database.major > 99) {
+    throw new Error("Invalid restore database identity");
+  }
+  if (doc.database.kind === "pgbackrest") {
+    if (!/^[A-Za-z0-9_-]{1,64}$/.test(doc.database.stanza ?? "")
+      || !/^[A-Za-z0-9_-]{1,128}$/.test(doc.database.backup_set ?? "")
+      || canonicalTime(doc.database.recovery_target) > incident) throw new Error("Invalid PITR target");
+    if (doc.database.repo_cipher_type !== undefined && !["none", "aes-256-cbc"].includes(doc.database.repo_cipher_type)) {
+      throw new Error("Invalid repository cipher type");
+    }
+  }
+  if (!Array.isArray(doc.files) || doc.files.length < 4 || doc.files.length > 20_000) throw new Error("Invalid snapshot inventory");
+  const paths = new Set<string>();
+  for (const file of doc.files) {
+    if (!safeRestorePath(file.path) || paths.has(file.path) || !Number.isSafeInteger(file.bytes) || file.bytes < 0
+      || !/^[a-f0-9]{64}$/.test(file.sha256)) throw new Error("Invalid snapshot file");
+    paths.add(file.path);
+  }
+  if (COMPONENTS.some((component) => ![...paths].some((path) => path.startsWith(`${component}/`)))
+    || !paths.has("secrets/runtime-env.enc")) throw new Error("Snapshot component is missing");
+  if (doc.database.kind === "logical-full" && (!paths.has("database/database.dump") || !paths.has("database/globals.sql"))) {
+    throw new Error("Logical database artifacts are missing");
+  }
+  if (doc.database.kind === "pgbackrest" && ![...paths].some((path) => path.startsWith("database/repo/"))) {
+    throw new Error("pgBackRest repository is missing");
+  }
+  if (!Array.isArray(doc.database_env_keys) || doc.database_env_keys.length > 16
+    || doc.database_env_keys.some((key) => !/^[A-Z][A-Z0-9_]{0,127}$/.test(key))) throw new Error("Invalid database environment mapping");
+  if (!Array.isArray(doc.sql_checks) || doc.sql_checks.length < 3 || doc.sql_checks.length > 100) throw new Error("Missing SQL checks");
+  for (const category of ["permissions", "queues", "business"]) {
+    if (!doc.sql_checks.some((check) => check.category === category)) throw new Error("Missing required SQL check category");
+  }
+  if (doc.sql_checks.filter((check) => check.category === "permissions").length < 2) {
+    throw new Error("Both permitted and tenant-isolated permission fixtures are required");
+  }
+  for (const check of doc.sql_checks) {
+    assertRestoreQuery(check.query);
+    if (!/^[A-Za-z0-9_-]{1,64}$/.test(check.name) || !/^[A-Za-z_][A-Za-z0-9_]{0,62}$/.test(check.role)
+      || !Array.isArray(check.expected)) throw new Error("Invalid SQL check");
+  }
+  assertRestoreQuery(doc.marker_query);
+  if (!Array.isArray(doc.http_checks) || doc.http_checks.length > 100
+    || !doc.http_checks.some((check) => check.auth === "anonymous" && [401, 403].includes(check.status))
+    || !doc.http_checks.some((check) => check.auth === "service_role" && check.status >= 200 && check.status < 300)) {
+    throw new Error("Authenticated and denied function checks are required");
+  }
+  for (const check of doc.http_checks) {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(check.slug) || typeof check.path !== "string"
+      || !/^\/[A-Za-z0-9/_-]*$/.test(check.path) || !["anonymous", "service_role"].includes(check.auth)
+      || !Number.isInteger(check.status) || check.status < 200 || check.status > 599
+      || !/^[a-f0-9]{64}$/.test(check.sha256)) throw new Error("Invalid HTTP check");
+  }
+  if (!Number.isSafeInteger(doc.max_rpo_ms) || doc.max_rpo_ms < 0
+    || !Number.isSafeInteger(doc.max_rto_ms) || doc.max_rto_ms < 1 || doc.max_rto_ms > 3_600_000) {
+    throw new Error("Invalid restore budgets");
+  }
+  return doc;
+}

--- a/packages/management-api/src/utils/secret-crypto-core.ts
+++ b/packages/management-api/src/utils/secret-crypto-core.ts
@@ -1,0 +1,34 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+const PREFIX = "enc:v1:";
+
+function keyMaterial(encryptionKey: string): Buffer {
+  if (encryptionKey.length < 32) throw new Error("Secret encryption keys must contain at least 32 characters");
+  return createHash("sha256").update(encryptionKey).digest();
+}
+
+export function secretEncryptionKeyFingerprint(encryptionKey: string): string {
+  keyMaterial(encryptionKey);
+  return createHash("sha256").update("supacloud:enc:v1:\0", "utf8").update(encryptionKey, "utf8").digest("hex");
+}
+
+export function isEncryptedSecret(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.startsWith(PREFIX);
+}
+
+export function encryptSecretWithKey(value: string, encryptionKey: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", keyMaterial(encryptionKey), iv);
+  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${PREFIX}${Buffer.concat([iv, tag, ciphertext]).toString("base64url")}`;
+}
+
+export function decryptSecretWithKey(value: string, encryptionKey: string): string {
+  if (!isEncryptedSecret(value)) return value;
+  const raw = Buffer.from(value.slice(PREFIX.length), "base64url");
+  if (raw.length < 28) throw new Error("Invalid encrypted secret payload");
+  const decipher = createDecipheriv("aes-256-gcm", keyMaterial(encryptionKey), raw.subarray(0, 12));
+  decipher.setAuthTag(raw.subarray(12, 28));
+  return Buffer.concat([decipher.update(raw.subarray(28)), decipher.final()]).toString("utf8");
+}

--- a/packages/management-api/src/utils/secret-crypto.ts
+++ b/packages/management-api/src/utils/secret-crypto.ts
@@ -1,52 +1,12 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import { config } from "../config";
-
-const PREFIX = "enc:v1:";
-
-function keyMaterial(encryptionKey: string): Buffer {
-  if (encryptionKey.length < 32) {
-    throw new Error("Secret encryption keys must contain at least 32 characters");
-  }
-  return createHash("sha256").update(encryptionKey).digest();
-}
-
-export function secretEncryptionKeyFingerprint(encryptionKey: string): string {
-  keyMaterial(encryptionKey);
-  return createHash("sha256")
-    .update("supacloud:enc:v1:\0", "utf8")
-    .update(encryptionKey, "utf8")
-    .digest("hex");
-}
+import { decryptSecretWithKey, encryptSecretWithKey, isEncryptedSecret } from "./secret-crypto-core";
+export { decryptSecretWithKey, encryptSecretWithKey, isEncryptedSecret, secretEncryptionKeyFingerprint } from "./secret-crypto-core";
 
 function currentEncryptionKey(): string {
   if (config.secretsEncryptionKey === config.masterToken) {
     throw new Error("SECRETS_ENCRYPTION_KEY must be independent from MASTER_TOKEN");
   }
   return config.secretsEncryptionKey;
-}
-
-export function isEncryptedSecret(value: string | null | undefined): boolean {
-  return typeof value === "string" && value.startsWith(PREFIX);
-}
-
-export function encryptSecretWithKey(value: string, encryptionKey: string): string {
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", keyMaterial(encryptionKey), iv);
-  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return `${PREFIX}${Buffer.concat([iv, tag, ciphertext]).toString("base64url")}`;
-}
-
-export function decryptSecretWithKey(value: string, encryptionKey: string): string {
-  if (!isEncryptedSecret(value)) return value;
-  const raw = Buffer.from(value.slice(PREFIX.length), "base64url");
-  if (raw.length < 28) throw new Error("Invalid encrypted secret payload");
-  const iv = raw.subarray(0, 12);
-  const tag = raw.subarray(12, 28);
-  const ciphertext = raw.subarray(28);
-  const decipher = createDecipheriv("aes-256-gcm", keyMaterial(encryptionKey), iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
 }
 
 export function encryptSecret(value: string): string {

--- a/packages/management-api/tests/fixtures/create-restore-drill-snapshot.ts
+++ b/packages/management-api/tests/fixtures/create-restore-drill-snapshot.ts
@@ -1,0 +1,117 @@
+import { mkdir, readdir, readFile, lstat, unlink, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { encryptSecretWithKey } from "../../src/utils/secret-crypto-core";
+import { COMPONENTS, sha256, signDrillDocument, type RestoreFile, type RestoreSnapshot } from "../../src/services/restore-drill-contract";
+
+// 只在专用临时容器中生成合成数据，不能连接现有项目或外部数据库。
+const [kind, output] = process.argv.slice(2);
+if (!["logical-full", "pgbackrest"].includes(kind ?? "") || output !== "/tmp/drill-fixture/backup") throw new Error("Invalid fixture target");
+const source = "/tmp/supacloud-drill-source";
+const socket = "/tmp/supacloud-drill-socket";
+const environment = { ...process.env, PGHOST: socket, PGPORT: "55431", PGUSER: "postgres" };
+async function command(cmd: string[]) {
+  const child = Bun.spawn(cmd, { env: environment, stdout: "pipe", stderr: "pipe" });
+  const [code, out, err] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+  if (code !== 0) throw new Error(`Fixture command ${cmd[0]} failed: ${err}`);
+  return out.trim();
+}
+const sql = (value: string, database = "project_fixture") =>
+  command(["psql", "-X", "-Atq", "-v", "ON_ERROR_STOP=1", "-d", database, "-c", value]);
+await mkdir(output, { recursive: true });
+for (const component of COMPONENTS) await mkdir(join(output, component));
+await mkdir(socket);
+await command(["initdb", "-D", source, "-U", "postgres", "--auth=trust", "--no-locale", "--encoding=UTF8"]);
+if (kind === "pgbackrest") {
+  await mkdir(join(output, "database/repo"));
+  await Bun.write("/tmp/drill-pgbackrest.conf", `[global]\nrepo1-path=${output}/database/repo\nrepo1-retention-full=1\nlog-level-console=error\nstart-fast=y\n[fixture]\npg1-path=${source}\npg1-socket-path=${socket}\npg1-port=55431\npg1-user=postgres\n`);
+  await appendFile(join(source, "postgresql.conf"),
+    "\narchive_mode=on\narchive_command='pgbackrest --config=/tmp/drill-pgbackrest.conf --stanza=fixture archive-push %p'\n");
+}
+await command(["pg_ctl", "-D", source, "-l", "/tmp/drill-source.log", "-w", "-o", `-p 55431 -k ${socket} -h 127.0.0.1`, "start"]);
+try {
+  const snapshotId = crypto.randomUUID();
+  const point = new Date().toISOString();
+  await command(["createdb", "project_fixture"]);
+  await sql(`
+    CREATE ROLE authenticated;
+    CREATE TABLE documents (id integer PRIMARY KEY, tenant text NOT NULL);
+    INSERT INTO documents VALUES (1, 'tenant_a'), (2, 'tenant_b');
+    ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+    GRANT SELECT ON documents TO authenticated;
+    CREATE POLICY tenant_policy ON documents USING (tenant = current_setting('request.jwt.claims', true)::jsonb->>'tenant');
+    CREATE SCHEMA pgmq;
+    CREATE TABLE pgmq.q_work (msg_id bigint, message jsonb);
+    INSERT INTO pgmq.q_work VALUES (1, '{"kind":"fixture"}');
+    CREATE TABLE restore_marker (snapshot_id text, recovered_through timestamptz);
+    INSERT INTO restore_marker VALUES ('${snapshotId}', '${point}');
+    CREATE TABLE recovery_noise (id integer);
+  `);
+  const database: RestoreSnapshot["database"] = { kind: kind as "logical-full" | "pgbackrest", name: "project_fixture", admin_role: "postgres", major: 18 };
+  if (kind === "logical-full") {
+    await command(["pg_dumpall", "--roles-only", "-f", join(output, "database/globals.sql")]);
+    await command(["pg_dump", "--format=custom", "-d", "project_fixture", "-f", join(output, "database/database.dump")]);
+  } else {
+    await command(["pgbackrest", "--config=/tmp/drill-pgbackrest.conf", "--stanza=fixture", "stanza-create"]);
+    await command(["pgbackrest", "--config=/tmp/drill-pgbackrest.conf", "--stanza=fixture", "--type=full", "backup"]);
+    const inventory = JSON.parse(await command(["pgbackrest", "--config=/tmp/drill-pgbackrest.conf", "--stanza=fixture", "--output=json", "info"]));
+    database.stanza = "fixture";
+    database.backup_set = inventory[0].backup.at(-1).label;
+    database.recovery_target = new Date().toISOString();
+    await Bun.sleep(30);
+    await sql("INSERT INTO recovery_noise VALUES (1)");
+    await sql("SELECT pg_switch_wal()");
+    await command(["pgbackrest", "--config=/tmp/drill-pgbackrest.conf", "--stanza=fixture", "check"]);
+  }
+  await command(["pg_ctl", "-D", source, "-m", "fast", "-w", "stop"]);
+  await Bun.write(join(output, "objects/fixture.txt"), "restored-object");
+  await Bun.write(join(output, "runtime/check.js"), 'export default () => new Response("restore-ok");\n');
+  await Bun.write(join(output, "runtime/check.config.json"), JSON.stringify({ verify_jwt: true }));
+  const encryptionKey = process.env.SUPACLOUD_RESTORE_ENCRYPTION_KEY!;
+  await Bun.write(join(output, "secrets/runtime-env.enc"), encryptSecretWithKey(JSON.stringify({
+    snapshot_id: snapshotId, project_ref: "drillfixture",
+    values: { SUPACLOUD_AUTH_RUNTIME_MODE: "local", SUPABASE_SERVICE_ROLE_KEY: "synthetic-drill-service-role" },
+  }), encryptionKey));
+  const files: RestoreFile[] = [];
+  async function inventory(directory: string, prefix: string) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      const relative = `${prefix}/${entry.name}`;
+      if (entry.isSymbolicLink() && kind === "pgbackrest" && entry.name === "latest") {
+        await unlink(path); continue;
+      }
+      if (entry.isDirectory()) await inventory(path, relative);
+      else {
+        const bytes = await readFile(path);
+        if (!(await lstat(path)).isFile()) throw new Error("Unsupported fixture inventory entry");
+        files.push({ path: relative, bytes: bytes.length, sha256: sha256(bytes) });
+      }
+    }
+  }
+  for (const component of COMPONENTS) await inventory(join(output, component), component);
+  const snapshot: RestoreSnapshot = {
+    schema: "supacloud.project-restore-snapshot.v1", snapshot_id: snapshotId, project_ref: "drillfixture",
+    incident_at: new Date().toISOString(), recovery_points: Object.fromEntries(COMPONENTS.map((component) => [component, point])) as RestoreSnapshot["recovery_points"],
+    database, files, database_env_keys: [],
+    sql_checks: [
+      { name: "tenant_a_visible", category: "permissions", role: "authenticated", claims: { tenant: "tenant_a" }, query: "SELECT id FROM documents ORDER BY id", expected: [{ id: 1 }] },
+      { name: "foreign_tenant_empty", category: "permissions", role: "authenticated", claims: { tenant: "tenant_c" }, query: "SELECT id FROM documents ORDER BY id", expected: [] },
+      { name: "queue_fixture", category: "queues", role: "postgres", query: "SELECT msg_id, message FROM pgmq.q_work ORDER BY msg_id", expected: [{ msg_id: 1, message: { kind: "fixture" } }] },
+      { name: "business_fixture", category: "business", role: "postgres", query: "SELECT count(*)::integer AS count FROM documents", expected: [{ count: 2 }] },
+    ],
+    marker_query: `SELECT snapshot_id, to_char(recovered_through AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS recovered_through FROM restore_marker`,
+    http_checks: [
+      { slug: "check", path: "/", auth: "anonymous", status: 401, sha256: sha256(JSON.stringify({ msg: "Invalid JWT" })) },
+      { slug: "check", path: "/", auth: "service_role", status: 200, sha256: sha256("restore-ok") },
+    ],
+    max_rpo_ms: 600_000, max_rto_ms: 120_000, signature: "",
+  };
+  if (kind === "pgbackrest") snapshot.sql_checks.push({
+    name: "after_target_transaction_absent", category: "business", role: "postgres",
+    query: "SELECT count(*)::integer AS count FROM recovery_noise", expected: [{ count: 0 }],
+  });
+  snapshot.signature = signDrillDocument(snapshot as unknown as Record<string, unknown>, process.env.SUPACLOUD_SNAPSHOT_SIGNING_KEY!);
+  await Bun.write(join(output, "manifest.json"), JSON.stringify(snapshot) + "\n");
+  console.log(JSON.stringify({ snapshot_id: snapshotId, method: kind, files: files.length }));
+} finally {
+  await command(["pg_ctl", "-D", source, "-m", "immediate", "-w", "stop"]).catch(() => {});
+}

--- a/packages/management-api/tests/unit/restore-drill.test.ts
+++ b/packages/management-api/tests/unit/restore-drill.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  COMPONENTS, parseRestoreSnapshot, safeRestorePath, sha256, signDrillDocument, verifyDrillDocument,
+  type RestoreSnapshot,
+} from "../../src/services/restore-drill-contract";
+import { assertDrillIsolation, pgbackrestArgs, postgresRecoveryTimestamp, verifyRestoreInventory } from "../../src/services/project-restore-drill";
+import { decryptSecretWithKey, encryptSecretWithKey } from "../../src/utils/secret-crypto-core";
+
+const key = "snapshot-key-".repeat(4);
+const roots: string[] = [];
+afterEach(async () => { for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true }); });
+
+function fixture(): RestoreSnapshot {
+  const snapshot: RestoreSnapshot = {
+    schema: "supacloud.project-restore-snapshot.v1", snapshot_id: crypto.randomUUID(), project_ref: "testproject",
+    incident_at: "2026-09-08T00:00:00.000Z",
+    recovery_points: Object.fromEntries(COMPONENTS.map((component) => [component, "2026-09-07T23:59:00.000Z"])) as RestoreSnapshot["recovery_points"],
+    database: { kind: "logical-full", name: "project_db", admin_role: "postgres", major: 18 },
+    files: ["database/database.dump", "database/globals.sql", "objects/file", "runtime/check.js", "secrets/runtime-env.enc"]
+      .map((path) => ({ path, bytes: 4, sha256: sha256("test") })),
+    database_env_keys: ["FA_DATABASE_URL"],
+    sql_checks: [
+      { category: "permissions", name: "tenant_allowed", role: "authenticated", query: "SELECT 1 AS visible", expected: [{ visible: 1 }] },
+      { category: "permissions", name: "tenant_denied", role: "authenticated", query: "SELECT 1 WHERE false", expected: [] },
+      { category: "queues", name: "queue", role: "postgres", query: "SELECT 1", expected: [] },
+      { category: "business", name: "business", role: "postgres", query: "SELECT 1", expected: [] },
+    ],
+    marker_query: "SELECT snapshot_id, recovered_through FROM restore_marker",
+    http_checks: [
+      { slug: "check", path: "/", auth: "anonymous", status: 401, sha256: sha256("denied") },
+      { slug: "check", path: "/", auth: "service_role", status: 200, sha256: sha256("ok") },
+    ],
+    max_rpo_ms: 60000, max_rto_ms: 120000, signature: "",
+  };
+  return snapshot;
+}
+
+function serialized(snapshot = fixture()): string {
+  snapshot.signature = signDrillDocument(snapshot as unknown as Record<string, unknown>, key);
+  return JSON.stringify(snapshot);
+}
+
+test("signed complete manifests preserve method, fixture coverage and budgets", () => {
+  const result = parseRestoreSnapshot(serialized(), key);
+  expect(result.database.kind).toBe("logical-full");
+  expect(result.sql_checks.length).toBe(4);
+  expect(result.max_rpo_ms).toBe(60000);
+});
+
+test("tampering, missing keys and invalid source signature fail closed", () => {
+  const raw = serialized();
+  expect(() => parseRestoreSnapshot(raw.replace("60000", "60001"), key)).toThrow("signature");
+  expect(() => parseRestoreSnapshot(raw, "other-key-".repeat(4))).toThrow("signature");
+  expect(() => parseRestoreSnapshot(raw, "")).toThrow();
+});
+
+test("paths cannot escape a component or use traversal separators", () => {
+  for (const path of ["/etc/passwd", "runtime/../secret", "runtime//file", "runtime\\file", "secrets/\u0000", "other/file"]) {
+    expect(safeRestorePath(path)).toBe(false);
+  }
+  expect(safeRestorePath("runtime/.versions/check/1/src/.supacloud-entry.js")).toBe(true);
+});
+
+test("missing component and incomplete fixture coverage cannot produce a valid plan", () => {
+  for (const component of COMPONENTS) {
+    const snapshot = fixture();
+    snapshot.files = snapshot.files.filter((entry) => !entry.path.startsWith(component + "/"));
+    expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+  }
+  for (const category of ["permissions", "queues", "business"]) {
+    const snapshot = fixture();
+    snapshot.sql_checks = snapshot.sql_checks.filter((check) => check.category !== category);
+    expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+  }
+  const snapshot = fixture();
+  snapshot.http_checks = snapshot.http_checks.filter((check) => check.auth !== "anonymous");
+  expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+});
+
+test("invalid SQL, database identities and future recovery times are rejected", () => {
+  for (const query of ["DELETE FROM business", "SELECT 1; COMMIT", "SELECT 1 -- skip", "SELECT /* injected */ 1"]) {
+    const snapshot = fixture(); snapshot.marker_query = query;
+    expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+  }
+  for (const name of ["postgres", "template1", "bad-name", "db;drop"]) {
+    const snapshot = fixture(); snapshot.database.name = name;
+    expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+  }
+  const snapshot = fixture(); snapshot.recovery_points.objects = "2099-01-01T00:00:00.000Z";
+  expect(() => parseRestoreSnapshot(serialized(snapshot), key)).toThrow();
+});
+
+test("PITR commands only reference the private target and staged repository", () => {
+  const snapshot = fixture();
+  snapshot.database = { ...snapshot.database, kind: "pgbackrest", stanza: "tenant", backup_set: "20260907-235900F", recovery_target: snapshot.incident_at };
+  snapshot.files = snapshot.files.filter((entry) => !entry.path.startsWith("database/"));
+  snapshot.files.push({ path: "database/repo/backup/tenant/backup.info", bytes: 4, sha256: sha256("test") });
+  const validated = parseRestoreSnapshot(serialized(snapshot), key);
+  const args = pgbackrestArgs(validated, "/drill/owned");
+  expect(args).toContain("--pg1-path=/drill/owned/pgdata");
+  expect(args).toContain("--repo1-path=/drill/owned/input/database/repo");
+  expect(args.join(" ")).not.toContain("pig pitr");
+  expect(postgresRecoveryTimestamp(snapshot.incident_at)).toBe("2026-09-08 00:00:00.000+00");
+});
+
+test("inventory verification reads actual bytes and refuses omissions or symlinks", async () => {
+  const root = await mkdtemp(join(tmpdir(), "supacloud-restore-inventory-")); roots.push(root);
+  const snapshot = fixture();
+  for (const component of COMPONENTS) await mkdir(join(root, component));
+  for (const entry of snapshot.files) await Bun.write(join(root, entry.path), "test");
+  await verifyRestoreInventory(root, snapshot);
+  await Bun.write(join(root, "objects/unlisted"), "extra");
+  await expect(verifyRestoreInventory(root, snapshot)).rejects.toThrow("incomplete");
+  await rm(join(root, "objects/unlisted"));
+  await Bun.write(join(root, "objects/file"), "edit");
+  await expect(verifyRestoreInventory(root, snapshot)).rejects.toThrow("digest");
+  await rm(join(root, "objects/file"));
+  await symlink(join(root, "runtime/check.js"), join(root, "objects/file"));
+  await expect(verifyRestoreInventory(root, snapshot)).rejects.toThrow("symlink");
+});
+
+test("existing AES-GCM snapshot encryption requires the exact recovery key", () => {
+  const payload = JSON.stringify({ snapshot_id: "fixture", project_ref: "testproject", values: { credential: "private" } });
+  const encrypted = encryptSecretWithKey(payload, "recovery-key-".repeat(4));
+  expect(encrypted).not.toContain("private");
+  expect(decryptSecretWithKey(encrypted, "recovery-key-".repeat(4))).toBe(payload);
+  expect(() => decryptSecretWithKey(encrypted, "wrong-key-".repeat(4))).toThrow();
+});
+
+test("receipt signature detects forged success and does not expose key material", () => {
+  const receipt = { schema: "supacloud.project-restore-drill.v1", status: "failed", signature: "" };
+  receipt.signature = signDrillDocument(receipt, key);
+  verifyDrillDocument(receipt, key);
+  expect(JSON.stringify(receipt)).not.toContain(key);
+  expect(() => verifyDrillDocument({ ...receipt, status: "succeeded" }, key)).toThrow("signature");
+});
+
+test.skipIf(process.platform === "linux")("host execution refuses restoration before any command", async () => {
+  await expect(assertDrillIsolation()).rejects.toThrow("non-root Linux container");
+});

--- a/scripts/project-restore-drill.ts
+++ b/scripts/project-restore-drill.ts
@@ -1,0 +1,18 @@
+import { readProjectRestoreDrill, runProjectRestoreDrill } from "../packages/management-api/src/services/project-restore-drill";
+
+const [operation, drillId, confirmation] = process.argv.slice(2);
+try {
+  if (operation === "status" && drillId && !confirmation) {
+    console.log(JSON.stringify(await readProjectRestoreDrill(drillId)));
+  } else if (operation === "run" && drillId && confirmation) {
+    const receipt = await runProjectRestoreDrill(drillId, confirmation);
+    console.log(JSON.stringify(receipt));
+    if (receipt.status !== "succeeded") process.exitCode = 1;
+  } else {
+    console.error("Usage: project-restore-drill.ts run <uuid> <confirmation> | status <uuid>");
+    process.exitCode = 2;
+  }
+} catch {
+  console.error("Restore drill refused or outcome unknown; inspect the signed receipt before any new attempt.");
+  process.exitCode = 1;
+}

--- a/scripts/test-project-restore-drill.ts
+++ b/scripts/test-project-restore-drill.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, realpath, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { verifyDrillDocument } from "../packages/management-api/src/services/restore-drill-contract";
+
+// 端到端测试只使用显式选择的本地 Docker socket 和临时合成数据。
+const [image, linuxBun, context] = process.argv.slice(2);
+if (!image || !linuxBun || !context) {
+  throw new Error("Usage: bun scripts/test-project-restore-drill.ts <postgres-pgbackrest-image> <linux-bun-path> <local-docker-context>");
+}
+const docker = ["docker", "--context", context];
+async function command(args: string[], allowFailure = false) {
+  const child = Bun.spawn(args, { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+  const timer = setTimeout(() => child.kill("SIGKILL"), 180_000);
+  try {
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+    ]);
+    if (code !== 0 && !allowFailure) throw new Error(`Local drill test command failed (${args[0]}): ${stderr.slice(-2000)}`);
+    return { code, stdout, stderr };
+  } finally { clearTimeout(timer); }
+}
+const inspected = JSON.parse((await command([...docker, "context", "inspect", context])).stdout);
+if (!String(inspected[0]?.Endpoints?.docker?.Host).startsWith("unix://")) throw new Error("Only local Docker sockets are allowed");
+const repository = resolve(import.meta.dir, "..");
+const binary = await realpath(linuxBun);
+const dependencyLink = join(repository, "packages/edge-runtime/node_modules");
+const dependencyDirectory = await realpath(dependencyLink);
+const artifacts = await mkdtemp(join(tmpdir(), "supacloud-restore-drill-e2e-"));
+const suffix = crypto.randomUUID().slice(0, 8);
+const volume = `supacloud-drill-e2e-${suffix}`;
+const containers: string[] = [];
+const signingKey = "synthetic-snapshot-signing-key-for-local-drills";
+const encryptionKey = "synthetic-encryption-key-for-local-restore-drills";
+const receiptKey = "synthetic-receipt-signing-key-for-local-drills";
+const secrets = [
+  "--env", `SUPACLOUD_SNAPSHOT_SIGNING_KEY=${signingKey}`,
+  "--env", `SUPACLOUD_RESTORE_ENCRYPTION_KEY=${encryptionKey}`,
+  "--env", `SUPACLOUD_DRILL_RECEIPT_KEY=${receiptKey}`,
+];
+const mounts = [
+  "--mount", `type=bind,src=${binary},dst=/usr/local/bin/bun,readonly`,
+  "--mount", `type=bind,src=${repository},dst=/app,readonly`,
+  ...(dependencyDirectory !== dependencyLink
+    ? ["--mount", `type=bind,src=${dependencyDirectory},dst=${dependencyDirectory},readonly`] : []),
+];
+const base = [
+  ...docker, "run", "--network", "none", "--cap-drop", "ALL", "--security-opt", "no-new-privileges",
+  "--user", "postgres", "--entrypoint", "/usr/local/bin/bun", ...secrets, ...mounts,
+];
+const results: Array<Record<string, unknown>> = [];
+await command([...docker, "volume", "create", volume]);
+try {
+  await command([
+    ...docker, "run", "--rm", "--network", "none", "--mount", `type=volume,src=${volume},dst=/drill`,
+    "--entrypoint", "install", image, "-d", "-m", "700", "-o", "postgres", "-g", "postgres", "/drill",
+  ]);
+  for (const [index, kind] of ["logical-full", "pgbackrest"].entries()) {
+    const producer = `supacloud-drill-source-${suffix}-${index}`;
+    containers.push(producer);
+    const generated = await command([
+      ...base, "--name", producer, image, "--no-env-file",
+      "/app/packages/management-api/tests/fixtures/create-restore-drill-snapshot.ts", kind, "/tmp/drill-fixture/backup",
+    ]);
+    const { snapshot_id: snapshotId } = JSON.parse(generated.stdout.trim());
+    const backup = join(artifacts, kind);
+    await command([...docker, "cp", `${producer}:/tmp/drill-fixture/backup`, backup]);
+    const runMounts = [
+      "--mount", `type=bind,src=${backup},dst=/backup,readonly`,
+      "--mount", `type=volume,src=${volume},dst=/drill`,
+    ];
+    const drillId = crypto.randomUUID();
+    const consumer = `supacloud-drill-target-${suffix}-${index}`;
+    containers.push(consumer);
+    const confirmation = `RESTORE_DRILL:drillfixture:${snapshotId}:${drillId}`;
+    const completed = await command([
+      ...base, "--name", consumer, ...runMounts, image, "--no-env-file",
+      "/app/scripts/project-restore-drill.ts", "run", drillId, confirmation,
+    ]);
+    const receipt = JSON.parse(completed.stdout.trim());
+    verifyDrillDocument(receipt, receiptKey);
+    if (receipt.status !== "succeeded" || receipt.backup_method !== kind
+      || !Number.isSafeInteger(receipt.max_rpo_ms) || receipt.rpo_ms > receipt.max_rpo_ms
+      || !Number.isSafeInteger(receipt.max_rto_ms) || receipt.rto_ms > receipt.max_rto_ms
+      || (kind === "pgbackrest" && !receipt.checks.some((check: { name: string }) => check.name === "after_target_transaction_absent"))) {
+      throw new Error("Full restore acceptance did not pass");
+    }
+    await command([...docker, "cp", `${consumer}:/drill/${drillId}/receipt.json`, join(artifacts, `${kind}-receipt.json`)]);
+    const replay = await command([
+      ...base, "--rm", ...runMounts, image, "--no-env-file",
+      "/app/scripts/project-restore-drill.ts", "run", drillId, confirmation,
+    ], true);
+    if (replay.code === 0) throw new Error("Existing drill ID was incorrectly replayed");
+    const status = JSON.parse((await command([
+      ...base, "--rm", ...runMounts, image, "--no-env-file",
+      "/app/scripts/project-restore-drill.ts", "status", drillId,
+    ])).stdout);
+    verifyDrillDocument(status.receipt, receiptKey);
+    if (status.receipt.signature !== receipt.signature || status.effective_status !== "succeeded") {
+      throw new Error("Replay modified the authoritative receipt");
+    }
+    // 使用新的演练 ID 验证真实损坏对象会在数据库恢复前被拒绝。
+    await writeFile(join(backup, "objects/fixture.txt"), "tampered-object");
+    const failedId = crypto.randomUUID();
+    const failure = await command([
+      ...base, "--rm", ...runMounts, image, "--no-env-file",
+      "/app/scripts/project-restore-drill.ts", "run", failedId,
+      `RESTORE_DRILL:drillfixture:${snapshotId}:${failedId}`,
+    ], true);
+    const failed = JSON.parse(failure.stdout.trim());
+    verifyDrillDocument(failed, receiptKey);
+    if (failure.code === 0 || failed.status !== "failed" || failed.phase !== "inventory") {
+      throw new Error("Corrupt component was not rejected before restore");
+    }
+    await writeFile(join(backup, "objects/fixture.txt"), "restored-object");
+    results.push({
+      method: kind, drill_id: drillId, snapshot_id: snapshotId, snapshot_sha256: receipt.snapshot_sha256,
+      rpo_ms: receipt.rpo_ms, rto_ms: receipt.rto_ms, checks: receipt.checks.length,
+      duplicate_id_refused: true, corrupted_component_refused: true,
+    });
+  }
+  await writeFile(join(artifacts, "summary.json"), JSON.stringify({
+    scope: "synthetic-local-fixtures-only", image, results,
+  }, null, 2) + "\n");
+  console.log(JSON.stringify({ artifacts, results }));
+} finally {
+  for (const name of containers.reverse()) await command([...docker, "rm", "-f", name], true);
+  await command([...docker, "volume", "rm", volume], true);
+}


### PR DESCRIPTION
## Summary
- Add an operator-only isolated project restore runner with a signed complete inventory covering database backups, exported object files, encrypted runtime secrets and function/runtime metadata.
- Support actual pgBackRest time-target recovery and explicitly separate logical-full restores. Remap tablespaces, replace production PostgreSQL configuration and verify recovery has completed before acceptance.
- Require non-root Linux Docker execution, disabled networking, a read-only source, private new target directory, independent keys and exact source/snapshot/drill confirmation. Never overwrite or replay an existing drill ID.
- Verify staged file bytes before restore commands, decrypt using the existing AES-GCM format, run tenant permission/queue/business/function canaries, and persist signed status/evidence receipts with actual RPO/RTO and budgets.
- Add a reproducible local-only end-to-end harness, snapshot fixtures, operator documentation and an operational image definition.
- Extract explicit-key crypto helpers without changing their format or existing exports, so the isolated runner does not load Management configuration before its safety guards.

## Validation
- Restore, secret-key migration and final security regression suites: 65 passed, 264 assertions.
- Management API typecheck and restore CLI Bun bundle passed.
- Real local Linux PostgreSQL 18 / pgBackRest 2.58.0 / Bun 1.4.0: logical-full and physical PITR restored successfully with eight and nine acceptance checks respectively.
- Both methods reject duplicate drill IDs without altering the original receipt and reject a corrupted object before database restoration. Physical PITR excludes a transaction committed after the requested target.
- `git diff --check`.
- Final integrated run against main `645b23e7`: logical-full RPO/RTO 408/1293 ms; physical PITR RPO/RTO 2177/4415 ms. These are tiny synthetic fixtures, not production measurements.
- Logical snapshot SHA-256: `f58e955f428782164ff882b82827276920d28818cb08ac69906661c3feef4b1e`.
- PITR snapshot SHA-256: `c90628fc08de5f079e3c6c276dcb5f00ac518123011b90e0a2fb1159388ad239`.

## Safety And Scope
- No SSH, server access, production restore, deployment, public restore endpoint, second execution ledger or historical migration changes.
- Snapshot export consistency remains the backup operator's responsibility. This restores the exported object filesystem namespace, not production S3 provisioning or provider-specific object version/ACL behavior.
- Queue checks verify supplied recovered SQL fixtures; the synthetic harness does not provision a production queue service. Applications requiring additional services must supply compatible isolated fixtures.
- Orphaned running receipts report unknown outcome; mutations are never automatically retried.
- Synthetic RPO/RTO does not establish production recovery guarantees. The operational Dockerfile still needs a full image build, digest pinning and approved production-snapshot acceptance; source execution was validated in a local equivalent toolchain image.

## Related
- Completes the restore-drill workstream alongside #1209 (metrics), #1210 (JSON response contracts), #1212 (tracing), and #1215 (multi-function release manifests).
