### PR TITLE
fix(management-api): preserve application ACLs during runtime maintenance

### DIFF
--- a/docs/postgrest-runtime-lifecycle.md
+++ b/docs/postgrest-runtime-lifecycle.md
@@ -71,6 +71,21 @@ The runtime reconcile worker periodically compares desired state with systemd ac
 
 The worker does not implement idle auto-shrink. That is intentional for the first version because it avoids request-path cold starts and avoids per-tenant access-time tracking complexity.
 
+### Application Permissions
+
+Runtime preparation and the existing-tenant schema maintenance script only ensure
+`service_role` has `USAGE` on `public`. They must not grant privileges on all
+application tables, sequences, or routines. Application migrations own those
+object-level `GRANT` and `REVOKE` decisions; `BYPASSRLS` is not a substitute for
+object privileges or authorization through command functions.
+
+This change prevents future runtime maintenance from broadening application
+permissions. It does not infer or revoke grants introduced by older releases:
+operators must review their application's expected ACLs and restore them through
+an explicit forward migration. Keep intentionally authorized RPCs and direct data
+access working. New-project bootstrap and branch-restore privilege policies are
+separate from this runtime-maintenance change.
+
 ## Systemd Units
 
 PostgREST remains one physical systemd unit per project:

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -1,6 +1,7 @@
 import { sql, resolveDbName, resolveSlotName } from '../db';
 import { SQL_MODULES } from '../db/sql-modules';
 import { databaseService } from '../services/database.service';
+import { TENANT_PUBLIC_SCHEMA_ACCESS_SQL } from '../services/tenant-public-schema-access';
 import { logger } from '../utils/logger';
 
 const ALTER_TENANT_SQL = `
@@ -325,12 +326,8 @@ GRANT USAGE, CREATE ON SCHEMA realtime TO supabase_admin, supabase_realtime_admi
 
 GRANT ALL ON ALL TABLES IN SCHEMA auth TO supabase_auth_admin;
 
--- 10a. service_role must be able to administer existing application tables.
--- BYPASSRLS is not enough when PostgREST checks table privileges first.
-GRANT USAGE ON SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL ROUTINES IN SCHEMA public TO service_role;
+-- 10a. Preserve application-managed object privileges during runtime maintenance.
+${TENANT_PUBLIC_SCHEMA_ACCESS_SQL}
 
 -- 10. Functions Schema (Webhooks)
 CREATE SCHEMA IF NOT EXISTS supabase_functions;

--- a/packages/management-api/src/services/tenant-public-schema-access.ts
+++ b/packages/management-api/src/services/tenant-public-schema-access.ts
@@ -1,0 +1,5 @@
+// Runtime reconciliation may restore schema lookup, but must preserve application
+// GRANT/REVOKE decisions. Object privileges belong to application migrations.
+export const TENANT_PUBLIC_SCHEMA_ACCESS_SQL = `
+GRANT USAGE ON SCHEMA public TO service_role;
+`;

--- a/packages/management-api/src/services/tenant-runtime-migration.ts
+++ b/packages/management-api/src/services/tenant-runtime-migration.ts
@@ -1,4 +1,5 @@
 import { SQL_MODULES } from "../db/sql-modules";
+import { TENANT_PUBLIC_SCHEMA_ACCESS_SQL } from "./tenant-public-schema-access";
 
 // Tenant schema migration SQL (sourced from migrate-tenant-schema.ts)
 export const ALTER_TENANT_SQL = `
@@ -307,12 +308,8 @@ GRANT USAGE, CREATE ON SCHEMA realtime TO supabase_admin, supabase_realtime_admi
 
 GRANT ALL ON ALL TABLES IN SCHEMA auth TO supabase_auth_admin;
 
--- 10a. service_role must be able to administer existing application tables.
--- BYPASSRLS is not enough when PostgREST checks table privileges first.
-GRANT USAGE ON SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO service_role;
-GRANT ALL PRIVILEGES ON ALL ROUTINES IN SCHEMA public TO service_role;
+-- 10a. Preserve application-managed object privileges during runtime maintenance.
+${TENANT_PUBLIC_SCHEMA_ACCESS_SQL}
 
 -- 10. Functions Schema (Webhooks)
 CREATE SCHEMA IF NOT EXISTS supabase_functions;

