### PR TITLE
build(caddy): pin Go 1.27.1 and upgrade xcaddy to 0.4.7

### DIFF
--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -147,7 +147,7 @@ describe('trusted review workflow', () => {
     assert.match(readFileSync(new URL('../../scripts/audit_dependencies.ts', import.meta.url), 'utf8'), /\["audit", "--audit-level", "high"\]/);
     assert.match(workflow, /bun run \.\.\/\.\.\/scripts\/audit_dependencies\.ts/);
     assert.match(workflow, /anchore\/sbom-action@/);
-    assert.match(workflow, /XCADDY_VERSION:\s*["']v0\.4\.5["']/);
+    assert.match(workflow, /XCADDY_VERSION:\s*["']v0\.4\.7["']/);
     assert.match(workflow, /xcaddy\/cmd\/xcaddy@\$\{XCADDY_VERSION\}/);
     assert.doesNotMatch(workflow, /xcaddy\/cmd\/xcaddy@latest/);
     for (const contents of [workflow, releaseWorkflow]) {

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -943,6 +943,12 @@ jobs:
       - name: Install xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}
 
+      - name: Typecheck Caddy build contracts
+        working-directory: packages/management-api
+        run: |
+          bun install --frozen-lockfile
+          bun run typecheck:caddy-tests
+
       - name: Build Caddy Linux amd64 binary
         run: CADDY_BUILD_TARGETS=linux-amd64 OUT_DIR=packages/management-api/dist bash scripts/build_supacloud_caddy.sh
 

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -45,7 +45,8 @@ concurrency:
 env:
   NODE_VERSION: "24.x"
   BUN_VERSION: "1.4.0"
-  XCADDY_VERSION: "v0.4.5"
+  GO_VERSION: "1.27.1"
+  XCADDY_VERSION: "v0.4.7"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   # noqa: hardcoded-jwt — these are the Supabase public demo keys used for local/CI testing only
   # Source: https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys
@@ -933,7 +934,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install edge-runtime dependencies
         working-directory: packages/edge-runtime
@@ -1020,7 +1021,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,8 @@ env:
   LANG: C.UTF-8
   LC_ALL: C.UTF-8
   BUN_VERSION: "1.4.0"
-  XCADDY_VERSION: "v0.4.5"
+  GO_VERSION: "1.27.1"
+  XCADDY_VERSION: "v0.4.7"
 
 on:
   push:
@@ -75,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install dependencies
         working-directory: packages/management-api

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -212,7 +212,7 @@ bun --cwd packages/pgredis-runtime run build:linux
 bun --cwd packages/web-console install --frozen-lockfile
 bun --cwd packages/web-console run build
 mkdir -p .local/bin dist
-GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.5
+GOTOOLCHAIN=go1.27.1 GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7
 PATH="$PWD/.local/bin:$PATH" OUT_DIR="$PWD/dist" bash scripts/build_supacloud_caddy.sh
 
 # 3. Configurar e instalar desde las salidas de construcción local validadas
@@ -222,6 +222,10 @@ sudo env SUPACLOUD_SETUP_ARTIFACT_MODE=local \
 # 4. Habilitar CLI
 source /etc/profile.d/supacloud.sh
 ```
+
+Las compilaciones locales, Docker y de publicación usan Caddy 2.11.4, xcaddy
+0.4.7 y Go 1.27.1. Go 1.21 o posterior descarga automáticamente el compilador
+fijado sin cambiar la instalación predeterminada de Go del equipo.
 
 **Actualizaciones de producción**
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ bun --cwd packages/pgredis-runtime run build:linux
 bun --cwd packages/web-console install --frozen-lockfile
 bun --cwd packages/web-console run build
 mkdir -p .local/bin dist
-GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.5
+GOTOOLCHAIN=go1.27.1 GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7
 PATH="$PWD/.local/bin:$PATH" OUT_DIR="$PWD/dist" bash scripts/build_supacloud_caddy.sh
 
 # 3. Configure and install from the validated local build outputs
@@ -228,6 +228,10 @@ sudo env SUPACLOUD_SETUP_ARTIFACT_MODE=local \
 # 4. Enable CLI
 source /etc/profile.d/supacloud.sh
 ```
+
+Caddy builds use Caddy 2.11.4, xcaddy 0.4.7, and Go 1.27.1 across source,
+Docker, and release builds. Go 1.21 or newer can download the pinned compiler
+automatically; the host's default Go installation is not changed.
 
 **Production Upgrades**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,7 +214,7 @@ bun --cwd packages/pgredis-runtime run build:linux
 bun --cwd packages/web-console install --frozen-lockfile
 bun --cwd packages/web-console run build
 mkdir -p .local/bin dist
-GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.5
+GOTOOLCHAIN=go1.27.1 GOBIN="$PWD/.local/bin" go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7
 PATH="$PWD/.local/bin:$PATH" OUT_DIR="$PWD/dist" bash scripts/build_supacloud_caddy.sh
 
 # 3. 显式使用本地产物安装（参数会持久化到 /etc/supabase/install.env）
@@ -224,6 +224,9 @@ sudo env SUPACLOUD_SETUP_ARTIFACT_MODE=local \
 # 4. 启用命令行工具
 source /etc/profile.d/supacloud.sh
 ```
+
+源码、Docker 和发布构建统一使用 Caddy 2.11.4、xcaddy 0.4.7 和 Go 1.27.1。
+已安装 Go 1.21 或更高版本时会自动下载指定编译器，不修改主机默认 Go 安装。
 
 **生产环境升级**
 

--- a/docker/self-host/caddy/Dockerfile
+++ b/docker/self-host/caddy/Dockerfile
@@ -1,6 +1,10 @@
 FROM caddy:2.11.4-builder@sha256:522c540599fa8f6a340b18dea8ee12dfd9d8198347cefa2c4c54344159ae6c0b AS builder
 
-RUN GOBIN=/usr/bin go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.5 \
+ARG GOPROXY=https://proxy.golang.org,direct
+ENV GOTOOLCHAIN=go1.27.1
+
+RUN go version \
+    && GOBIN=/usr/bin go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.7 \
     && xcaddy build v2.11.4 \
         --with github.com/mholt/caddy-ratelimit@5625512f24f6f59d6f64fb3aafe5eecff0b286db \
         --output /usr/bin/caddy

--- a/docs/platform-component-upgrade-notes.md
+++ b/docs/platform-component-upgrade-notes.md
@@ -13,6 +13,20 @@
 | JuiceFS | 1.2.2 | 1.4.0 | 1.4 是 LTS；启用 storage tiers 时所有客户端必须先到 1.4.0；元数据备份默认清理两年以上备份；1.4 包含 SQL 元数据字段类型调整 | 本平台只使用单一 gateway 和 Postgres metadata；不启用 storage tiers。已有 `juicefs` metadata 在生产升级前必须做 `juicefs dump`/pg_dump 并保留回滚副本 |
 | Docker Compose | v2.29.2 | v5.3.1 | v5 删除内部构建器，`compose build` 改走 Docker Bake，并要求 Docker Buildx >= 0.17；这是唯一需要额外运行时前置条件的主版本更新 | CI 已使用 Docker Buildx；安装器的 Podman 路径只负责 `pull/up`，不把 Compose v5 当作 Podman 的构建器。Podman 用户构建镜像应使用 Podman build/兼容的 Buildx，或先提供已构建镜像 |
 
+## Caddy 构建工具链补充
+
+Caddy 保持 v2.11.4，xcaddy 从 v0.4.5 升级至 v0.4.7，Go 编译器统一固定为
+1.27.1。源码脚本和 Docker builder 显式使用 `GOTOOLCHAIN=go1.27.1`，发布与 CI
+通过 `GO_VERSION` 选择相同版本，不再使用浮动的 `stable`。Docker 基础镜像摘要与
+限流插件提交保持不变；源码安装器始终安装指定 xcaddy，避免复用主机旧版本。
+
+Go 1.21 或更高版本可自动下载该工具链，离线构建需要提前缓存。源码构建可通过
+`GO_VERSION` 显式选择回滚版本；Docker 和发布回滚仍应使用已验证的旧产物，
+不要仅根据 Caddy 的版本字符串判断编译器是否升级，应读取 `go version -m <binary>`。
+
+Docker 构建默认使用官方 Go 模块代理；网络受限时可通过 `--build-arg GOPROXY=...`
+显式指定可信代理，不关闭 Go 模块校验。
+
 ## PostgreSQL 18 边界
 
 SupaCloud 的实际部署、Dockerfile 和 self-host Compose 继续使用 `postgres:18-bookworm`。CI 中的 `supabase/postgres:17.6.1.143` 只是上游 Supabase 兼容 fixture，用于验证 Supabase schema/Realtime 迁移，不表示部署回退到 PostgreSQL 17。跨 PostgreSQL 大版本升级仍然是独立的备份、迁移和回滚任务，本轮没有执行。

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,8 @@ PGREDIS_INSTALL_TRANSACTION_DIR=""
 CREDENTIALS_FILE="${SUPACLOUD_CREDENTIALS_FILE:-/etc/supabase/supacloud-credentials.env}"
 MASTER_TOKEN_FILE="${SUPACLOUD_MASTER_TOKEN_FILE:-/etc/supabase/master-token.env}"
 BUN_VERSION="${BUN_VERSION:-1.4.0}"
-XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"
+GO_VERSION="${GO_VERSION:-1.27.1}"
+XCADDY_VERSION="${XCADDY_VERSION:-v0.4.7}"
 
 # shellcheck source=scripts/lib/install_config.sh
 source "${SCRIPT_DIR}/scripts/lib/install_config.sh"
@@ -2046,10 +2047,9 @@ install_caddy_gateway() {
         chmod 0755 "$target"
     elif [[ -x "${SCRIPT_DIR}/scripts/build_supacloud_caddy.sh" ]] && command -v go >/dev/null 2>&1; then
         log_info "Building supacloud-caddy locally with xcaddy and the rate-limit module..."
-        if ! command -v xcaddy >/dev/null 2>&1; then
-            GOBIN=/usr/local/bin go install "github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}"
-        fi
-        OUT_DIR=/tmp/supacloud-caddy-build "${SCRIPT_DIR}/scripts/build_supacloud_caddy.sh"
+        GOTOOLCHAIN="go${GO_VERSION}" GOBIN=/usr/local/bin go install "github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}"
+        PATH="/usr/local/bin:$PATH" GO_VERSION="$GO_VERSION" XCADDY_VERSION="$XCADDY_VERSION" \
+            OUT_DIR=/tmp/supacloud-caddy-build "${SCRIPT_DIR}/scripts/build_supacloud_caddy.sh"
         install -m 0755 "/tmp/supacloud-caddy-build/supacloud-caddy-linux-${arch}" "$target"
         rm -rf /tmp/supacloud-caddy-build
     elif [[ "${SUPACLOUD_ALLOW_STOCK_CADDY_FALLBACK:-false}" == "true" ]]; then

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -11,6 +11,7 @@
     "realtime:reconcile-schema": "bun run scripts/reconcile-realtime-schema-privileges.ts",
     "tsc": "tsc",
     "typecheck": "tsc --noEmit",
+    "typecheck:caddy-tests": "tsc --project tsconfig.caddy-tests.json",
     "test": "bun run test:local",
     "test:local": "bun run sql:check && bun run test:unit && bun run test:integration",
     "test:unit": "bun run scripts/run-unit-tests.ts",

--- a/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
+++ b/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const commandPath = process.env["PATH"];
+if (!commandPath) throw new Error("PATH is required for Caddy build tests");
+
 const builder = readFileSync(
   new URL("../../../../scripts/build_supacloud_caddy.sh", import.meta.url),
   "utf8",
@@ -108,7 +111,7 @@ exit 1
         {
           env: {
             ...process.env,
-            PATH: `${dir}:${process.env.PATH}`,
+            PATH: `${dir}:${commandPath}`,
             GO_VERSION: goVersion,
             GOTOOLCHAIN: "local",
             XCADDY_VERSION: "",

--- a/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
+++ b/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const builder = readFileSync(
   new URL("../../../../scripts/build_supacloud_caddy.sh", import.meta.url),
@@ -7,6 +10,14 @@ const builder = readFileSync(
 );
 const workflow = readFileSync(
   new URL("../../../../.github/workflows/management-api.yml", import.meta.url),
+  "utf8",
+);
+const releaseWorkflow = readFileSync(
+  new URL("../../../../.github/workflows/release-please.yml", import.meta.url),
+  "utf8",
+);
+const installer = readFileSync(
+  new URL("../../../../install.sh", import.meta.url),
   "utf8",
 );
 const caddyDockerfile = readFileSync(
@@ -45,6 +56,84 @@ function workflowJob(source: string, job: string): string {
 }
 
 describe("Caddy release build reproducibility", () => {
+  test("source, installer, Docker, and release builds pin the same Go and xcaddy versions", () => {
+    for (const source of [builder, installer]) {
+      expect(source).toContain('GO_VERSION="${GO_VERSION:-1.27.1}"');
+      expect(source).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.7}"');
+    }
+    expect(installer).toContain('GOTOOLCHAIN="go${GO_VERSION}" GOBIN=/usr/local/bin go install');
+    expect(installer).toContain('PATH="/usr/local/bin:$PATH" GO_VERSION="$GO_VERSION" XCADDY_VERSION="$XCADDY_VERSION"');
+    expect(installer).not.toContain("if ! command -v xcaddy");
+    expect(caddyDockerfile).toContain("ENV GOTOOLCHAIN=go1.27.1");
+    for (const source of [workflow, releaseWorkflow]) {
+      expect(source).toContain('GO_VERSION: "1.27.1"');
+      expect(source).toContain('XCADDY_VERSION: "v0.4.7"');
+      const versions = source.match(/^\s+go-version: .+$/gm) ?? [];
+      expect(versions.length).toBeGreaterThan(0);
+      for (const version of versions) {
+        expect(version.trim()).toBe("go-version: ${{ env.GO_VERSION }}");
+      }
+    }
+  });
+
+  test.each([
+    { goVersion: "", expected: "go1.27.1", xcaddyVersion: "v0.4.7", succeeds: true },
+    { goVersion: "1.26.8", expected: "go1.26.8", xcaddyVersion: "v0.4.7", succeeds: true },
+    { goVersion: "", expected: "go1.27.1", xcaddyVersion: "v0.4.5", succeeds: false },
+  ])("selects $expected with xcaddy $xcaddyVersion", ({ goVersion, expected, xcaddyVersion, succeeds }) => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-caddy-build-"));
+    try {
+      const calls = join(dir, "calls");
+      writeFileSync(join(dir, "go"), `#!/bin/sh
+printf 'go %s %s\\n' "$GOTOOLCHAIN" "$*" >> "$BUILD_CALLS"
+`, { mode: 0o755 });
+      writeFileSync(join(dir, "xcaddy"), `#!/bin/sh
+if [ "$1" = "version" ]; then
+  printf '%s h1:test\\n' "$TEST_XCADDY_VERSION"
+  exit 0
+fi
+printf 'xcaddy %s %s %s %s\\n' "$GOTOOLCHAIN" "$GOOS" "$GOARCH" "$CGO_ENABLED" >> "$BUILD_CALLS"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    shift
+    printf 'test binary\\n' > "$1"
+    exit 0
+  fi
+  shift
+done
+exit 1
+`, { mode: 0o755 });
+      const result = Bun.spawnSync(
+        ["bash", fileURLToPath(new URL("../../../../scripts/build_supacloud_caddy.sh", import.meta.url))],
+        {
+          env: {
+            ...process.env,
+            PATH: `${dir}:${process.env.PATH}`,
+            GO_VERSION: goVersion,
+            GOTOOLCHAIN: "local",
+            XCADDY_VERSION: "",
+            TEST_XCADDY_VERSION: xcaddyVersion,
+            BUILD_CALLS: calls,
+            CADDY_BUILD_TARGETS: "linux-amd64 linux-arm64",
+            OUT_DIR: join(dir, "dist"),
+          },
+        },
+      );
+      expect(result.exitCode).toBe(succeeds ? 0 : 1);
+      if (!succeeds) {
+        expect(result.stderr.toString()).toContain("xcaddy v0.4.7 is required; found v0.4.5");
+        return;
+      }
+      expect(readFileSync(calls, "utf8").trim().split("\n")).toEqual([
+        `go ${expected} version`,
+        `xcaddy ${expected} linux amd64 0`,
+        `xcaddy ${expected} linux arm64 0`,
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("pins the rate-limit plugin to an immutable upstream commit", () => {
     expect(builder).toContain("5625512f24f6f59d6f64fb3aafe5eecff0b286db");
     expect(builder).toContain("github.com/mholt/caddy-ratelimit@");
@@ -58,7 +147,7 @@ describe("Caddy release build reproducibility", () => {
       "FROM caddy:2.11.4-builder@sha256:522c540599fa8f6a340b18dea8ee12dfd9d8198347cefa2c4c54344159ae6c0b AS builder",
       "FROM caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d",
     ]);
-    expect(caddyDockerfile).toContain("xcaddy/cmd/xcaddy@v0.4.5");
+    expect(caddyDockerfile).toContain("xcaddy/cmd/xcaddy@v0.4.7");
     expect(caddyDockerfile).toContain(
       "github.com/mholt/caddy-ratelimit@5625512f24f6f59d6f64fb3aafe5eecff0b286db",
     );

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import {
   SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_SHA256,
   SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_SIZE,
@@ -12,6 +14,8 @@ import {
 } from "../../src/sigstore-trusted-root";
 
 const repoRoot = join(import.meta.dir, "../../..", "..");
+const commandPath = process.env["PATH"];
+if (!commandPath) throw new Error("PATH is required for runtime asset tests");
 setDefaultTimeout(60_000);
 
 function readRepoFile(path: string): string {
@@ -19,9 +23,9 @@ function readRepoFile(path: string): string {
 }
 
 function readShellConstant(script: string, name: string): string {
-  const assignment = script.match(new RegExp(`^${name}="([^"]+)"$`, "m"));
+  const assignment = script.match(new RegExp(`^${name}="([^"]+)"$`, "m"))?.[1];
   if (!assignment) throw new Error(`Missing shell constant: ${name}`);
-  return assignment[1];
+  return assignment;
 }
 
 function readDocumentedComponentVersion(notes: string, component: string): string {
@@ -37,9 +41,9 @@ function systemdDirectiveSections(source: string, directive: string): string[] {
   const sections: string[] = [];
   for (const rawLine of source.split(/\r?\n/)) {
     const line = rawLine.trim();
-    const sectionMatch = line.match(/^\[([A-Za-z]+)\]$/);
+    const sectionMatch = line.match(/^\[([A-Za-z]+)\]$/)?.[1];
     if (sectionMatch) {
-      section = sectionMatch[1]!;
+      section = sectionMatch;
       continue;
     }
     if (line.startsWith(`${directive}=`)) sections.push(section);
@@ -95,7 +99,11 @@ describe("runtime companion version assets", () => {
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(JSON.parse(result.stdout).tag_name).toBe("management-api-v0.38.0");
+    const release: unknown = JSON.parse(result.stdout);
+    if (!Value.Check(Type.Object({ tag_name: Type.String() }), release)) {
+      throw new Error("Release resolver returned an invalid tag");
+    }
+    expect(release.tag_name).toBe("management-api-v0.38.0");
   });
 
   test("missing release asset URL returns a non-zero status", () => {
@@ -190,7 +198,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${tools}:${process.env.PATH}`,
+          PATH: `${tools}:${commandPath}`,
           ROOT: dir,
           TARGET: target,
           MANAGEMENT_ASSET: managementAsset,
@@ -216,7 +224,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${tools}:${process.env.PATH}`,
+          PATH: `${tools}:${commandPath}`,
           ROOT: dir,
           MANAGEMENT_ASSET: managementAsset,
           EDGE_ASSET: edgeAsset,
@@ -235,7 +243,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${tools}:${process.env.PATH}`,
+          PATH: `${tools}:${commandPath}`,
           ROOT: dir,
           MANAGEMENT_ASSET: managementAsset,
           EDGE_ASSET: edgeAsset,
@@ -604,7 +612,7 @@ describe("runtime companion version assets", () => {
         SUPACLOUD_INSTALL_DIR: installDir,
         SUPACLOUD_SETUP_BRANCH: "main",
         SUPACLOUD_TEST_REMOTE_URL: reportedOrigin,
-        PATH: `${fakeBin}:${process.env.PATH}`,
+        PATH: `${fakeBin}:${commandPath}`,
         GIT_TERMINAL_PROMPT: "0",
       },
       encoding: "utf8",
@@ -698,7 +706,11 @@ describe("runtime companion version assets", () => {
       .toBe(SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_SHA256);
     expect(trustedRoot.endsWith("\n")).toBe(true);
     expect(trustedRoot.slice(0, -1)).not.toContain("\n");
-    expect(JSON.parse(trustedRoot).mediaType)
+    const parsedRoot: unknown = JSON.parse(trustedRoot);
+    if (!Value.Check(Type.Object({ mediaType: Type.String() }), parsedRoot)) {
+      throw new Error("Trusted root has an invalid media type");
+    }
+    expect(parsedRoot.mediaType)
       .toBe("application/vnd.dev.sigstore.trustedroot+json;version=0.1");
     expect(SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_TUF_TARGET_SHA256)
       .toBe("6494e21ea73fa7ee769f85f57d5a3e6a08725eae1e38c755fc3517c9e6bc0b66");
@@ -761,7 +773,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${dir}:${process.env.PATH}`,
+          PATH: `${dir}:${commandPath}`,
           GH_FAKE_VERSION: version,
           GH_HELP_TEXT: helpText,
         },
@@ -812,7 +824,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${fakeTools}:${process.env.PATH}`,
+          PATH: `${fakeTools}:${commandPath}`,
           ARCHIVE: archive,
           CHECKSUM: checksum,
           TARGET: target,
@@ -902,7 +914,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${fakeBin}:${process.env.PATH}`,
+          PATH: `${fakeBin}:${commandPath}`,
           ARTIFACT: artifact,
           GH_BUNDLE_ARGUMENT_RECORD: bundleArgumentRecord,
           TMPDIR: dir,
@@ -957,7 +969,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${fakeBin}:${process.env.PATH}`,
+          PATH: `${fakeBin}:${commandPath}`,
           ARTIFACT: artifact,
           GH_BUNDLE_ARGUMENT_RECORD: bundleArgumentRecord,
           GH_SOURCE_REF_ARGUMENT_RECORD: sourceRefArgumentRecord,
@@ -1183,7 +1195,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${fakeTools}:${process.env.PATH}`,
+          PATH: `${fakeTools}:${commandPath}`,
           ARCHIVE: archive,
           CHECKSUM: checksum,
           TAR_LOG: tarLog,
@@ -1224,7 +1236,7 @@ describe("runtime companion version assets", () => {
         cwd: repoRoot,
         env: {
           ...process.env,
-          PATH: `${fakeTools}:${process.env.PATH}`,
+          PATH: `${fakeTools}:${commandPath}`,
           ARCHIVE: archive,
           ARCH: arch,
           CHECKSUM: checksum,

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -469,11 +469,11 @@ describe("runtime companion version assets", () => {
     expect(systemdBrokerUnit).toContain("ProtectSystem=strict");
     expect(serviceRenderer).not.toContain("/opt/supacloud/config.env");
     expect(serviceRenderer).toContain("/etc/supabase/management-api.env");
-    expect(installer).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"');
+    expect(installer).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.7}"');
     expect(installer).toContain('xcaddy/cmd/xcaddy@${XCADDY_VERSION}');
-    expect(workflow).toContain('XCADDY_VERSION: "v0.4.5"');
+    expect(workflow).toContain('XCADDY_VERSION: "v0.4.7"');
     expect(workflow).toContain('xcaddy/cmd/xcaddy@${XCADDY_VERSION}');
-    expect(caddyBuilder).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"');
+    expect(caddyBuilder).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.7}"');
     expect(caddyBuilder).toContain('xcaddy/cmd/xcaddy@${XCADDY_VERSION}');
     expect(installer).not.toContain("xcaddy/cmd/xcaddy@latest");
     expect(workflow).not.toContain("xcaddy/cmd/xcaddy@latest");

--- a/packages/management-api/tsconfig.caddy-tests.json
+++ b/packages/management-api/tsconfig.caddy-tests.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": false
+  },
+  "include": [
+    "tests/unit/caddy-build-reproducibility.test.ts",
+    "tests/unit/runtime-version-assets.test.ts"
+  ]
+}

--- a/scripts/build_supacloud_caddy.sh
+++ b/scripts/build_supacloud_caddy.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 CADDY_VERSION="${CADDY_VERSION:-v2.11.4}"
-XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"
+GO_VERSION="${GO_VERSION:-1.27.1}"
+XCADDY_VERSION="${XCADDY_VERSION:-v0.4.7}"
 RATE_LIMIT_MODULE_VERSION="${RATE_LIMIT_MODULE_VERSION:-5625512f24f6f59d6f64fb3aafe5eecff0b286db}"
 RATE_LIMIT_MODULE="${RATE_LIMIT_MODULE:-github.com/mholt/caddy-ratelimit@${RATE_LIMIT_MODULE_VERSION}}"
 CADDY_BUILD_TARGETS="${CADDY_BUILD_TARGETS:-linux-amd64 linux-arm64}"
@@ -15,9 +16,19 @@ if [[ "$RATE_LIMIT_MODULE" != *@* ]]; then
 fi
 
 if ! command -v xcaddy >/dev/null 2>&1; then
-  echo "xcaddy is required. Install with: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}" >&2
+  echo "xcaddy is required. Install with: GOTOOLCHAIN=go${GO_VERSION} go install github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}" >&2
   exit 1
 fi
+
+xcaddy_version="$(xcaddy version)"
+if [[ "${xcaddy_version%% *}" != "$XCADDY_VERSION" ]]; then
+  echo "xcaddy ${XCADDY_VERSION} is required; found ${xcaddy_version%% *}. Install with: GOTOOLCHAIN=go${GO_VERSION} go install github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}" >&2
+  exit 1
+fi
+
+# Use the same compiler as release and Docker builds, even on older Go hosts.
+export GOTOOLCHAIN="go${GO_VERSION}"
+go version
 
 build_one() {
   local goos="$1"

--- a/scripts/test_supacloud_caddy_edge_proxy.sh
+++ b/scripts/test_supacloud_caddy_edge_proxy.sh
@@ -93,6 +93,22 @@ cat >"$work_dir/caddy.json" <<EOF
           "listen": ["127.0.0.1:$CADDY_PORT"],
           "automatic_https": { "disable": true },
           "routes": [{
+            "match": [{ "host": ["auth.edge.test"], "path": ["/__rate_limit_probe"] }],
+            "handle": [
+              {
+                "handler": "rate_limit",
+                "rate_limits": {
+                  "smoke": {
+                    "key": "{http.request.remote.host}",
+                    "window": "1m",
+                    "max_events": 2
+                  }
+                }
+              },
+              { "handler": "static_response", "status_code": 200, "body": "ok" }
+            ],
+            "terminal": true
+          }, {
             "match": [{ "host": ["auth.edge.test"] }],
             "handle": [
               {
@@ -178,6 +194,16 @@ if [[ "$caddy_ready" != true ]]; then
   exit 1
 fi
 
+for expected_status in 200 200 429; do
+  actual_status="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' \
+    -H "Host: auth.edge.test" "http://127.0.0.1:$CADDY_PORT/__rate_limit_probe")"
+  if [[ "$actual_status" != "$expected_status" ]]; then
+    echo "Caddy rate limit: expected $expected_status, got $actual_status" >&2
+    cat "$caddy_log" >&2
+    exit 1
+  fi
+done
+
 curl -fsS --max-time 10 -H "Host: auth.edge.test" \
   "http://127.0.0.1:$CADDY_PORT/api/v1/slow" >/dev/null 2>&1 &
 slow_client_pid=$!
@@ -252,4 +278,4 @@ if [[ "$probe_failed" == true ]]; then
   exit 1
 fi
 
-echo "Caddy disconnect cancellation and 12 concurrent Edge Runtime round-trips passed"
+echo "Caddy rate limiting, disconnect cancellation, and 12 concurrent Edge Runtime round-trips passed"


### PR DESCRIPTION
## Summary
- Keep Caddy at 2.11.4 and pin Go 1.27.1 with xcaddy 0.4.7 across source, Docker, installers, and release workflows.
- Reject stale xcaddy executables; preserve pinned base image digests and the rate-limit plugin commit.
- Add real rate-limit smoke coverage alongside disconnect cancellation and concurrent Edge Runtime proxying.
- Add a strict Caddy test type-checking project and run it in the Caddy CI job; narrow optional captures, validate JSON with TypeBox, and check environment access.

## Local Validation
- Management API typecheck: passed using its existing configuration.
- Caddy test typecheck: passed with strict indexed/optional-property checks and skipLibCheck=false. This covers the two maintained Caddy build/runtime asset tests, not a repository-wide strictness migration.
- Focused build/runtime asset tests: 38 passed.
- Workflow contract tests: 16 passed.
- ShellCheck and git diff --check: passed.
- Linux amd64 and arm64 Caddy builds using Go 1.27.1: passed.
- Real rate limiting, disconnect cancellation, and 12 concurrent proxy requests: passed.
- Prior implementation validation also passed Docker arm64 build, module read-back, and bootstrap HTTPS configuration validation.

## Boundaries
- Synced with origin/main before integration.
- Local validation is not represented as a remote Required Checks result.
- No host-default Go replacement or production deployment.