### PR TITLE
fix(admin): correct jq escaping in Management upgrade bootstrap

### DIFF
--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -337,7 +337,7 @@ function componentBootstrapCommands(request: UpgradeRequest): string[] {
         `MANAGEMENT_RELEASE=$(supacloud_fetch_component_release management-api ${quoteEnvValue(managementVersion)} "$MANAGEMENT_ASSET" web-console-build.tar.gz)`,
         `supacloud_download_release_asset "$MANAGEMENT_RELEASE" "$MANAGEMENT_ASSET" "$STAGED_MANAGEMENT" binary`,
         `chmod 0755 "$STAGED_MANAGEMENT"`,
-        `TARGET_MANAGEMENT_VERSION=$(jq -er '.tag_name | capture("^management-api-v(?<version>(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$").version' <<< "$MANAGEMENT_RELEASE")`,
+        `TARGET_MANAGEMENT_VERSION=$(jq -er '.tag_name | capture("^management-api-v(?<version>(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*))$").version' <<< "$MANAGEMENT_RELEASE")`,
         `STAGED_VERSION=$(timeout 5s "$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
         `test "$STAGED_VERSION" = "$TARGET_MANAGEMENT_VERSION" || { echo 'Target Management binary version does not match its verified release' >&2; exit 1; }`,
         `supacloud_version_at_least "$STAGED_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)} || { echo 'Target Management release lacks component transaction capability' >&2; exit 1; }`,

--- a/packages/admin/src/shared/tools/upgrade-tag-resolution.test.ts
+++ b/packages/admin/src/shared/tools/upgrade-tag-resolution.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { buildRootUpgradeScript } from "./ssh-tools";
+
+function resolveTag(tag: string) {
+    const statement = buildRootUpgradeScript({ helperPath: "/tmp/release-assets.sh" })
+        .split("\n").find(line => line.startsWith("TARGET_MANAGEMENT_VERSION="));
+    if (!statement) throw new Error("Upgrade script is missing release tag resolution");
+    return Bun.spawnSync(["bash", "-c", [
+        "set -euo pipefail",
+        statement,
+        "printf '%s' \"$TARGET_MANAGEMENT_VERSION\"",
+    ].join("\n")], {
+        env: { ...process.env, MANAGEMENT_RELEASE: JSON.stringify({ tag_name: tag }) },
+    });
+}
+
+describe("generated Management upgrade tag resolution", () => {
+    test.each(["0.77.1", "1.2.3", "10.20.30"])("resolves %s using real bash and jq", version => {
+        const result = resolveTag(`management-api-v${version}`);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.toString()).toBe(version);
+        expect(result.stderr.toString()).toBe("");
+    });
+
+    test.each([
+        "management-api-v0x77x1",
+        "management-api-v00.77.1",
+        "management-api-v0.77.1-rc.1",
+        "management-api-v0.77.1+build",
+        "edge-runtime-v0.77.1",
+        "management-api-v0.77",
+    ])("rejects invalid release tag %s", tag => {
+        const result = resolveTag(tag);
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stdout.toString()).toBe("");
+    });
+});


### PR DESCRIPTION
## Problem
A real Management-only upgrade from 0.77.0 to the signed 0.77.1 release failed before invoking the target upgrade runner. The generated Bash statement passed a JSON string containing an invalid backslash-dot escape to jq, which exited 3. Existing tests inspected generated source or skipped this parsing statement, so the error was not detected.

## Fix
Use regex character classes [.] for version separators, preserving strict stable-version matching without crossing TypeScript, shell and jq string-escape layers. No signature/checksum, version identity, lock, backup, environment or service-mode checks are relaxed.

## Tests
Add a regression suite executing the actual generated statement using real Bash and jq: three valid versions, malformed separators, leading zero, prerelease, build suffix, wrong component and missing patch. The original code failed all three valid-version cases; the fix passes.

- bun test src/shared/tools/upgrade-tag-resolution.test.ts src/shared/tools/ssh-tools.test.ts: 94 passed, 0 failed.
- bun run typecheck: passed.
- bun run build: passed.
- git diff --check: passed.

The initial failed upgrade left the installed Management version at 0.77.0. This is an operator-client fix, separate from the already-published Management 0.77.1 GraphQL entrypoint fix. Test-environment upgrade validation is ongoing; no production action was taken.