--- a/packages/management-api/tests/integration/tenant-public-schema-access.test.ts
+++ b/packages/management-api/tests/integration/tenant-public-schema-access.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { TENANT_PUBLIC_SCHEMA_ACCESS_SQL } from "../../src/services/tenant-public-schema-access";
+
+// Opt in to an explicitly selected local PostgreSQL container; never discover a
+// server or reuse the management service's DATABASE_URL for this DDL fixture.
+const container = process.env.SUPACLOUD_TEST_PG_CONTAINER;
+const postgresTests = container ? describe : describe.skip;
+
+postgresTests("tenant runtime application ACL preservation (PostgreSQL)", () => {
+  test("repeated maintenance preserves least privilege and explicitly granted commands", () => {
+    const sql = `
+BEGIN;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN;
+  END IF;
+END $$;
+CREATE SCHEMA tenant_acl_fixture;
+CREATE TABLE public.tenant_acl_fixture_records(id bigint PRIMARY KEY);
+CREATE SEQUENCE public.tenant_acl_fixture_sequence;
+CREATE FUNCTION public.tenant_acl_fixture_internal() RETURNS integer LANGUAGE sql AS $$ SELECT 1 $$;
+CREATE FUNCTION public.tenant_acl_fixture_command() RETURNS integer LANGUAGE sql AS $$ SELECT 2 $$;
+REVOKE ALL ON TABLE public.tenant_acl_fixture_records FROM PUBLIC, service_role;
+GRANT SELECT ON TABLE public.tenant_acl_fixture_records TO service_role;
+REVOKE ALL ON SEQUENCE public.tenant_acl_fixture_sequence FROM PUBLIC, service_role;
+GRANT USAGE ON SEQUENCE public.tenant_acl_fixture_sequence TO service_role;
+REVOKE ALL ON FUNCTION public.tenant_acl_fixture_internal() FROM PUBLIC, service_role;
+REVOKE ALL ON FUNCTION public.tenant_acl_fixture_command() FROM PUBLIC, service_role;
+GRANT EXECUTE ON FUNCTION public.tenant_acl_fixture_command() TO service_role;
+CREATE FUNCTION tenant_acl_fixture.permissions() RETURNS jsonb LANGUAGE sql AS $$
+  SELECT jsonb_build_object(
+    'select', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'SELECT'),
+    'insert', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'INSERT'),
+    'update', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'UPDATE'),
+    'delete', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'DELETE'),
+    'truncate', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'TRUNCATE'),
+    'references', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'REFERENCES'),
+    'trigger', has_table_privilege('service_role', 'public.tenant_acl_fixture_records', 'TRIGGER'),
+    'sequenceUsage', has_sequence_privilege('service_role', 'public.tenant_acl_fixture_sequence', 'USAGE'),
+    'sequenceSelect', has_sequence_privilege('service_role', 'public.tenant_acl_fixture_sequence', 'SELECT'),
+    'sequenceUpdate', has_sequence_privilege('service_role', 'public.tenant_acl_fixture_sequence', 'UPDATE'),
+    'internal', has_function_privilege('service_role', 'public.tenant_acl_fixture_internal()', 'EXECUTE'),
+    'command', has_function_privilege('service_role', 'public.tenant_acl_fixture_command()', 'EXECUTE')
+  )
+$$;
+SELECT tenant_acl_fixture.permissions();
+${TENANT_PUBLIC_SCHEMA_ACCESS_SQL}
+SELECT tenant_acl_fixture.permissions();
+${TENANT_PUBLIC_SCHEMA_ACCESS_SQL}
+SELECT tenant_acl_fixture.permissions();
+ROLLBACK;
+`;
+    const result = spawnSync("docker", ["exec", "-i", container!, "psql", "-X", "-qAt",
+      "-v", "ON_ERROR_STOP=1", "-U", "postgres", "-d", "postgres"], {
+      input: sql, encoding: "utf8", timeout: 30_000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    const rows = result.stdout.trim().split("\n").map(line => JSON.parse(line));
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual({
+      select: true, insert: false, update: false, delete: false, truncate: false,
+      references: false, trigger: false, sequenceUsage: true, sequenceSelect: false,
+      sequenceUpdate: false, internal: false, command: true,
+    });
+    expect(rows[1]).toEqual(rows[0]);
+    expect(rows[2]).toEqual(rows[0]);
+  }, 35_000);
+});

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { SQL_MODULES } from "../../src/db/sql-modules";
 import { ALTER_TENANT_SQL } from "../../src/services/tenant-runtime-migration";
+import { TENANT_PUBLIC_SCHEMA_ACCESS_SQL } from "../../src/services/tenant-public-schema-access";
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(resolve(import.meta.dir, "../..", relativePath), "utf8");
@@ -13,6 +14,21 @@ function sqlModuleInterpolation(name: keyof typeof SQL_MODULES): string {
 }
 
 describe("supabase bootstrap schema", () => {
+  test("runtime maintenance preserves application object ACLs in both migration entry points", () => {
+    expect(TENANT_PUBLIC_SCHEMA_ACCESS_SQL.trim()).toBe("GRANT USAGE ON SCHEMA public TO service_role;");
+    expect(ALTER_TENANT_SQL).toContain(TENANT_PUBLIC_SCHEMA_ACCESS_SQL);
+    for (const source of [
+      ALTER_TENANT_SQL,
+      readRepoFile("src/services/tenant-runtime-migration.ts"),
+      readRepoFile("src/scripts/migrate-tenant-schema.ts"),
+    ]) {
+      expect(source).not.toMatch(/GRANT\s+[^;]*ON\s+ALL\s+(?:TABLES|SEQUENCES|ROUTINES|FUNCTIONS)\s+IN\s+SCHEMA\s+"?public"?\s+TO\s+[^;]*\bservice_role\b/i);
+      expect(source).not.toMatch(/ALTER\s+DEFAULT\s+PRIVILEGES[^;]*IN\s+SCHEMA\s+public[^;]*TO\s+service_role/i);
+    }
+    expect(readRepoFile("src/scripts/migrate-tenant-schema.ts"))
+      .toContain("${TENANT_PUBLIC_SCHEMA_ACCESS_SQL}");
+  });
+
   test("exports the extracted tenant runtime migration used by the service", () => {
     const service = readRepoFile("src/services/tenant-runtime.service.ts");
 


### PR DESCRIPTION
## Problem
PostgREST preparation calls ensureTenantSchemaMigrations, whose ALTER_TENANT_SQL grants service_role all privileges on every public table, sequence and routine. Restart/resume/repair can therefore override application REVOKE decisions, enabling direct writes and internal-function execution again. The standalone existing-tenant maintenance script duplicates this behavior.

## Change
- Share the runtime public-schema access fragment between both maintenance paths.
- Ensure schema USAGE only; preserve application-managed object ACLs.
- Keep new-project bootstrap and branch-restore behavior unchanged.
- Document that already broadened ACLs still need application-reviewed forward remediation; this patch does not guess or automatically revoke them.

## Verification
- Real local PostgreSQL reproduction of the old block: table write/internal execute changed from false/false to true/true. Entire experiment rolled back.
- 49 tests pass, 0 fail, 473 assertions, including a real PostgreSQL regression that preserves SELECT-only tables, USAGE-only sequences, private functions and explicitly granted command functions after repeated maintenance.
- Command: SUPACLOUD_TEST_PG_CONTAINER=fa-pg18-rpc bun --no-env-file test tests/unit/supabase-schema.test.ts tests/unit/tenant-runtime.security.test.ts tests/integration/tenant-public-schema-access.test.ts
- git diff --check passed.
- No production writes or deployments; remote CI not polled.