### PR TITLE
fix(compiler): avoid duplicate GraphQL enum and input types

### DIFF
--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -72,6 +72,41 @@ Consumers of that optional file must install `@graphql-typed-document-node/core`
 it provides `ResultOf` and `VariablesOf` for operation-level inference. The default
 fetch client still needs no GraphQL runtime dependency.
 
+Both outputs use the operation plugin as the single owner of referenced enums
+and input objects. Regenerate both files after upgrading the compiler; do not
+deduplicate declarations by editing generated files. Scalar mappings are applied
+directly to operation/input fields, and types unused by queries are not emitted.
+
+Consumer acceptance tests cover both SDK and TypedDocumentNode output:
+
+```gherkin
+Scenario: Shared enum types
+  Given multiple queries share an enum in variables and selected fields
+  When the compiler generates the client artifacts
+  Then each artifact declares the enum once and passes strict TypeScript checks
+
+Scenario: Nested input objects
+  Given recursive input objects contain enum lists, defaults and custom scalars
+  When the compiler generates the client artifacts
+  Then input declarations are unique and valid variables retain their types
+
+Scenario: Invalid consumer code
+  Given generated query contracts
+  When a consumer supplies invalid variables or reads an unselected field
+  Then TypeScript rejects the consumer code
+
+Scenario: Release package acceptance
+  Given an installed compiler package
+  When its CLI runs the same consumer acceptance suite
+  Then both artifact formats pass without editing generated files
+```
+
+Run `bun test src/graphql-package.test.ts` from this package. To test an installed
+tarball or registry release with the same suite, set
+`SUPACLOUD_COMPILER_TEST_CLI` to its absolute `dist/cli.js` path.
+`bun run test:package` checks the built CLI and runs automatically after the build
+in `prepublishOnly`, blocking publication when generated consumer types fail.
+
 ```ts
 import { createGraphqlClient } from "./generated/graphql";
 const queries = createGraphqlClient({

--- a/packages/compiler/bun.lock
+++ b/packages/compiler/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@graphql-codegen/core": "^6.2.0",
         "@graphql-codegen/typed-document-node": "^7.1.0",
-        "@graphql-codegen/typescript": "^6.1.0",
         "@graphql-codegen/typescript-operations": "^6.1.6",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@typescript/typescript6": "^6.0.2",
@@ -31,8 +30,6 @@
     "@graphql-codegen/schema-ast": ["@graphql-codegen/schema-ast@6.1.0", "https://registry.npmmirror.com/@graphql-codegen/schema-ast/-/schema-ast-6.1.0.tgz", { "dependencies": { "@graphql-codegen/plugin-helpers": "^7.1.0", "@graphql-tools/utils": "^11.2.0", "tslib": "^2.8.0" }, "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-/xuGkM5gUNFRoaQLumKbENdX7Hc8ha49z9OXsEZY8E+46mMjqzXGF0NtCJ892cmoX7EUgI5c8T+LZqS2upx2Aw=="],
 
     "@graphql-codegen/typed-document-node": ["@graphql-codegen/typed-document-node@7.1.0", "https://registry.npmmirror.com/@graphql-codegen/typed-document-node/-/typed-document-node-7.1.0.tgz", { "dependencies": { "@graphql-codegen/plugin-helpers": "^7.1.0", "@graphql-codegen/visitor-plugin-common": "^7.2.0", "auto-bind": "^5.0.0", "change-case-all": "^2.1.0", "tslib": "^2.8.0" }, "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-V6H+ItyqXtYY+JQb76LAoN627Xfzpn29/ifwCFAv61iEepzNzh86sa+yZclflr0G8LDmhcVY5hpPJd3a1qbOfw=="],
-
-    "@graphql-codegen/typescript": ["@graphql-codegen/typescript@6.1.0", "https://registry.npmmirror.com/@graphql-codegen/typescript/-/typescript-6.1.0.tgz", { "dependencies": { "@graphql-codegen/plugin-helpers": "^7.1.0", "@graphql-codegen/schema-ast": "^6.1.0", "@graphql-codegen/visitor-plugin-common": "^7.2.0", "auto-bind": "^5.0.0", "tslib": "~2.8.0" }, "peerDependencies": { "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-2Hu3111O/AwV28Ap7tNsixlmXSAJuQbQArQklx+IC/tNswpckZnCfmlcBtTJrGU1+mJXEneJXGfb2XWvKjbhlQ=="],
 
     "@graphql-codegen/typescript-operations": ["@graphql-codegen/typescript-operations@6.1.6", "https://registry.npmmirror.com/@graphql-codegen/typescript-operations/-/typescript-operations-6.1.6.tgz", { "dependencies": { "@graphql-codegen/plugin-helpers": "^7.1.0", "@graphql-codegen/schema-ast": "^6.1.0", "@graphql-codegen/visitor-plugin-common": "^7.2.5", "auto-bind": "^5.0.0", "tslib": "^2.8.0" }, "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "graphql-sock": "^1.0.0" }, "optionalPeers": ["graphql-sock"] }, "sha512-qsYRkK27YbSL2doifPvldVwdwHRQtpsxXJINs22wQWGksC1Mrgn9YNaAGUZ2so46U20TKTm4SBoiNXRJE3esqA=="],
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -25,8 +25,9 @@
     "build:js": "bun build src/index.ts src/cli.ts --outdir dist --target node --external @typescript/typescript6 --external graphql --external '@graphql-codegen/*'",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "clean": "rm -rf dist",
-    "prepublishOnly": "bun run build",
+    "prepublishOnly": "bun run build && bun run test:package",
     "test": "bun test",
+    "test:package": "SUPACLOUD_COMPILER_TEST_CLI=\"$PWD/dist/cli.js\" bun test src/graphql-package.test.ts",
     "benchmark": "bun run src/benchmark.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
@@ -47,7 +48,6 @@
   "dependencies": {
     "@graphql-codegen/core": "^6.2.0",
     "@graphql-codegen/typed-document-node": "^7.1.0",
-    "@graphql-codegen/typescript": "^6.1.0",
     "@graphql-codegen/typescript-operations": "^6.1.6",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@typescript/typescript6": "^6.0.2",

--- a/packages/compiler/src/graphql-client.ts
+++ b/packages/compiler/src/graphql-client.ts
@@ -50,7 +50,7 @@ export function createGraphqlClient(options: GraphqlClientOptions) {
       method: "POST",
       headers,
       body: JSON.stringify({ query, variables }),
-      signal: request?.signal,
+      ...(request?.signal ? { signal: request.signal } : {}),
       redirect: "error",
     });
     if (!response.ok) {

--- a/packages/compiler/src/graphql-package.test.ts
+++ b/packages/compiler/src/graphql-package.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { writeFixtureProject } from "./fixtures/helpers";
+
+const temporary: string[] = [];
+const consumerOptions = {
+  strict: true,
+  noUncheckedIndexedAccess: true,
+  exactOptionalPropertyTypes: true,
+  noImplicitOverride: true,
+  noPropertyAccessFromIndexSignature: true,
+  noFallthroughCasesInSwitch: true,
+  skipLibCheck: false,
+  noEmit: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  types: [],
+} satisfies ts.CompilerOptions;
+
+const scenarios = [
+  {
+    name: "scalar variables",
+    schema: "",
+    arguments: "id: ID!",
+    variables: "$id: ID!",
+    call: "id: $id",
+    valid: '{ id: "42" }',
+    invalid: "{ id: 42 }",
+    declarations: [],
+  },
+  {
+    name: "shared input and output enums",
+    schema: "enum Status { OPEN CLOSED }",
+    arguments: "status: Status!",
+    variables: "$status: Status! = OPEN",
+    call: "status: $status",
+    valid: '{ status: "OPEN" }',
+    invalid: '{ status: "INVALID" }',
+    declarations: ["Status"],
+  },
+  {
+    name: "recursive input objects with enum lists and defaults",
+    schema: `
+enum Status { OPEN CLOSED }
+input IdFilter { eq: ID! }
+input OrderFilter {
+  id: IdFilter!
+  statuses: [Status!] = [OPEN]
+  and: [OrderFilter!]
+  minimum: BigInt
+}`,
+    arguments: "filter: OrderFilter!",
+    variables: "$filter: OrderFilter!",
+    call: "filter: $filter",
+    valid: '{ filter: { id: { eq: "42" }, statuses: ["OPEN"], and: [{ id: { eq: "43" } }], minimum: "100" } }',
+    invalid: '{ filter: { id: { eq: 42 }, statuses: ["INVALID"], minimum: 100 } }',
+    declarations: ["Status", "IdFilter", "OrderFilter"],
+  },
+] as const;
+
+afterEach(async () => {
+  await Promise.all(temporary.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+function diagnostics(path: string): string[] {
+  const program = ts.createProgram([path], consumerOptions);
+  return ts.getPreEmitDiagnostics(program).map((diagnostic) =>
+    ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
+}
+
+describe("GraphQL compiler consumer acceptance", () => {
+  for (const artifact of ["SDK", "TypedDocumentNode"] as const) {
+    test.each([...scenarios])(`${artifact}: $name compiles without duplicate declarations`, async (scenario) => {
+      const cli = process.env["SUPACLOUD_COMPILER_TEST_CLI"] ?? join(import.meta.dir, "cli.ts");
+      if (!isAbsolute(cli)) throw new Error("SUPACLOUD_COMPILER_TEST_CLI must be an absolute CLI entry point");
+      const directory = await mkdtemp(join(tmpdir(), "supacloud-graphql-package-"));
+      temporary.push(directory);
+      const hasStatus = scenario.declarations.some((name) => name === "Status");
+      const fields = `id total${hasStatus ? " status" : ""}`;
+      await writeFixtureProject(directory, {
+        "src/main.ts": "export const application = true;",
+        "schema.graphql": `
+scalar BigInt
+${scenario.schema}
+type Order { id: ID!, total: BigInt!, internal: String${hasStatus ? ", status: Status!" : ""} }
+type Query { orders(${scenario.arguments}): [Order!]! }
+`,
+        "src/orders.graphql": `
+query Orders(${scenario.variables}) { orders(${scenario.call}) { ...OrderFields } }
+fragment OrderFields on Order { ${fields} }
+`,
+        "src/other.graphql": `query Other(${scenario.variables}) { orders(${scenario.call}) { ${fields} } }`,
+        "supacloud.config.mjs": `export default {
+  graphql: { schema: "schema.graphql", typedDocuments: ${artifact === "TypedDocumentNode"}, scalars: { BigInt: "string" } },
+};`,
+      });
+      await symlink(join(import.meta.dir, "../node_modules"), join(directory, "node_modules"), "dir");
+      const child = Bun.spawn([process.execPath, "--no-env-file", cli, "compile", "--json"], {
+        cwd: directory, stdout: "pipe", stderr: "pipe",
+      });
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+      ]);
+      expect({ status, stderr }, stdout).toEqual({ status: 0, stderr: "" });
+
+      const output = join(directory, "generated");
+      const filename = artifact === "SDK" ? "graphql.ts" : "graphql.documents.ts";
+      const generated = await readFile(join(output, filename), "utf8");
+      const prelude = artifact === "SDK"
+        ? `import { createGraphqlClient } from "./graphql";
+type Client = ReturnType<typeof createGraphqlClient>;
+type Variables = Parameters<Client["Orders"]>[0];
+type Result = Awaited<ReturnType<Client["Orders"]>>;`
+        : `import { OrdersDocument } from "./graphql.documents";
+import type { ResultOf, VariablesOf } from "@graphql-typed-document-node/core";
+type Variables = VariablesOf<typeof OrdersDocument>;
+type Result = ResultOf<typeof OrdersDocument>;`;
+      const validConsumer = join(output, "consumer.ts");
+      await writeFile(validConsumer, `${prelude}
+const variables: Variables = ${scenario.valid};
+declare const result: Result;
+const id: string | undefined = result.orders[0]?.id;
+const total: string | undefined = result.orders[0]?.total;
+${hasStatus ? 'const status: "OPEN" | "CLOSED" | undefined = result.orders[0]?.status;' : ""}
+`);
+      expect(diagnostics(validConsumer)).toEqual([]);
+
+      const source = ts.createSourceFile(filename, generated, ts.ScriptTarget.Latest, true);
+      const declarations = source.statements.flatMap((statement) =>
+        ts.isTypeAliasDeclaration(statement) || ts.isInterfaceDeclaration(statement) || ts.isEnumDeclaration(statement)
+          ? [statement.name.text] : []);
+      expect(declarations.filter((name, index) => declarations.indexOf(name) !== index)).toEqual([]);
+      for (const name of scenario.declarations) {
+        expect(declarations.filter((declaration) => declaration === name)).toHaveLength(1);
+      }
+
+      const invalidConsumer = join(output, "invalid-consumer.ts");
+      await writeFile(invalidConsumer, `${prelude}
+const variables: Variables = ${scenario.invalid};
+declare const result: Result;
+result.orders[0]?.internal;
+`);
+      const rejected = diagnostics(invalidConsumer);
+      expect(rejected.some((message) => message.includes("is not assignable to type"))).toBe(true);
+      expect(rejected.some((message) => message.includes("Property 'internal' does not exist"))).toBe(true);
+    }, 20_000);
+  }
+});

--- a/packages/compiler/src/graphql.test.ts
+++ b/packages/compiler/src/graphql.test.ts
@@ -228,7 +228,7 @@ result.order?.internal;
     options.graphql = { schema, scalars: { BigInt: "string" } };
     const result = await renderGraphql(options);
     expect(result.diagnostics).toEqual([]);
-    expect(result.files["graphql.ts"]).toContain("BigInt: { input: string; output: string;");
+    expect(result.files["graphql.ts"]).toContain("total: string | null");
   });
 
   test("missing/broken schema and empty document inventory are structured failures", async () => {

--- a/packages/compiler/src/graphql.ts
+++ b/packages/compiler/src/graphql.ts
@@ -19,7 +19,6 @@ import {
   type IntrospectionQuery,
 } from "graphql";
 import { codegen } from "@graphql-codegen/core";
-import * as typescript from "@graphql-codegen/typescript";
 import * as operations from "@graphql-codegen/typescript-operations";
 import type { CompileOptions, Diagnostic, GraphqlContractSummary } from "./types";
 import { GRAPHQL_CLIENT_SOURCE } from "./graphql-client";
@@ -130,23 +129,23 @@ export async function renderGraphql(options: CompileOptions): Promise<GraphqlArt
   try {
     const config = {
       useTypeImports: true,
-      skipTypename: true,
-      enumsAsTypes: true,
-      onlyOperationTypes: true,
+      nonOptionalTypename: false,
+      enumType: "string-literal",
       namingConvention: "keep",
       dedupeOperationSuffix: false,
       omitOperationSuffix: false,
       defaultScalarType: "unknown",
       scalars: { ID: { input: "string", output: "string" }, ...options.graphql.scalars },
-    };
+    } satisfies operations.TypeScriptDocumentsPluginConfig;
     const generated = await codegen({
       filename: "graphql.ts",
       schema: parse(printSchema(schema)),
       schemaAst: schema,
       documents,
       config,
-      plugins: [{ typescript: {} }, { operations: {} }],
-      pluginMap: { typescript, operations },
+      // Operations v6 owns referenced enums and inputs as well as operation types.
+      plugins: [{ operations: {} }],
+      pluginMap: { operations },
     });
     const separated = separateOperations(combined);
     const methods = Object.entries(separated).sort(([a], [b]) => a.localeCompare(b)).map(([name, document]) => {
@@ -175,8 +174,8 @@ ${methods.join(",\n")}
         schemaAst: schema,
         documents,
         config,
-        plugins: [{ typescript: {} }, { operations: {} }, { typedDocuments: {} }],
-        pluginMap: { typescript, operations, typedDocuments },
+        plugins: [{ operations: {} }, { typedDocuments: {} }],
+        pluginMap: { operations, typedDocuments },
       });
     }
     result.files["graphql.manifest.json"] = JSON.stringify({


### PR DESCRIPTION
## Customer impact
Queries using enums or input objects generate duplicate TypeScript declarations in both the SDK and TypedDocumentNode output of the published @supacloud/compiler 0.13.0 package. FA migration must remain blocked until a fixed official release is available; no FA-generated files are modified.

## Fix
- Use typescript-operations v6 as the single owner of referenced enum/input/operation types in both artifact formats; remove the redundant typescript plugin and dependency.
- Keep explicit string-literal enum output, operation names and scalar mappings. Unused schema-only types and the redundant Scalars helper are no longer emitted.
- Omit an absent AbortSignal to support exactOptionalPropertyTypes without weakening consumer checks.
- Add six CLI-driven consumer cases covering scalar variables, shared input/output enums, recursive inputs, enum lists/defaults, custom scalars, fragments, multiple operations, and rejected invalid variables/unselected fields.
- Run the built-CLI consumer acceptance suite in prepublishOnly. The same suite accepts an installed registry/tarball CLI via SUPACLOUD_COMPILER_TEST_CLI.

## Local verification
- Compiler tests: 243 passed, zero failures.
- typecheck and typecheck:test passed.
- New acceptance test source separately passes all requested strict flags, including skipLibCheck: false. Generated consumers use the same strict flags. Existing compiler-wide tsconfig settings are unchanged; this is not a claim of repository-wide strict compliance.
- Build and prepublishOnly passed; built CLI acceptance: 6/6.
- Registry-installed 0.13.0 reproduces duplicate enum/input errors; the stricter added matrix also exposes the absent-signal error (1 pass, 5 fail). This is a new matrix, not the customer original six tests.
- Independently packed and installed fixed tarball: 6/6.
- Frozen install, dependency audit and git diff --check passed.

## Release boundary
This PR is the upstream fix, not an official npm release. Use the normal protected merge and Release Please publication flow; do not bypass Required Checks or substitute a local tarball for FA migration acceptance.