### PR TITLE
feat(compiler): add local delivery planning and independent builds

### DIFF
--- a/docs/app-delivery-automation-spec.md
+++ b/docs/app-delivery-automation-spec.md
@@ -1,0 +1,210 @@
+# Automated App Delivery
+
+Status: stages 1-2 implemented as read-only `plan` and local `build-delivery`.
+Stage 2 exports independent module factories, not deployable HTTP handlers.
+Every target is rebundled; unchanged immutable artifacts are reused.
+Stages 3-4 remain proposed. No production deployment is authorized by this document.
+Date: 2026-09-09
+
+## Job To Be Done
+
+Let a developer describe a business capability and receive tested application
+changes without manually maintaining function entrypoints, bundles, and deployment
+manifests. Keep runtime placement deterministic and security decisions explicit.
+
+## Existing Foundation
+
+The compiler CLI exposes context, compile/check JSON diagnostics, and preview-first
+structured fixes. Extend these surfaces instead of creating a separate AI compiler.
+The existing application generator emits a shared application factory and manifest;
+the delivery builder projects it into target-local factories and an atomic local
+inspection manifest. Existing compile/check/dev output remains unchanged.
+
+## Ownership
+
+- The user owns business intent and authorization to change production.
+- AI proposes source edits and typed, runtime-validated capability declarations.
+- The compiler deterministically resolves dependencies, routes, and target plans.
+- Build and test tools produce evidence; AI cannot substitute its judgment for gates.
+- The deployment executor verifies environment identity, approval, and live receipts.
+
+AI must not infer elevated permissions, public exposure, secret access, or
+asynchronous business semantics from names or prose without explicit declarations.
+An ambiguous declaration produces an actionable diagnostic, not a guessed placement.
+
+## User Workflow
+
+1. Describe the capability; AI produces acceptance tests and edits business source.
+2. Compile the source into a preview of behavior, target, and permission changes.
+3. Run type checks, contract rejection tests, and affected behavior tests.
+4. Preview locally; deploy only to an explicitly configured and authorized test target.
+5. Present a concise release decision with evidence and any required approval.
+6. Promote the exact validated artifacts and read back their active state.
+
+Show only changed behavior, verification status, and required decisions in the
+normal summary. Expand diagnostics and target plans on demand.
+Empty projects use a single API target. Running operations expose progress.
+Failures preserve the last good generated output and provide a retryable diagnosis.
+
+## Deterministic Placement
+
+The initial policy has a small, versioned set of target profiles:
+
+- Interactive HTTP routes default to api.
+- Explicitly declared queued jobs use jobs when an authorized queue adapter exists.
+- Webhooks use a separate target only when declared credential or ingress boundaries
+  require it; webhook verification remains mandatory.
+- Schedules enqueue declared jobs; they do not duplicate job business logic.
+
+Each exposed route and job has one declared owner. Dependency traversal includes
+providers without implicitly exposing routes from their modules. Conflicting
+ownership, unavailable adapters, and unsatisfied isolation requirements fail closed.
+
+Do not automatically convert a synchronous route into an asynchronous API. That
+changes its contract and requires explicit source and acceptance-test changes.
+Do not move workloads based on live measurements in the first version.
+Existing deployments require a reviewed topology migration before changing owners.
+
+## Compiler And Artifact Contracts
+
+Use one runtime schema source for configuration, plans, receipts, and derived types.
+Validate external data before entering typed compiler or deployment code.
+
+A target plan records policy/schema versions, exposed routes/jobs, dependency closure,
+capability references, required isolation, reasons for placement, and diagnostics.
+It includes no secret values. Sorting and hashing must be stable.
+
+Produce one self-contained bundle directory per target, including required assets.
+Preserve public URL contracts through explicit gateway mappings when targets change.
+Generate target-local factories and manifests plus a global inspection manifest.
+Keep the current single-target behavior as the compatibility default.
+
+Incremental build identity includes source and dependency hashes, lockfile, compiler,
+bundler, policy, build configuration, and non-secret environment contract versions.
+Shared dependency changes invalidate every affected target. Uncertain dependencies
+invalidate conservatively. Removed artifacts are cleaned only within owned output.
+
+## Runtime And Delivery
+
+Separate target names are not proof of resource or security isolation.
+Targets declaring process isolation require a host capability check and independent
+process resource enforcement. Unsupported hosts reject the plan.
+
+Jobs require a durable queue, bounded retries, idempotency, cancellation semantics,
+failure handling, and transaction/outbox integration where submission accompanies
+a database mutation. Do not promise exactly-once external effects.
+
+Publish immutable artifacts with per-target hashes and activation preconditions.
+Validate target host/project/environment before remote writes.
+Bind approvals to the plan digest, artifact digest, environment, and expiry.
+Material changes invalidate approval.
+
+Perform complete applicable type checks and required build gates before integration
+or release, even when affected tests suffice for the local edit loop.
+Smoke tests must exercise declared routes and expected authorization failures.
+An unknown activation outcome triggers read-back before any retry.
+Database compatibility and irreversible side effects can prevent safe rollback;
+report these cases instead of blindly rolling back bundles.
+
+## Automation Limits
+
+Local compile/test/preview can run automatically inside the authorized workspace.
+Automated repair has bounded attempts and stops on repeated diagnostics or no progress.
+It cannot disable type checks, weaken schemas, remove meaningful tests, expand
+permissions, or mutate generated files to hide a source defect.
+
+Test deployment requires prior authorization scoped to a concrete environment.
+Production promotion, destructive migrations, new public routes, broader credentials,
+and weakened isolation require explicit approval or a preapproved policy covering
+the exact action. Never infer production permission from a general automation request.
+
+This is an invoked delivery workflow, not a recurring unattended scheduler.
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Deterministic automated app delivery
+
+  Scenario: Ordinary business edits preserve simple deployment
+    Given an application with interactive routes and no special workload declarations
+    When the same validated input is planned twice
+    Then both plans have identical canonical content and digests
+    And all routes belong to the single api target
+    And imported providers do not expose additional routes
+
+  Scenario: Explicit jobs require their runtime guarantees
+    Given a declared queued job requiring process isolation
+    When the selected host lacks that isolation or a durable queue adapter
+    Then planning or deployment fails with an actionable diagnostic
+    And no route is silently converted to asynchronous behavior
+    And no remote activation occurs
+
+  Scenario: Incremental work preserves complete release gates
+    Given two targets sharing a provider and one unrelated target
+    When the shared provider changes
+    Then both dependent targets are invalidated
+    And the unrelated target is reusable only with a matching complete build identity
+    And release still requires complete applicable type and build gates
+
+  Scenario: Unsafe repair cannot complete the workflow
+    Given invalid external configuration or a contract rejection test failure
+    When AI attempts to deliver the change
+    Then runtime validation or the test gate rejects it
+    And bypassing type checks, schema checks, or meaningful tests is not permitted
+    And repeated unsuccessful repair stops with evidence
+
+  Scenario: Production activation is scoped and recoverable
+    Given approved artifacts and a plan bound to a specific production environment
+    When the plan changes or activation returns an unknown outcome
+    Then a changed plan cannot reuse the approval
+    And an unknown outcome is resolved by reading active state before retrying
+    And success requires matching activation receipts and route smoke evidence
+```
+
+## Implementation Sequence
+
+Stage 2 acceptance:
+
+```gherkin
+Feature: Local independent delivery artifacts
+  Scenario: Routes stay within their owning target
+    Given two HTTP targets sharing providers and a declared Job
+    When delivery artifacts are built
+    Then each bundle exposes only its owned routes or jobs
+    And command governance and dependency factories are retained
+
+  Scenario: Shared source changes affect dependent artifacts
+    Given three targets, two of which import a shared implementation
+    When the shared implementation changes
+    Then the two dependent input digests change
+    And the unrelated artifact is reused without changing its files
+    And all targets still undergo validation and bundling
+
+  Scenario: Invalid builds preserve the last successful release
+    Given an existing delivery manifest
+    When a source, generated-type, asset, or bundle check fails
+    Then the current manifest and referenced artifacts remain unchanged
+
+  Scenario: Artifact ownership is enforced
+    Given an unowned output directory or a symlink inside the owned namespace
+    When a build tries to write there
+    Then it fails without replacing unrelated files
+
+  Scenario: Topology changes do not deploy themselves
+    Given an earlier manifest with a target that is now removed
+    When a new local build succeeds
+    Then the active local manifest excludes that target
+    And old immutable objects remain available for inspection
+    And no gateway or remote activation is performed
+```
+
+1. Add validated target declarations, a deterministic dry-run planner, reasons,
+   dependency closure, and ownership diagnostics. No deployment side effects.
+2. Add per-target emission, independent bundles, stable public route mappings,
+   dependency-sensitive caching, and compatibility regression tests.
+3. Connect authorized test deployment and immutable promotion to existing delivery
+   tools; add receipt reconciliation and host isolation checks.
+4. Integrate the bounded AI edit/diagnostic/test loop using existing context packs.
+
+Non-goals: one function per route, arbitrary AI deployment decisions, runtime
+self-repartitioning, automatic production access, and a new orchestration UI.

--- a/packages/compiler/DELIVERY.md
+++ b/packages/compiler/DELIVERY.md
@@ -1,0 +1,223 @@
+# Local Delivery Planning And Builds
+
+`supacloud-compiler plan --json` is a read-only first step toward automated app
+delivery. It uses the existing source analysis and compiler checks, then groups
+HTTP routes and declared Jobs into deterministic target previews.
+
+`supacloud-compiler build-delivery --json` additionally builds independent local
+module factory bundles. It does **not** configure queues or gateways, verify remote
+hosts, deploy functions, or run an unattended AI repair loop.
+Existing compile/check/dev output remains unchanged.
+
+## Zero-Configuration HTTP
+
+```sh
+supacloud-compiler plan --json
+```
+
+All discovered HTTP routes default to `api`. Module imports contribute dependencies,
+not route ownership. A dependency module's own routes remain with their own explicit
+owner or the default API; they are not copied into the importing target.
+All discovered routes remain exposed in the plan. To make a module private, remove
+its route declarations; simply omitting a module from target configuration does not
+hide its routes.
+
+Declared Jobs default to `jobs`, require a durable queue declaration, and default
+to process isolation. A Job declaration does not rewrite a synchronous HTTP route.
+If these runtime declarations are absent, planning returns errors with no plan.
+
+## Explicit Boundaries
+
+Add an optional `delivery` section to the existing configuration:
+
+```ts
+import { defineSupacloudConfig } from "@supacloud/compiler";
+
+export default defineSupacloudConfig({
+  delivery: {
+    version: 1,
+    targets: [
+      { name: "orders", kind: "api", modules: ["orders"] },
+      {
+        name: "payment-hooks",
+        kind: "webhook",
+        modules: ["payments"],
+        isolation: "process",
+        capabilities: ["payments.verify"],
+      },
+    ],
+    runtime: {
+      processIsolation: true,
+      durableQueue: true,
+      capabilities: ["payments.verify"],
+    },
+  },
+});
+```
+
+The names in `modules` are declared module names, not class names or paths.
+Targets select all routes or all jobs belonging to those modules, depending on
+their kind. HTTP and Job ownership are independent, so one module can contribute
+HTTP to `api` and Jobs to `jobs`. Two HTTP targets cannot both own the same module.
+`api` and `jobs` are reserved for their matching workload kinds.
+
+No unused explicit target is accepted. Unknown modules, duplicate ownership,
+unresolved imports, cyclic dependencies, duplicate job names, and conflicting
+method/path patterns reject the plan. Parameter-name aliases such as `/:id` and
+`/:key` do not establish different route identities.
+
+`runtime` is a declaration only, not host attestation. `capabilities` contains
+adapter/credential boundary references, never values. Declaring a webhook target
+does not implement signature verification or authorize public ingress. The runtime
+and deployment layers must still verify these requirements before activation.
+Changing `isolation` to `shared` is an explicit relaxation requiring user review.
+
+For an AI-generated JSON declaration instead of editing executable config:
+
+```sh
+supacloud-compiler plan --delivery delivery.json --json
+```
+
+`delivery.json` contains the `delivery` object above, not the outer project config.
+It replaces, rather than merges with, `config.delivery`. The executable project
+config is still loaded normally. Invalid configuration is rejected, not echoed.
+`--write` and unknown plan arguments fail. Successful output exits 0; failures exit 1.
+
+## Programmatic Contract
+
+```ts
+import {
+  compileOptionsFromConfig,
+  loadSupacloudConfig,
+  planDeliveryProject,
+  parseDeliveryPlanResult,
+} from "@supacloud/compiler";
+
+const config = await loadSupacloudConfig();
+const result = await planDeliveryProject(compileOptionsFromConfig(config), config.delivery);
+if (result.ok) {
+  for (const target of result.plan.targets) {
+    console.log(target.name, target.routes, target.requirements);
+  }
+}
+
+// File/message data must be validated, not asserted as DeliveryPlanResult.
+const received: unknown = JSON.parse(JSON.stringify(result));
+const validated = parseDeliveryPlanResult(received);
+console.log(validated.ok);
+```
+
+Exported TypeBox schemas are the source of both runtime validation and static types:
+`DeliveryOptionsSchema`, `DeliveryTargetSchema`, `DeliveryPlanSchema`,
+`DeliveryPlanResultSchema`. `createDeliveryPlan` accepts a trusted compiler graph;
+it is not a deserializer for arbitrary external graph JSON.
+
+## Local Builds
+
+```sh
+supacloud-compiler build-delivery --json
+supacloud-compiler build-delivery --delivery delivery.json --json
+```
+
+Requires Bun and a project `tsconfig.json`. The configured output directory must
+be project-local and must not contain the application source root. Output uses
+the dedicated `<outDir>/delivery` namespace:
+
+```text
+delivery/
+  owner.json
+  delivery.manifest.json
+  objects/<objectId>/
+    generated/application.ts
+    bundle/index.js
+    bundle/package.json
+    bundle/app.manifest.json
+    bundle/target.json
+    bundle/assets/...
+```
+
+`bundle/index.js` exports `createCompiledModules`. Move the whole `bundle` directory,
+not just its entrypoint. The generated TypeScript is inspection output and still
+references application sources; the bundle does not require those source files.
+This is **not** a default HTTP handler or a ready-to-deploy Function. A compatible
+host must supply HTTP composition, trusted identity, database/governance adapters,
+and durable Job execution. Route mappings are local metadata, not applied gateway
+configuration. All results continue to report `deploymentReady: false`.
+
+Optional build settings live in the same validated `delivery` declaration:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "minify": true,
+    "environmentContract": "app-env-v1",
+    "assets": [
+      { "target": "api", "source": "templates/report.html", "path": "report.html" }
+    ]
+  }
+}
+```
+
+Asset `source` is relative to configured source root; `path` is relative to
+`bundle/assets`. Only explicit relative paths are accepted. Missing assets, path
+traversal, duplicate destinations, and symlinks reject the build. Environment
+contracts are references, not secret values. Environment values are not inlined.
+Code doing runtime filesystem reads must use declared assets and the host's
+documented asset-location convention; automatic discovery is not provided.
+Computed `import()` and direct computed `require()` calls are rejected. This is
+not a sandbox for arbitrary JavaScript, eval, or filesystem access.
+
+Each target includes its conservative module dependency closure, while route and
+Job descriptors remain exclusive to their owner. Provider pruning is disabled to
+preserve Job and lifecycle dependencies. Package imports are bundled; only Bun
+and Node builtin imports may remain external. Native/platform-dependent packages
+still need destination-platform validation.
+
+Every invocation reruns compiler checks, TypeScript diagnostics, and bundling for
+**all** targets. The generator's type-check project includes application source
+and target-generated files, preserving configured checks and widening only the
+emit-path `rootDir` to the project directory. This does not replace application
+tests or full release checks. Refresh GraphQL artifacts through normal `compile`
+before building when GraphQL drift is reported.
+
+`inputDigest` includes generated source, captured bundled inputs, compiler and Bun
+identity, configuration/lockfile hashes, target build options, explicit assets,
+and environment-contract reference. Shared dependency changes invalidate dependent
+targets; configuration changes conservatively invalidate more targets. Unchanged
+immutable artifacts are reused without touching their files. This is **artifact
+reuse, not skipped bundler work**.
+
+Success exposes `manifest`, `bundledTargets`, `changedTargets`, `unchangedTargets`,
+`removedTargets`, and `written`. An unchanged build has `written: []`.
+`manifest.objects` records per-file size and SHA-256 plus the object identity.
+Use `parseDeliveryBuildResult` / `parseDeliveryBuildManifest` for received JSON;
+matching hashes are integrity checks, not authorization or authenticity proofs.
+
+An exclusive lock protects the owned output directory. Existing unowned output,
+invalid manifests, and modified immutable objects are rejected without overwrites.
+Only an atomic replacement of `delivery.manifest.json` activates a local build.
+Failures preserve the previous active pointer; inactive objects can remain after
+an interrupted publication. Removed target objects are retained for inspection,
+not automatically garbage-collected. Inspect stale locks after confirming no
+writer is active; the builder never removes them automatically.
+
+## Planning Evidence And Limits
+
+- Every result has `written: []`. A failure has `ok: false` and `plan: null`.
+- Success has `deploymentReady: false`. No planning result authorizes deployment.
+- `topologyDigest` hashes canonical target topology, requirements, and declared
+  readiness. It excludes business source contents, toolchain, lockfile, credentials,
+  migrations, and full runtime contracts. It is **not** an artifact hash, cache key,
+  approval token, or proof that a received plan is authentic.
+- Dependencies are a conservative module closure, not provider-level tree shaking.
+  External token inventory is conservative within that closure.
+- `planDeliveryProject` runs existing compiler analysis/governance/contract gates
+  using supplied compile options. Artifact drift is intentionally ignored so a
+  new project can be planned before generation. Existing artifacts are not rewritten.
+- Compiler analysis is not a complete TypeScript type check. Run the application's
+  type checker, tests, full integration/build gates, and host verification before
+  release. Do not weaken those gates to make a plan succeed.
+- This version does not reconcile old deployment topology, validate all possible
+  router-specific pattern overlaps, or attest queue adapters. Deployment remains
+  a separate, explicitly authorized step.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,5 +1,12 @@
 # @supacloud/compiler
 
+## Local Delivery
+
+`supacloud-compiler plan --json` previews workload targets and route ownership.
+`supacloud-compiler build-delivery --json` creates independent local factory bundles
+and an atomic inspection manifest, reusing unchanged artifacts without deployment.
+See [local delivery](./DELIVERY.md) for configuration, contracts, and limitations.
+
 ## Persistent Execution Policy
 
 Set `commandCapabilities.requirePersistentAdapters: true` to require named adapters

--- a/packages/compiler/bun.lock
+++ b/packages/compiler/bun.lock
@@ -9,6 +9,7 @@
         "@graphql-codegen/typed-document-node": "^7.1.0",
         "@graphql-codegen/typescript-operations": "^6.1.6",
         "@graphql-typed-document-node/core": "^3.2.0",
+        "@sinclair/typebox": "^0.34.52",
         "@typescript/typescript6": "^6.0.2",
         "graphql": "^16",
       },
@@ -46,6 +47,8 @@
     "@graphql-tools/utils": ["@graphql-tools/utils@11.2.2", "https://registry.npmmirror.com/@graphql-tools/utils/-/utils-11.2.2.tgz", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "https://registry.npmmirror.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "DELIVERY.md"
   ],
   "scripts": {
     "build": "bun run clean && bun run build:js && bun run build:types",
@@ -46,6 +47,7 @@
     "directory": "packages/compiler"
   },
   "dependencies": {
+    "@sinclair/typebox": "^0.34.52",
     "@graphql-codegen/core": "^6.2.0",
     "@graphql-codegen/typed-document-node": "^7.1.0",
     "@graphql-codegen/typescript-operations": "^6.1.6",

--- a/packages/compiler/src/cli.ts
+++ b/packages/compiler/src/cli.ts
@@ -9,6 +9,9 @@ import type { Diagnostic, ModuleBoundaryPresetName } from "./types";
 import { compileOptionsFromConfig, loadSupacloudConfig, resolveSupacloudConfig } from "./config";
 import { applyDiagnosticFix } from "./fixes";
 import { GraphqlConfigurationError } from "./graphql-options";
+import { planDeliveryProject, formatDeliveryPlan } from "./delivery-plan";
+import { DeliveryConfigurationError } from "./delivery-schema";
+import { buildDeliveryProject } from "./delivery-build";
 
 function isModuleBoundaryPresetName(value: string | undefined): value is ModuleBoundaryPresetName {
   return value === "modular-monolith"
@@ -32,6 +35,8 @@ Usage:
   supacloud-compiler explain <name> [rootDir] [options]
   supacloud-compiler context <module> [rootDir] [options]
   supacloud-compiler doctor  [rootDir] [options]
+  supacloud-compiler plan    [rootDir] [options]
+  supacloud-compiler build-delivery [rootDir] [options]
   supacloud-compiler fix     <fix.json> [options]
   supacloud-compiler graphql-schema --url <project-url> --key-env <name> [--token-env <name>]
 
@@ -43,6 +48,8 @@ Commands:
   explain             Explain a module, provider, or external token
   context             Extract an AI-sized module context pack
   doctor              Run project and generated-artifact health checks
+  plan                Preview deterministic workload targets without writing or deploying
+  build-delivery      Build independent local factories and an atomic delivery manifest (Bun)
   graphql-schema      Explicitly export a caller-scoped schema to the configured local file
 
 Options:
@@ -60,7 +67,8 @@ Options:
   --token-env <name>  Environment variable holding the intended user's access token
   --check             graphql-schema: compare the remote schema without changing the snapshot
   --debounce <ms>     Debounce source changes in dev mode (default: 100)
-  --json              Print machine-readable output for compile/check/graph/explain/context/doctor
+  --json              Print machine-readable output for compile/check/graph/explain/context/doctor/plan/build-delivery
+  --delivery <file>   plan/build-delivery: validated JSON configuration (overrides config.delivery)
   --dry-run           Preview a fix without writing the target file
   --write             Apply a fix to disk (fix is preview-only by default)
   --preset, -p <name> Architecture preset ('modular-monolith' | 'angular-enterprise' | 'clean-architecture')
@@ -76,7 +84,7 @@ async function run(): Promise<void> {
   }
 
   const command = args[0];
-  if (!["compile", "check", "dev", "graph", "explain", "context", "doctor", "fix", "graphql-schema"].includes(command)) {
+  if (!command || !["compile", "check", "dev", "graph", "explain", "context", "doctor", "fix", "graphql-schema", "plan", "build-delivery"].includes(command)) {
     console.error(`Error: unknown command "${command}"`);
     printUsage();
     process.exit(1);
@@ -97,10 +105,32 @@ async function run(): Promise<void> {
   let keyEnv: string | undefined;
   let tokenEnv: string | undefined;
   let checkSchema = false;
+  let deliveryPath: string | undefined;
+  const deliveryCommand = command === "plan" || command === "build-delivery";
+  const planFlags = new Set([
+    "--delivery", "--root", "-r", "--out", "-o", "--strict", "--no-strict",
+    "--client", "--no-client", "--permissions", "--no-permissions", "--no-graphql",
+    "--json", "--dry-run", "--preset", "-p",
+  ]);
+  const planValueFlags = new Set(["--delivery", "--root", "-r", "--out", "-o", "--preset", "-p"]);
 
   for (let i: number = 1; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "--root" || arg === "-r") {
+    if (arg === undefined) throw new Error("Missing command-line argument");
+    if (deliveryCommand && arg.startsWith("-")) {
+      if (!planFlags.has(arg)) throw new Error("Unsupported plan argument");
+      if (command === "build-delivery" && arg === "--dry-run") throw new Error("Use plan for read-only previews");
+      const next = args[i + 1];
+      if (planValueFlags.has(arg) && (!next || next.startsWith("-"))) {
+        throw new Error("Plan option requires a value");
+      }
+    }
+    if (arg === "--delivery") {
+      deliveryPath = args[++i];
+      if (!deliveryCommand || !deliveryPath || deliveryPath.startsWith("-")) {
+        throw new Error("--delivery requires a JSON file and a delivery command");
+      }
+    } else if (arg === "--root" || arg === "-r") {
       rootDir = args[++i];
     } else if (arg === "--out" || arg === "-o") {
       outDir = args[++i];
@@ -137,6 +167,7 @@ async function run(): Promise<void> {
     } else if (arg === "--dry-run") {
       dryRun = true;
     } else if (arg === "--write") {
+      if (command === "plan") throw new Error("plan is read-only; --write is not supported");
       dryRun = false;
     } else if (arg === "--preset" || arg === "-p") {
       const presetArg = args[++i];
@@ -150,6 +181,8 @@ async function run(): Promise<void> {
       else rootDir = arg;
     } else if (!arg.startsWith("-") && (command === "explain" || command === "context" || command === "fix") && !query) {
       query = arg;
+    } else if (deliveryCommand) {
+      throw new Error("Unsupported plan argument");
     }
   }
 
@@ -162,17 +195,37 @@ async function run(): Promise<void> {
     ...loadedConfig,
     root: resolvedRoot,
     outDir: resolvedOut,
-    strict: strict ?? loadedConfig.strict,
-    generateClient: generateClient ?? loadedConfig.generateClient,
-    generatePermissions: generatePermissions ?? loadedConfig.generatePermissions,
-    graphql: noGraphql ? false : loadedConfig.graphql,
+    ...(strict === undefined ? {} : { strict }),
+    ...(generateClient === undefined ? {} : { generateClient }),
+    ...(generatePermissions === undefined ? {} : { generatePermissions }),
+    ...(noGraphql ? { graphql: false } : {}),
   }, process.cwd());
   const compileDefaults = {
     ...configured,
-    moduleBoundaryPreset: preset ?? configured.moduleBoundaryPreset,
+    ...(preset ? { moduleBoundaryPreset: preset } : {}),
   };
 
-  if (command === "graphql-schema") {
+  if (deliveryCommand) {
+    let delivery: unknown = loadedConfig.delivery;
+    if (deliveryPath !== undefined) {
+      try {
+        delivery = JSON.parse(await readFile(resolve(process.cwd(), deliveryPath), "utf8"));
+      } catch {
+        throw new DeliveryConfigurationError();
+      }
+    }
+    if (command === "build-delivery") {
+      const result = await buildDeliveryProject(compileDefaults, delivery);
+      console.log(json ? JSON.stringify(result, null, 2) : result.ok
+        ? `Local delivery artifacts built. Changed: ${result.changedTargets.join(", ") || "-"}. Unchanged: ${result.unchangedTargets.join(", ") || "-"}. No deployment performed.`
+        : result.diagnostics.map((item) => `${item.code}: ${item.message}\n${item.suggestion ?? ""}`).join("\n"));
+      if (!result.ok) process.exitCode = 1;
+    } else {
+      const result = await planDeliveryProject(compileDefaults, delivery);
+      console.log(json ? JSON.stringify(result, null, 2) : formatDeliveryPlan(result));
+      if (!result.ok) process.exitCode = 1;
+    }
+  } else if (command === "graphql-schema") {
     if (!projectUrl) throw new Error("graphql-schema requires --url with an explicit project URL");
     if (!compileDefaults.graphql) throw new Error("graphql-schema requires graphql configuration");
     const credential = (name: string | undefined): string | undefined => {
@@ -182,11 +235,13 @@ async function run(): Promise<void> {
       return value;
     };
     const { pullGraphqlSchema } = await import("./graphql-schema");
+    const publishableKey = credential(keyEnv);
+    const accessToken = credential(tokenEnv);
     const result = await pullGraphqlSchema({
       url: projectUrl,
       output: compileDefaults.graphql.schema,
-      publishableKey: credential(keyEnv),
-      accessToken: credential(tokenEnv),
+      ...(publishableKey === undefined ? {} : { publishableKey }),
+      ...(accessToken === undefined ? {} : { accessToken }),
       check: checkSchema,
     });
     console.log(json ? JSON.stringify({ ok: result.upToDate, ...result }, null, 2)
@@ -344,7 +399,7 @@ async function run(): Promise<void> {
       console.log(JSON.stringify(doctor, null, 2));
     } else {
       for (const check of doctor.checks) console.log(`${check.ok ? "OK" : "FAIL"} ${check.name}: ${check.detail}`);
-      printDiagnostics(doctor.diagnostics);
+      printDiagnostics(doctor.diagnostics ?? []);
     }
     if (doctor.errors > 0) process.exit(1);
   }
@@ -362,6 +417,22 @@ function printDiagnostics(diagnostics: Diagnostic[]): void {
 }
 
 run().catch((err: unknown) => {
+  if (process.argv[2] === "plan" || process.argv[2] === "build-delivery" || err instanceof DeliveryConfigurationError) {
+    const result = {
+      ok: false, written: [],
+      ...(process.argv[2] === "build-delivery" ? { manifest: null, bundledTargets: [] } : { plan: null }),
+      diagnostics: [{
+        severity: "error",
+        code: err instanceof DeliveryConfigurationError ? err.code : "delivery-planning-failed",
+        message: err instanceof DeliveryConfigurationError ? err.message
+          : "Planning failed. Check source/configuration paths and supported plan arguments.",
+      }],
+    };
+    console.log(process.argv.slice(2).includes("--json") ? JSON.stringify(result, null, 2)
+      : result.diagnostics.map((item) => `${item.code}: ${item.message}`).join("\n"));
+    process.exitCode = 1;
+    return;
+  }
   if (err instanceof GraphqlConfigurationError) {
     const diagnostic: Diagnostic = {
       code: err.code,

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { assertGraphqlOptions } from "./graphql-options";
+import { parseDeliveryOptions, type DeliveryOptions } from "./delivery-schema";
 import type {
   CommandExecutionCapabilities,
   CompileOptions,
@@ -10,6 +11,8 @@ import type {
 } from "./types";
 
 export interface SupaCloudConfig {
+  /** Local delivery configuration; does not authorize deployment. */
+  delivery?: DeliveryOptions;
   /** Opt-in outside app init. Schema is configuration-relative; documents are root-relative. */
   graphql?: GraphqlOptions | false;
   root?: string;
@@ -31,7 +34,7 @@ export interface SupaCloudConfig {
 
 export const DEFAULT_SUPACLOUD_CONFIG: Required<Omit<
   SupaCloudConfig,
-  "include" | "moduleBoundaryPreset" | "commandCapabilities" | "moduleBoundaries" | "typeSafety"
+  "include" | "moduleBoundaryPreset" | "commandCapabilities" | "moduleBoundaries" | "typeSafety" | "delivery"
   | "allowRouteCommandBindings" | "disallowControllerDirectDb" | "detectOrphanModules"
 >> & {
   include: string[];
@@ -50,6 +53,7 @@ export const DEFAULT_SUPACLOUD_CONFIG: Required<Omit<
 };
 
 export function defineSupacloudConfig(config: SupaCloudConfig = {}): SupaCloudConfig {
+  if (config.delivery !== undefined) parseDeliveryOptions(config.delivery);
   if (config.graphql !== undefined && config.graphql !== false) assertGraphqlOptions(config.graphql);
   validateGovernanceConfig(config);
   return {

--- a/packages/compiler/src/delivery-build-schema.ts
+++ b/packages/compiler/src/delivery-build-schema.ts
@@ -1,0 +1,85 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import { DeliveryDiagnosticSchema, DeliveryFilePathSchema, DeliveryPlanSchema } from "./delivery-schema";
+import { canonical, digest as hash } from "./delivery-files";
+
+const closed = { additionalProperties: false } as const;
+const digest = Type.String({ pattern: "^[a-f0-9]{64}$" });
+export const DeliveryObjectSchema = Type.Object({
+  name: Type.String({ pattern: "^[a-z][a-z0-9-]{0,62}$" }),
+  objectId: digest,
+  inputDigest: digest,
+  entrypoint: Type.Literal("bundle/index.js"),
+  entryKind: Type.Literal("compiled-module-factory"),
+  runtimeImports: Type.Array(Type.String()),
+  files: Type.Array(Type.Object({
+    path: DeliveryFilePathSchema,
+    sha256: digest,
+    bytes: Type.Integer({ minimum: 0 }),
+  }, closed), { minItems: 1 }),
+}, closed);
+
+export const DeliveryBuildManifestSchema = Type.Object({
+  schemaVersion: Type.Literal(1),
+  producer: Type.Literal("@supacloud/compiler/delivery-build-v1"),
+  deploymentReady: Type.Literal(false),
+  plan: DeliveryPlanSchema,
+  objects: Type.Array(DeliveryObjectSchema),
+  // This preserves public method/path contracts; it is not an applied gateway config.
+  routes: Type.Array(Type.Object({
+    method: Type.String(), path: Type.String(), target: Type.String(),
+  }, closed)),
+  jobs: Type.Array(Type.Object({ name: Type.String(), target: Type.String() }, closed)),
+}, closed);
+
+const resultFields = {
+  diagnostics: Type.Array(DeliveryDiagnosticSchema),
+  written: Type.Array(Type.String()),
+  bundledTargets: Type.Array(Type.String()),
+};
+export const DeliveryBuildResultSchema = Type.Union([
+  Type.Object({
+    ...resultFields, ok: Type.Literal(true), manifest: DeliveryBuildManifestSchema,
+    changedTargets: Type.Array(Type.String()),
+    unchangedTargets: Type.Array(Type.String()),
+    removedTargets: Type.Array(Type.String()),
+  }, closed),
+  Type.Object({
+    ...resultFields, written: Type.Array(Type.String(), { maxItems: 0 }),
+    ok: Type.Literal(false), manifest: Type.Null(),
+  }, closed),
+]);
+
+export type DeliveryObject = Static<typeof DeliveryObjectSchema>;
+export type DeliveryBuildManifest = Static<typeof DeliveryBuildManifestSchema>;
+export type DeliveryBuildResult = Static<typeof DeliveryBuildResultSchema>;
+
+export function parseDeliveryBuildManifest(value: unknown): DeliveryBuildManifest {
+  if (!Value.Check(DeliveryBuildManifestSchema, value)) throw new Error("Invalid delivery build manifest.");
+  if (new Set(value.objects.map((item) => item.name)).size !== value.objects.length) {
+    throw new Error("Duplicate delivery object owner.");
+  }
+  if (canonical(value.objects.map((item) => item.name).sort()) !== canonical(value.plan.targets.map((item) => item.name).sort())) {
+    throw new Error("Delivery objects do not match planned targets.");
+  }
+  for (const object of value.objects) {
+    if (new Set(object.files.map((file) => file.path)).size !== object.files.length
+      || !object.files.some((file) => file.path === object.entrypoint)
+      || hash(canonical({ inputDigest: object.inputDigest, files: object.files })) !== object.objectId) {
+      throw new Error("Invalid delivery object inventory.");
+    }
+  }
+  const routes = value.plan.targets.flatMap((target) => target.routes.map((route) =>
+    ({ method: route.method, path: route.path, target: target.name })));
+  const jobs = value.plan.targets.flatMap((target) => target.jobs.map((job) => ({ name: job.name, target: target.name })));
+  if (canonical(value.routes) !== canonical(routes) || canonical(value.jobs) !== canonical(jobs)) {
+    throw new Error("Delivery mappings do not match planned ownership.");
+  }
+  return value;
+}
+
+export function parseDeliveryBuildResult(value: unknown): DeliveryBuildResult {
+  if (!Value.Check(DeliveryBuildResultSchema, value)) throw new Error("Invalid delivery build result.");
+  if (value.ok) parseDeliveryBuildManifest(value.manifest);
+  return value;
+}

--- a/packages/compiler/src/delivery-build.test.ts
+++ b/packages/compiler/src/delivery-build.test.ts
@@ -1,0 +1,241 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { cp, mkdtemp, readFile, rm, stat, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildDeliveryProject } from "./delivery-build";
+import { parseDeliveryBuildManifest, parseDeliveryBuildResult } from "./delivery-build-schema";
+import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
+import { requireValue, writeFixtureProject } from "./fixtures/helpers";
+import { bundleDeliveryTarget } from "./delivery-bundle";
+import { reserveOutput } from "./delivery-files";
+import { parseDeliveryOptions } from "./delivery-schema";
+
+let root: string;
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "delivery-build-"));
+  await writeFixtureProject(root, {
+    ...GOOD_PROJECT_FILES,
+    "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"].replace('"strict": true', '"strict": true, "rootDir": "src"'),
+    "src/runtime.ts": GOOD_PROJECT_FILES["src/runtime.ts"].replaceAll("() => {}", "(..._args: unknown[]) => {}"),
+  });
+});
+afterAll(async () => { await rm(root, { recursive: true, force: true }); });
+
+const settings = { version: 1 };
+const build = () => buildDeliveryProject({
+  rootDir: root, outDir: join(root, "generated"), strict: false,
+  generateClient: false, generatePermissions: false,
+}, settings);
+
+test("builds a movable factory and reuses immutable artifacts; failures preserve the pointer", async () => {
+  const first = await build();
+  if (!first.ok) throw new Error(JSON.stringify(first.diagnostics));
+  expect(parseDeliveryBuildResult(JSON.parse(JSON.stringify(first)))).toEqual(first);
+  expect(first.manifest.deploymentReady).toBe(false);
+  expect(() => parseDeliveryBuildManifest({...first.manifest, routes: []})).toThrow();
+  expect(() => parseDeliveryBuildManifest({...first.manifest, objects: []})).toThrow();
+  expect(first.manifest.routes).toEqual([{ method: "POST", path: "/cases/:caseId/accept", target: "api" }]);
+  const object = requireValue(first.manifest.objects[0]);
+  const bundle = join(root, "generated/delivery/objects", object.objectId, "bundle");
+  const mtime = (await stat(join(bundle, "index.js"))).mtimeMs;
+  const detached = await mkdtemp(join(tmpdir(), "detached-delivery-"));
+  try {
+    await cp(bundle, detached, { recursive: true });
+    const loaded: unknown = await import(join(detached, "index.js"));
+    expect(typeof loaded).toBe("object");
+    if (loaded === null || typeof loaded !== "object" || !("createCompiledModules" in loaded)
+      || typeof loaded.createCompiledModules !== "function") throw new Error("Missing factory export");
+    expect(Array.isArray(loaded.createCompiledModules())).toBe(true);
+  } finally { await rm(detached, { recursive: true, force: true }); }
+  const second = await build();
+  if (!second.ok) throw new Error(JSON.stringify(second.diagnostics));
+  expect(second.written).toEqual([]);
+  expect(second.bundledTargets).toEqual(["api"]);
+  expect(second.unchangedTargets).toEqual(["api"]);
+  expect((await stat(join(bundle, "index.js"))).mtimeMs).toBe(mtime);
+  const pointer = join(root, "generated/delivery/delivery.manifest.json");
+  const before = await readFile(pointer, "utf8");
+  await writeFixtureProject(root, { "src/features/audit/logger.ts": "export function createLogger(config: {level: string}): string { return 42; }" });
+  const failed = await build();
+  expect(failed.ok).toBe(false);
+  expect(await readFile(pointer, "utf8")).toBe(before);
+  await writeFixtureProject(root, { "src/features/audit/logger.ts": GOOD_PROJECT_FILES["src/features/audit/logger.ts"].replace("return { level: config.level };", 'return { level: config.level + "-changed" };') });
+  const changed = await build();
+  if (!changed.ok) throw new Error(JSON.stringify(changed.diagnostics));
+  expect(changed.changedTargets).toEqual(["api"]);
+  expect(requireValue(changed.manifest.objects[0]).inputDigest).not.toBe(object.inputDigest);
+  expect((await stat(join(bundle, "index.js"))).mtimeMs).toBe(mtime);
+}, 120_000);
+
+test("isolates route owners, includes assets, and invalidates only dependent targets", async () => {
+  const project = await mkdtemp(join(tmpdir(), "delivery-targets-"));
+  try {
+    await writeFixtureProject(project, {
+      ...GOOD_PROJECT_FILES,
+      "src/runtime.ts": GOOD_PROJECT_FILES["src/runtime.ts"].replaceAll("() => {}", "(..._args: unknown[]) => {}"),
+      "src/features/health/health.module.ts": `import { Module, Controller, Get } from "../../runtime";
+        @Controller("/health") export class HealthController {
+          @Get("/", { response: {type: "string"} }) status(): string { return "ok"; }
+        }
+        @Module({name: "health", controllers: [HealthController]}) export class HealthModule {}`,
+      "src/template.txt": "first",
+    });
+    const options = { rootDir: project, outDir: join(project, "generated"), strict: false, generateClient: false, generatePermissions: false };
+    const config = { version: 1, targets: [{ name: "cases", kind: "api", modules: ["case"] }],
+      build: { assets: [{ target: "cases", source: "src/template.txt", path: "template.txt" }] } };
+    const first = await buildDeliveryProject(options, config);
+    if (!first.ok) throw new Error(JSON.stringify(first.diagnostics));
+    expect(first.manifest.routes).toEqual([
+      { method: "GET", path: "/health", target: "api" },
+      { method: "POST", path: "/cases/:caseId/accept", target: "cases" },
+    ]);
+    const cases = requireValue(first.manifest.objects.find((item) => item.name === "cases"));
+    const api = requireValue(first.manifest.objects.find((item) => item.name === "api"));
+    const objects = join(project, "generated/delivery/objects");
+    expect(await readFile(join(objects, cases.objectId, "bundle/assets/template.txt"), "utf8")).toBe("first");
+    expect(await readFile(join(objects, api.objectId, "generated/application.ts"), "utf8")).not.toContain("CaseController");
+    expect(await readFile(join(objects, cases.objectId, "generated/application.ts"), "utf8")).not.toContain("HealthController");
+    expect(await readFile(join(objects, cases.objectId, "generated/application.ts"), "utf8")).toContain("AuditService");
+    await writeFixtureProject(project, { "src/template.txt": "second" });
+    const changed = await buildDeliveryProject(options, config);
+    if (!changed.ok) throw new Error(JSON.stringify(changed.diagnostics));
+    expect(changed.changedTargets).toEqual(["cases"]);
+    expect(changed.unchangedTargets).toEqual(["api"]);
+    const pointer = join(project, "generated/delivery/delivery.manifest.json");
+    const before = await readFile(pointer, "utf8");
+    await writeFixtureProject(project, { "src/features/audit/logger.ts": GOOD_PROJECT_FILES["src/features/audit/logger.ts"].replace("config.level", 'config.level + "changed"') });
+    const dependency = await buildDeliveryProject(options, config);
+    if (!dependency.ok) throw new Error(JSON.stringify(dependency.diagnostics));
+    expect(dependency.changedTargets).toEqual(["cases"]);
+    expect(dependency.unchangedTargets).toEqual(["api"]);
+    expect(await readFile(pointer, "utf8")).not.toBe(before);
+    const active = await readFile(pointer, "utf8");
+    const badAsset = await buildDeliveryProject(options, { ...config, build: { assets: [{target: "cases", source: "missing.txt", path: "template.txt"}] } });
+    expect(badAsset.ok).toBe(false);
+    expect(await readFile(pointer, "utf8")).toBe(active);
+    const removed = await buildDeliveryProject(options, {version: 1});
+    if (!removed.ok) throw new Error(JSON.stringify(removed.diagnostics));
+    expect(removed.removedTargets).toEqual(["cases"]);
+    expect((await stat(join(objects, cases.objectId))).isDirectory()).toBe(true);
+    const current = requireValue(removed.manifest.objects[0]);
+    await writeFixtureProject(project, { [`generated/delivery/objects/${current.objectId}/bundle/index.js`]: "tampered" });
+    const corrupted = await buildDeliveryProject(options, {version: 1});
+    expect(corrupted.ok).toBe(false);
+    expect(await readFile(join(objects, current.objectId, "bundle/index.js"), "utf8")).toBe("tampered");
+  } finally { await rm(project, { recursive: true, force: true }); }
+}, 120_000);
+
+test("rejects unsafe paths, unowned output, links, and concurrent writers", async () => {
+  for (const path of ["../escape", "/absolute", ".hidden/file", "a/../b"]) {
+    expect(() => parseDeliveryOptions({version: 1, build: {assets: [{target: "api", source: path, path: "safe"}]}})).toThrow();
+  }
+  const project = await mkdtemp(join(tmpdir(), "delivery-ownership-"));
+  try {
+    await writeFixtureProject(project, { "unowned/keep.txt": "keep" });
+    await expect(reserveOutput(project, join(project, "unowned"))).rejects.toThrow();
+    expect(await readFile(join(project, "unowned/keep.txt"), "utf8")).toBe("keep");
+    await symlink(join(project, "unowned"), join(project, "linked"));
+    await expect(reserveOutput(project, join(project, "linked/output"))).rejects.toThrow();
+    const first = await reserveOutput(project, join(project, "owned"));
+    try { await expect(reserveOutput(project, join(project, "owned"))).rejects.toThrow(); }
+    finally { await first.release(); }
+  } finally { await rm(project, { recursive: true, force: true }); }
+});
+
+test("does not inline environment values and rejects computed imports", async () => {
+  const project = await mkdtemp(join(tmpdir(), "delivery-bundle-"));
+  const variable = "SUPACLOUD_DELIVERY_TEST_VALUE";
+  const previous = process.env[variable];
+  process.env[variable] = "DO_NOT_EMBED_DELIVERY_SECRET";
+  try {
+    await writeFixtureProject(project, { "entry.ts": `import { basename } from "node:path"; export const value = basename(process.env.${variable} ?? "");` });
+    const result = await bundleDeliveryTarget("api", 'export { value } from "./entry.ts";', project, project, {version: 1});
+    expect(new TextDecoder().decode(result.files.get("bundle/index.js"))).not.toContain("DO_NOT_EMBED_DELIVERY_SECRET");
+    expect(result.runtimeImports.map((path) => path.replace(/^node:/, ""))).toContain("path");
+    const script = `import { bundleDeliveryTarget } from ${JSON.stringify(join(import.meta.dir, "delivery-bundle.ts"))};
+      await bundleDeliveryTarget("api", 'export { value } from "./entry.ts";', ${JSON.stringify(project)}, ${JSON.stringify(project)}, {version: 1});`;
+    const child = Bun.spawn([Bun.argv[0] ?? "bun", "-e", script], {cwd: "/", stdout: "pipe", stderr: "pipe"});
+    const [, errors, status] = await Promise.all([
+      new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited,
+    ]);
+    expect(errors).toBe("");
+    expect(status).toBe(0);
+    await writeFixtureProject(project, { "entry.ts": 'const name = "./runtime"; export const load = () => import(name);' });
+    await expect(bundleDeliveryTarget("api", 'export { load } from "./entry.ts";', project, project, {version: 1})).rejects.toThrow();
+  } finally {
+    if (previous === undefined) delete process.env[variable]; else process.env[variable] = previous;
+    await rm(project, { recursive: true, force: true });
+  }
+});
+
+test("keeps shared-module routes private to their owner and preserves Job factories", async () => {
+  const project = await mkdtemp(join(tmpdir(), "delivery-jobs-"));
+  try {
+    await writeFixtureProject(project, {
+      ...GOOD_PROJECT_FILES,
+      "src/runtime.ts": GOOD_PROJECT_FILES["src/runtime.ts"].replaceAll("() => {}", "(..._args: unknown[]) => {}"),
+      "src/features/audit/audit.module.ts": GOOD_PROJECT_FILES["src/features/audit/audit.module.ts"]
+        .replace('import { Module }', 'import { Module, Controller, Get }')
+        .replace("@Module({", '@Controller("/audit") export class AuditController { @Get("/", {response: {type: "string"}}) status(): string {return "ok";} }\n@Module({controllers: [AuditController],'),
+      "src/jobs.module.ts": `import { Job, Module } from "./runtime";
+        import { AuditModule } from "./features/audit/audit.module";
+        @Job({name: "case.rebuild"}) export class RebuildJob {run(input: string): string {return input;}}
+        @Module({name: "worker", imports: [AuditModule], jobs: [RebuildJob]}) export class WorkerModule {}`,
+    });
+    const result = await buildDeliveryProject({
+      rootDir: project, outDir: join(project, "generated"), strict: false,
+      generateClient: false, generatePermissions: false,
+    }, {version: 1, targets: [{name: "cases", kind: "api", modules: ["case"]}],
+      runtime: {processIsolation: true, durableQueue: true, capabilities: []}});
+    if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+    expect(result.manifest.jobs).toEqual([{name: "case.rebuild", target: "jobs"}]);
+    for (const object of result.manifest.objects) {
+      const loaded: unknown = await import(join(project, "generated/delivery/objects", object.objectId, object.entrypoint));
+      if (loaded === null || typeof loaded !== "object" || !("createCompiledModules" in loaded)
+        || typeof loaded.createCompiledModules !== "function") throw new Error("Missing factory export");
+      const modules: unknown = loaded.createCompiledModules();
+      const text = JSON.stringify(modules);
+      expect(text.includes('"method":"GET"')).toBe(object.name === "api");
+      expect(text.includes('"method":"POST"')).toBe(object.name === "cases");
+      expect(text.includes('"name":"case.rebuild"')).toBe(object.name === "jobs");
+      if (object.name === "cases") expect(text).toContain('"permission":"case.accept"');
+      if (object.name === "jobs") {
+        expect(await readFile(join(project, "generated/delivery/objects", object.objectId, "generated/application.ts"), "utf8")).toContain("createJobScope");
+      }
+    }
+  } finally { await rm(project, {recursive: true, force: true}); }
+}, 60_000);
+
+test("CLI exposes structured builds and rejects write-like preview flags", async () => {
+  const project = await mkdtemp(join(tmpdir(), "delivery-cli-build-"));
+  try {
+    await writeFixtureProject(project, {
+      ...GOOD_PROJECT_FILES,
+      "src/runtime.ts": GOOD_PROJECT_FILES["src/runtime.ts"].replaceAll("() => {}", "(..._args: unknown[]) => {}"),
+      "supacloud.config.ts": `export default {root: ".", outDir: "generated", strict: false,
+        generateClient: false, generatePermissions: false};`,
+      "invalid.json": '{"version":1,"secret":"DO_NOT_ECHO_THIS"}',
+    });
+    async function run(args: string[]) {
+      const process = Bun.spawn([Bun.argv[0] ?? "bun", join(import.meta.dir, "cli.ts"), "build-delivery", ...args, "--json"], {
+        cwd: project, stdout: "pipe", stderr: "pipe",
+      });
+      const stdout = await new Response(process.stdout).text();
+      const stderr = await new Response(process.stderr).text();
+      const code = await process.exited;
+      expect(stdout + stderr).not.toContain("DO_NOT_ECHO_THIS");
+      return {code, result: parseDeliveryBuildResult(JSON.parse(stdout))};
+    }
+    const first = await run([]);
+    expect(first.code).toBe(0);
+    expect(first.result.ok).toBe(true);
+    const pointer = join(project, "generated/delivery/delivery.manifest.json");
+    const before = await readFile(pointer, "utf8");
+    for (const args of [["--dry-run"], ["--write"], ["--delivery", "invalid.json"]]) {
+      const rejected = await run(args);
+      expect(rejected.code).toBe(1);
+      expect(rejected.result.ok).toBe(false);
+      expect(await readFile(pointer, "utf8")).toBe(before);
+    }
+  } finally { await rm(project, {recursive: true, force: true}); }
+}, 60_000);

--- a/packages/compiler/src/delivery-build.ts
+++ b/packages/compiler/src/delivery-build.ts
@@ -1,0 +1,255 @@
+import { mkdir, mkdtemp, readFile, realpath, rename, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { checkProject } from "./compile";
+import { createDeliveryPlan } from "./delivery-plan";
+import { parseDeliveryOptions, type DeliveryDiagnostic } from "./delivery-schema";
+import { parseDeliveryBuildManifest, parseDeliveryBuildResult, type DeliveryBuildResult, type DeliveryObject } from "./delivery-build-schema";
+import { renderDeliveryTarget } from "./delivery-render";
+import { bundleDeliveryTarget } from "./delivery-bundle";
+import { artifactInventory, canonical, digest, exists, inside, noLinks, publishPointer, readOwned, reserveOutput, sourceInventory, writeArtifact } from "./delivery-files";
+import { scanGeneratedArtifacts } from "./type-safety";
+import type { CompileOptions } from "./types";
+
+const producer = "@supacloud/compiler/delivery-build-v1" as const;
+
+/** Build local, independently importable factories. Never activates remote Functions. */
+export async function buildDeliveryProject(
+  options: CompileOptions,
+  delivery?: unknown,
+): Promise<DeliveryBuildResult> {
+  const bundledTargets: string[] = [];
+  let resultDiagnostics: DeliveryDiagnostic[] = [];
+  const failed = (diagnostics: DeliveryDiagnostic[]): DeliveryBuildResult => {
+    resultDiagnostics = [...diagnostics];
+    return { ok: false, manifest: null, diagnostics: resultDiagnostics, written: [], bundledTargets };
+  };
+  let phase = "configuration";
+  let output: Awaited<ReturnType<typeof reserveOutput>> | undefined;
+  const temporary: string[] = [];
+  try {
+    const settings = parseDeliveryOptions(delivery);
+    if (typeof Bun === "undefined") throw new Error("Independent delivery builds require Bun.");
+    const configPath = ts.findConfigFile(resolve(options.rootDir), ts.sys.fileExists);
+    if (!configPath) throw new Error("Independent delivery builds require a project tsconfig.json.");
+    const lexicalProject = dirname(configPath);
+    const project = await realpath(lexicalProject);
+    const sourceRoot = await realpath(options.rootDir);
+    if (!inside(project, sourceRoot)) throw new Error("Application sources must be inside the project.");
+    const requested = resolve(options.outDir, "delivery");
+    if (!inside(lexicalProject, requested)) throw new Error("Output must be inside the application project.");
+    const buildRoot = resolve(project, relative(lexicalProject, requested));
+    const generatedRoot = resolve(project, relative(lexicalProject, options.outDir));
+    if (inside(generatedRoot, sourceRoot)) throw new Error("Output must not contain the application source root.");
+    const configInputs = new Map<string, string>();
+    const parsedConfig = ts.getParsedCommandLineOfConfigFile(await realpath(configPath), {}, {
+      ...ts.sys,
+      readFile(path) {
+        const contents = readFileSync(path, "utf8");
+        configInputs.set(resolve(path), digest(contents));
+        return contents;
+      },
+      onUnRecoverableConfigFileDiagnostic() { throw new Error("Invalid project TypeScript configuration."); },
+    });
+    if (!parsedConfig || parsedConfig.errors.length > 0) throw new Error("Invalid project TypeScript configuration.");
+
+    phase = "compiler-checks";
+    const sources = await sourceInventory(sourceRoot, generatedRoot);
+    const checked = await checkProject(options);
+    const planned = createDeliveryPlan({ ...checked.graph, diagnostics: checked.diagnostics }, settings);
+    if (!planned.ok) return failed(planned.diagnostics);
+    if (options.graphql && checked.mismatches.some((mismatch) => mismatch.startsWith("graphql"))) {
+      throw new Error("Refresh GraphQL artifacts with compile before building independent targets.");
+    }
+    const assets = settings.build?.assets ?? [];
+    for (const asset of assets) {
+      if (!planned.plan.targets.some((target) => target.name === asset.target)) {
+        throw new Error("An asset refers to an unknown delivery target.");
+      }
+    }
+    const assetOwners = assets.map((asset) => `${asset.target}/${asset.path}`);
+    if (new Set(assetOwners).size !== assetOwners.length) throw new Error("Duplicate target asset path.");
+
+    phase = "output-ownership";
+    output = await reserveOutput(project, buildRoot);
+    const objectRoot = join(output.path, "objects");
+    await noLinks(output.path, objectRoot);
+    await mkdir(objectRoot, { recursive: true });
+    const pointer = join(output.path, "delivery.manifest.json");
+    const previous = await exists(pointer)
+      ? parseDeliveryBuildManifest(JSON.parse(new TextDecoder().decode(await readOwned(output.path, pointer))))
+      : undefined;
+    const objects: DeliveryObject[] = [];
+    const candidates: Array<{ path: string; object: DeliveryObject }> = [];
+    const snapshots = new Map([...sources, ...configInputs]);
+
+    // Configuration and dependency resolution inputs invalidate every affected build.
+    // Bun resolves afresh on every invocation; there is no persisted "skip bundler" cache.
+    const configuration: Record<string, string> = {};
+    let directory = project;
+    while (true) {
+      for (const name of ["package.json", "bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bunfig.toml", "tsconfig.json"]) {
+        const path = join(directory, name);
+        if (await exists(path)) {
+          const bytes = await readFile(path);
+          const before = snapshots.get(path);
+          if (before !== undefined && before !== digest(bytes)) throw new Error("Configuration changed during analysis; retry.");
+          snapshots.set(path, digest(bytes));
+          configuration[relative(project, path).split(sep).join("/")] = digest(bytes);
+        }
+      }
+      const parent = dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
+    const toolchain = {
+      producer, bun: Bun.version, revision: Bun.revision,
+      compiler: digest(canonical(Object.fromEntries(
+        [...await sourceInventory(import.meta.dir, join(import.meta.dir, "node_modules"))]
+          .map(([path, hash]) => [relative(import.meta.dir, path), hash]),
+      ))),
+    };
+
+    for (const target of planned.plan.targets) {
+      phase = `target:${target.name}`;
+      const stage = await mkdtemp(join(objectRoot, ".build-"));
+      temporary.push(stage);
+      // Same depth as the immutable object directory; no random staging names enter source imports.
+      const generatedDirectory = join(objectRoot, "0".repeat(64), "generated");
+      const rendered = renderDeliveryTarget(checked.graph, target, {
+        ...options, rootDir: sourceRoot, outDir: generatedDirectory,
+      });
+      const generated: Record<string, string> = {
+        "application.ts": rendered.applicationCode,
+        ...(rendered.clientCode === undefined ? {} : { "client.ts": rendered.clientCode }),
+        ...(rendered.permissionsCode === undefined ? {} : { "permissions.ts": rendered.permissionsCode }),
+      };
+      const unsafe = scanGeneratedArtifacts(generated, true);
+      if (unsafe.some((item) => item.severity === "error")) return failed(unsafe);
+      for (const [name, contents] of Object.entries(generated)) await writeArtifact(stage, `generated/${name}`, contents);
+
+      {
+        // Widen only the emit-path boundary to include compiler-owned source.
+        // All application strictness and project-reference settings are preserved.
+        const program = ts.createProgram({
+          rootNames: [...parsedConfig.fileNames.filter((path) => !inside(generatedRoot, path)),
+            ...Object.keys(generated).map((name) => join(stage, "generated", name))],
+          options: { ...parsedConfig.options, rootDir: project },
+          ...(parsedConfig.projectReferences ? { projectReferences: parsedConfig.projectReferences } : {}),
+        });
+        const diagnostics = ts.getPreEmitDiagnostics(program);
+        if (diagnostics.some((item) => item.category === ts.DiagnosticCategory.Error)) {
+          return failed(diagnostics.filter((item) => item.category === ts.DiagnosticCategory.Error).map((item) => ({
+            severity: "error", code: "delivery-generated-type-error",
+            message: ts.flattenDiagnosticMessageText(item.messageText, "\n"),
+            ...(item.file ? { file: item.file.fileName } : {}),
+          })));
+        }
+      }
+
+      const bundled = await bundleDeliveryTarget(target.name, rendered.applicationCode, project, join(stage, "generated"), settings);
+      bundledTargets.push(target.name);
+      for (const [path, hash] of bundled.inputs) {
+        const previousHash = snapshots.get(path);
+        if (previousHash !== undefined && previousHash !== hash) throw new Error("Shared source changed between target builds; retry.");
+        snapshots.set(path, hash);
+      }
+      for (const [path, bytes] of bundled.files) await writeArtifact(stage, path, bytes);
+      await writeArtifact(stage, "bundle/package.json", canonical({ type: "module", private: true }));
+      await writeArtifact(stage, "bundle/app.manifest.json", rendered.manifestJson);
+      await writeArtifact(stage, "bundle/target.json", canonical({
+        target, entryKind: "compiled-module-factory", deploymentReady: false,
+      }));
+      const assetInputs: Record<string, string> = {};
+      for (const asset of assets.filter((asset) => asset.target === target.name)) {
+        const path = resolve(sourceRoot, asset.source);
+        const bytes = await readOwned(sourceRoot, path);
+        const hash = digest(bytes);
+        const previousHash = snapshots.get(path);
+        if (previousHash !== undefined && previousHash !== hash) throw new Error("Asset changed during build; retry.");
+        snapshots.set(path, hash);
+        assetInputs[asset.source] = hash;
+        await writeArtifact(stage, `bundle/assets/${asset.path}`, bytes);
+      }
+      const inputDigest = digest(canonical({
+        target, generated, toolchain, configuration,
+        build: { minify: settings.build?.minify ?? true,
+          environmentContract: settings.build?.environmentContract,
+          assets: assets.filter((asset) => asset.target === target.name) },
+        inputs: Object.fromEntries([...bundled.inputs].map(([path, hash]) =>
+          [relative(project, path).split(sep).join("/"), hash])),
+        assets: assetInputs,
+      }));
+      const files = await artifactInventory(stage);
+      const object: DeliveryObject = {
+        name: target.name, inputDigest,
+        objectId: digest(canonical({ inputDigest, files })),
+        entrypoint: "bundle/index.js", entryKind: "compiled-module-factory",
+        runtimeImports: bundled.runtimeImports, files,
+      };
+      objects.push(object);
+      candidates.push({ path: stage, object });
+    }
+
+    phase = "source-consistency";
+    if (canonical(Object.fromEntries(sources)) !== canonical(Object.fromEntries(
+      await sourceInventory(sourceRoot, generatedRoot),
+    ))) throw new Error("Application sources changed during analysis; retry.");
+    for (const [path, hash] of snapshots) {
+      if (digest(await readFile(path)) !== hash) throw new Error("Build inputs changed before publication; retry.");
+    }
+    const manifest = parseDeliveryBuildManifest({
+      schemaVersion: 1, producer, deploymentReady: false, plan: planned.plan, objects,
+      routes: planned.plan.targets.flatMap((target) => target.routes.map((route) =>
+        ({ method: route.method, path: route.path, target: target.name }))),
+      jobs: planned.plan.targets.flatMap((target) => target.jobs.map((job) => ({ name: job.name, target: target.name }))),
+    });
+    phase = "artifact-integrity";
+    for (const candidate of candidates) {
+      const destination = join(objectRoot, candidate.object.objectId);
+      await noLinks(output.path, destination);
+      if (await exists(destination) && canonical(await artifactInventory(destination)) !== canonical(candidate.object.files)) {
+        throw new Error("An immutable artifact was modified. Refusing to overwrite it.");
+      }
+    }
+    const written: string[] = [];
+    for (const candidate of candidates) {
+      const destination = join(objectRoot, candidate.object.objectId);
+      if (!await exists(destination)) {
+        await rename(candidate.path, destination);
+        written.push(...candidate.object.files.map((file) => join(destination, file.path)));
+      }
+    }
+    // Only this pointer defines the active local build. Earlier immutable objects
+    // remain available for rollback; failure never switches this pointer.
+    phase = "manifest-publication";
+    if (await publishPointer(output.path, canonical(manifest) + "\n")) written.push(pointer);
+    const unchangedTargets = objects.filter((object) =>
+      previous?.objects.some((old) => old.name === object.name && old.objectId === object.objectId)).map((object) => object.name);
+    resultDiagnostics = [...planned.diagnostics];
+    return parseDeliveryBuildResult({
+      ok: true, manifest, diagnostics: resultDiagnostics, written, bundledTargets,
+      unchangedTargets,
+      changedTargets: objects.filter((object) => !unchangedTargets.includes(object.name)).map((object) => object.name),
+      removedTargets: previous?.objects.filter((old) => !objects.some((object) => object.name === old.name)).map((old) => old.name) ?? [],
+    });
+  } catch {
+    // Build errors can contain source snippets or values. Return the phase, not rejected data.
+    return failed([{
+      severity: "error", code: "delivery-build-failed",
+      message: `Independent delivery build failed during ${phase}.`,
+      suggestion: phase === "configuration" ? "Use Bun, a project tsconfig, valid delivery options and a project-local output directory."
+        : phase === "output-ownership" ? "Use an empty output namespace or this project's owned directory; resolve locks and symlinks explicitly."
+        : "Check compiler/type diagnostics, static imports, declared asset paths and artifact integrity; retry only after resolving the failure.",
+    }]);
+  } finally {
+    const cleaned = await Promise.allSettled(temporary.map((path) => rm(path, { recursive: true, force: true })));
+    try { await output?.release(); } catch {
+      resultDiagnostics.push({ severity: "warn", code: "delivery-cleanup-failed", message: "Output lock cleanup failed; inspect the owned build directory before retrying." });
+    }
+    if (cleaned.some((result) => result.status === "rejected")) {
+      resultDiagnostics.push({ severity: "warn", code: "delivery-cleanup-failed", message: "Some inactive staging directories could not be removed." });
+    }
+  }
+}

--- a/packages/compiler/src/delivery-bundle.ts
+++ b/packages/compiler/src/delivery-bundle.ts
@@ -1,0 +1,107 @@
+import { isBuiltin } from "node:module";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import * as ts from "@typescript/typescript6";
+import { digest } from "./delivery-files";
+import type { DeliveryOptions } from "./delivery-schema";
+
+export interface BundledDeliveryTarget {
+  files: Map<string, Uint8Array>;
+  inputs: Map<string, string>;
+  runtimeImports: string[];
+}
+
+/** Reject direct computed module loads: their dependency closure cannot be bundled statically. */
+function checkStaticImports(path: string, contents: Uint8Array): void {
+  if (!/\.[cm]?[jt]sx?$/.test(path)) return;
+  const source = ts.createSourceFile(path, new TextDecoder().decode(contents), ts.ScriptTarget.Latest, true);
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && (node.expression.kind === ts.SyntaxKind.ImportKeyword
+      || (ts.isIdentifier(node.expression) && node.expression.text === "require"))) {
+      const argument = node.arguments[0];
+      if (!argument || (!ts.isStringLiteral(argument) && !ts.isNoSubstitutionTemplateLiteral(argument))) {
+        throw new Error("Computed module loading is not supported in independent delivery bundles.");
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+}
+
+export async function bundleDeliveryTarget(
+  name: string,
+  code: string,
+  project: string,
+  generatedDirectory: string,
+  options: DeliveryOptions,
+): Promise<BundledDeliveryTarget> {
+  const inputs = new Map<string, string>();
+  const workingDirectory = process.cwd();
+  const virtual = `supacloud-delivery:${name}`;
+  const result = await Bun.build({
+    entrypoints: [virtual],
+    root: project,
+    target: "bun",
+    format: "esm",
+    packages: "bundle",
+    splitting: false,
+    sourcemap: "none",
+    env: "disable",
+    minify: options.build?.minify ?? true,
+    naming: { entry: "index.js", asset: "assets/[name]-[hash].[ext]", chunk: "chunks/[name]-[hash].[ext]" },
+    metafile: true,
+    throw: false,
+    plugins: [{
+      name: "supacloud-delivery-inputs",
+      setup(build) {
+        // Bun can label imports of a virtual entry as file-namespace imports.
+        // Match its unique importer as well as the custom namespace below.
+        build.onResolve({ filter: /.*/ }, (args) => args.importer === name
+          ? { path: Bun.resolveSync(args.path, generatedDirectory), namespace: "file" }
+          : undefined);
+        build.onResolve({ filter: /^supacloud-delivery:/ }, () => ({ path: name, namespace: "supacloud-delivery" }));
+        build.onResolve({ filter: /.*/, namespace: "supacloud-delivery" }, (args) => ({
+          path: Bun.resolveSync(args.path, generatedDirectory), namespace: "file",
+        }));
+        build.onLoad({ filter: /.*/, namespace: "supacloud-delivery" }, () => ({ contents: code, loader: "ts" }));
+        build.onLoad({ filter: /.*/, namespace: "file" }, async (args) => {
+          const bytes = await readFile(args.path);
+          checkStaticImports(args.path, bytes);
+          inputs.set(resolve(args.path), digest(bytes));
+          return { contents: bytes, loader: args.loader };
+        });
+      },
+    }],
+  });
+  if (!result.success || !result.metafile) throw new Error("Independent bundle failed or has no dependency metadata.");
+  const runtimeImports = new Set<string>();
+  for (const [path, metadata] of Object.entries(result.metafile.inputs)) {
+    // Metafile paths are relative to the invoking process, not BuildConfig.root.
+    if (path !== virtual && !inputs.has(resolve(workingDirectory, path))) {
+      throw new Error("Bundler reported an input that was not captured by the delivery snapshot.");
+    }
+    for (const imported of metadata.imports) {
+      if (!imported.external) continue;
+      if (!isBuiltin(imported.path) && imported.path !== "bun" && !imported.path.startsWith("bun:")) {
+        throw new Error("Independent bundles cannot retain external package imports.");
+      }
+      runtimeImports.add(imported.path);
+    }
+  }
+  const files = new Map<string, Uint8Array>();
+  for (const output of result.outputs) {
+    const path = output.path.replace(/^\.\//, "");
+    // Every bundler output is inside this target; no shared external chunks.
+    if (path.startsWith("/") || path.split("/").some((part) => part === "..")) {
+      throw new Error("Bundler output escapes the target package.");
+    }
+    files.set(`bundle/${path}`, new Uint8Array(await output.arrayBuffer()));
+  }
+  if (!files.has("bundle/index.js")) throw new Error("Independent bundle has no index.js entrypoint.");
+  // Some native loaders do not appear as normal module imports. Their emitted assets
+  // are included above, but deployment still has to attest the destination platform.
+  for (const [path, hash] of inputs) {
+    if (digest(await readFile(path)) !== hash) throw new Error("Source changed during bundling; retry the build.");
+  }
+  return { files, inputs, runtimeImports: [...runtimeImports].sort() };
+}

--- a/packages/compiler/src/delivery-cli.test.ts
+++ b/packages/compiler/src/delivery-cli.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GOOD_PROJECT_FILES } from "./fixtures/good-project";
+import { writeFixtureProject } from "./fixtures/helpers";
+import { parseDeliveryPlanResult } from "./delivery-schema";
+import { planDeliveryProject } from "./delivery-plan";
+
+let root: string;
+const cli = join(import.meta.dir, "cli.ts");
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "supacloud-delivery-"));
+  await writeFixtureProject(root, {
+    ...GOOD_PROJECT_FILES,
+    "supacloud.config.ts": `export default {
+      root: ".", outDir: "generated", strict: false, requireRouteContracts: false,
+      generateClient: false, generatePermissions: false, treeShakeUnusedProviders: false,
+    };`,
+    "invalid.json": JSON.stringify({ version: 1, secret: "DO_NOT_ECHO_THIS" }),
+    "invalid-syntax.json": "{ DO_NOT_ECHO_THIS",
+    "valid.json": JSON.stringify({ version: 1 }),
+  });
+}, 30_000);
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+}, 30_000);
+
+async function run(args: string[]) {
+  const process = Bun.spawn([Bun.argv[0] ?? "bun", cli, "plan", ...args, "--json"], {
+    cwd: root, stdout: "pipe", stderr: "pipe",
+  });
+  const stdout = await new Response(process.stdout).text();
+  const stderr = await new Response(process.stderr).text();
+  const code = await process.exited;
+  const wire: unknown = JSON.parse(stdout);
+  return { result: parseDeliveryPlanResult(wire), stdout, stderr, code };
+}
+
+test("CLI plans an uncompiled project and writes nothing", async () => {
+  const result = await run([]);
+  expect(result.result.diagnostics).toEqual([]);
+  expect(result.code).toBe(0);
+  expect(result.result.ok).toBe(true);
+  expect(result.stderr).toBe("");
+  expect(existsSync(join(root, "generated"))).toBe(false);
+  expect((await run(["--delivery", "valid.json"])).result).toEqual(result.result);
+}, 30_000);
+
+test.each([
+  ["--delivery", "invalid.json"], ["--delivery", "invalid-syntax.json"],
+  ["--delivery", "missing.json"], ["--delivery"],
+  ["--write"], ["--unknown-option"],
+  ["--root"], ["--out", "--json"], ["--url", "https://unverified.example.test"],
+].map((args) => ({ args })))("CLI returns structured failures and nonzero status: %#", async ({ args }) => {
+  const result = await run(args);
+  expect(result.code).toBe(1);
+  expect(result.result.ok).toBe(false);
+  expect(result.result.plan).toBeNull();
+  expect(result.stdout + result.stderr).not.toContain("DO_NOT_ECHO_THIS");
+  expect(existsSync(join(root, "generated"))).toBe(false);
+}, 30_000);
+
+test("planning preserves existing generated content and propagates compiler failures", async () => {
+  await writeFixtureProject(root, { "generated/application.ts": "// last good artifact\n" });
+  const result = await planDeliveryProject({
+    rootDir: root, outDir: join(root, "generated"), strict: false,
+  });
+  expect(result.ok).toBe(true);
+  expect(await readFile(join(root, "generated/application.ts"), "utf8")).toBe("// last good artifact\n");
+  const controller = Object.entries(GOOD_PROJECT_FILES).find(([, source]) => source.includes("response: AcceptResult,"));
+  if (!controller) throw new Error("Expected controller fixture");
+  await writeFixtureProject(root, { [controller[0]]: controller[1].replace("response: AcceptResult,", "") });
+  const rejected = await planDeliveryProject({
+    rootDir: root, outDir: join(root, "generated"), requireRouteContracts: true,
+  });
+  expect(rejected.ok).toBe(false);
+  expect(rejected.plan).toBeNull();
+  expect(rejected.written).toEqual([]);
+}, 30_000);

--- a/packages/compiler/src/delivery-files.ts
+++ b/packages/compiler/src/delivery-files.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+import { lstat, mkdir, open, readFile, readdir, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Value } from "@sinclair/typebox/value";
+import { DeliveryFilePathSchema } from "./delivery-schema";
+import type { DeliveryObject } from "./delivery-build-schema";
+
+export const digest = (value: string | Uint8Array): string => createHash("sha256").update(value).digest("hex");
+export function canonical(value: unknown): string {
+  return JSON.stringify(value, (_key, item: unknown) =>
+    item !== null && typeof item === "object" && !Array.isArray(item)
+      ? Object.fromEntries(Object.entries(item).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0))
+      : item);
+}
+
+export function inside(parent: string, path: string): boolean {
+  const part = relative(parent, path);
+  return !isAbsolute(part) && part !== ".." && !part.startsWith(`..${sep}`);
+}
+
+export async function exists(path: string): Promise<boolean> {
+  try { await lstat(path); return true; } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/** The anchor must already be canonical; reject links in every descendant component. */
+export async function noLinks(anchor: string, path: string): Promise<void> {
+  if (!inside(anchor, path)) throw new Error("Delivery path escapes its owned root.");
+  let current = anchor;
+  for (const part of relative(anchor, path).split(sep).filter(Boolean)) {
+    current = join(current, part);
+    if (!await exists(current)) continue;
+    if ((await lstat(current)).isSymbolicLink()) throw new Error("Delivery paths cannot contain symbolic links.");
+  }
+}
+
+export async function readOwned(anchor: string, path: string): Promise<Uint8Array> {
+  await noLinks(anchor, path);
+  const stat = await lstat(path);
+  if (!stat.isFile()) throw new Error("Expected a regular delivery input or artifact.");
+  return readFile(path);
+}
+
+export async function reserveOutput(project: string, requested: string) {
+  if (!inside(project, requested)) throw new Error("Delivery output must be inside the application project.");
+  const base = await realpath(project);
+  const path = resolve(base, relative(project, requested));
+  if (relative(base, path).split(sep).some((part) => part === ".git" || part === "node_modules")) {
+    throw new Error("Delivery output cannot use repository or dependency internals.");
+  }
+  await noLinks(base, path);
+  await mkdir(path, { recursive: true });
+  const marker = join(path, "owner.json");
+  const owner = canonical({ producer: "@supacloud/compiler/delivery-build-v1", project: base });
+  if (!await exists(marker)) {
+    if ((await readdir(path)).length > 0) throw new Error("Refusing to adopt an unowned delivery directory.");
+    await writeFile(marker, owner, { flag: "wx" });
+  } else if (new TextDecoder().decode(await readOwned(base, marker)) !== owner) {
+    throw new Error("Delivery output is owned by a different project or producer.");
+  }
+  const lockPath = join(path, "build.lock");
+  await noLinks(base, lockPath);
+  const lock = await open(lockPath, "wx");
+  return {
+    path,
+    async release(): Promise<void> {
+      await lock.close();
+      await rm(lockPath);
+    },
+  };
+}
+
+export async function writeArtifact(root: string, path: string, content: string | Uint8Array): Promise<void> {
+  if (!Value.Check(DeliveryFilePathSchema, path)) throw new Error("Invalid artifact path.");
+  const destination = join(root, path);
+  await noLinks(root, destination);
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, content, { flag: "wx" });
+}
+
+export async function artifactInventory(root: string): Promise<DeliveryObject["files"]> {
+  const files: DeliveryObject["files"] = [];
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw new Error("Artifact contains a symbolic link.");
+      if (entry.isDirectory()) await visit(path);
+      else {
+        const content = await readOwned(root, path);
+        files.push({ path: relative(root, path).split(sep).join("/"), sha256: digest(content), bytes: content.length });
+      }
+    }
+  }
+  await visit(root);
+  return files.sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+}
+
+/** Snapshot application sources before graph analysis, excluding generated output. */
+export async function sourceInventory(root: string, output: string): Promise<Map<string, string>> {
+  const inputs = new Map<string, string>();
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (inside(output, path) || entry.name === "node_modules" || entry.name === ".git") continue;
+      if (entry.isDirectory()) await visit(path);
+      else if (/\.(?:[cm]?[jt]sx?|json)$/.test(entry.name)) {
+        inputs.set(path, digest(await readOwned(root, path)));
+      }
+    }
+  }
+  await visit(root);
+  return inputs;
+}
+
+export async function publishPointer(root: string, content: string): Promise<boolean> {
+  const path = join(root, "delivery.manifest.json");
+  if (await exists(path) && new TextDecoder().decode(await readOwned(root, path)) === content) return false;
+  const temporary = join(root, "delivery.manifest.pending");
+  await noLinks(root, path);
+  await noLinks(root, temporary);
+  await writeFile(temporary, content, { flag: "wx" });
+  try { await rename(temporary, path); } finally { await rm(temporary, { force: true }); }
+  return true;
+}

--- a/packages/compiler/src/delivery-plan.test.ts
+++ b/packages/compiler/src/delivery-plan.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { createDeliveryPlan, formatDeliveryPlan } from "./delivery-plan";
+import { parseDeliveryOptions, parseDeliveryPlanResult, type DeliveryOptions, type DeliveryPlanResult } from "./delivery-schema";
+import { defineSupacloudConfig } from "./config";
+import { requireValue } from "./fixtures/helpers";
+import type { ApplicationGraph, ModuleNode } from "./types";
+
+function module(name: string, imports: string[] = []): ModuleNode {
+  return {
+    name, className: `${name}Module`, file: `${name}.ts`, line: 1, imports,
+    providers: [], controllers: [], commands: [], queries: [], exports: [],
+  };
+}
+
+function http(name: string, imports: string[] = []): ModuleNode {
+  return { ...module(name, imports), controllers: [{
+    className: `${name}Controller`, path: `/${name}`, scope: "application", deps: [],
+    file: `${name}.ts`, importPath: name,
+    routes: [{ method: "GET", path: "/", handler: "list" }],
+  }] };
+}
+
+function graph(...modules: ModuleNode[]): ApplicationGraph {
+  return { modules, externalTokens: [] };
+}
+
+function successful(result: DeliveryPlanResult) {
+  if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+  return result.plan;
+}
+
+const runtime = { processIsolation: true, durableQueue: true, capabilities: [] } satisfies NonNullable<DeliveryOptions["runtime"]>;
+const jobs: ModuleNode = {
+  ...module("documents", ["shared"]),
+  jobs: [{ name: "documents.render", className: "Render", serviceKey: "Render", scope: "job" }],
+  providers: [{
+    token: "Render", tokenKind: "class", kind: "class", scope: "job", deps: [],
+    exported: false, file: "documents.ts", line: 1,
+  }],
+};
+
+describe("delivery input and output boundaries", () => {
+  test.each([
+    null, false, [], {}, { version: 2 }, { version: 1, secret: "REDACTED_FIXTURE" },
+    { version: 1, targets: [null] },
+    { version: 1, targets: [{ name: "../escape", kind: "api", modules: ["orders"] }] },
+    { version: 1, targets: [{ name: "api", kind: "api", modules: [] }] },
+    { version: 1, targets: [{ name: "api", kind: "api", modules: ["orders", "orders"] }] },
+    { version: 1, targets: [{ name: "api", kind: "api", modules: ["orders"], isolation: "worker" }] },
+    { version: 1, runtime: { ...runtime, durableQueue: "true" } },
+    { version: 1, runtime: { ...runtime, credentials: "REDACTED_FIXTURE" } },
+  ].map((input: unknown) => ({ input })))("rejects malformed configuration without leaking values: %#", ({ input }) => {
+    expect(() => parseDeliveryOptions(input)).toThrow("Invalid delivery configuration");
+    const result = createDeliveryPlan(graph(), input);
+    expect(result.ok).toBe(false);
+    expect(result.plan).toBeNull();
+    expect(JSON.stringify(result)).not.toContain("REDACTED_FIXTURE");
+    expect(result.written).toEqual([]);
+  });
+
+  test("config and JSON share one schema and static type", () => {
+    const delivery = { version: 1, targets: [{ name: "orders", kind: "api", modules: ["orders"] }] } satisfies DeliveryOptions;
+    expect(defineSupacloudConfig({ delivery }).delivery).toEqual(parseDeliveryOptions(delivery));
+    expect(defineSupacloudConfig().delivery).toBeUndefined();
+  });
+
+  test("rejects malformed deserialized results", () => {
+    const result = createDeliveryPlan(graph(http("orders")));
+    const wire: unknown = JSON.parse(JSON.stringify(result));
+    expect(parseDeliveryPlanResult(wire)).toEqual(result);
+    expect(() => parseDeliveryPlanResult({ ...result, written: ["unexpected.ts"] })).toThrow();
+    expect(() => parseDeliveryPlanResult({ ...result, ok: false })).toThrow();
+  });
+});
+
+describe("deterministic workload placement", () => {
+  test("defaults to one API, keeps paths, and never claims deployment readiness", () => {
+    const plan = successful(createDeliveryPlan(graph(http("orders"), http("users"))));
+    const target = requireValue(plan.targets[0]);
+    expect(plan.targets).toHaveLength(1);
+    expect(target.name).toBe("api");
+    expect(target.routes.map((route) => route.path)).toEqual(["/orders", "/users"]);
+    expect(target.routes.every((route) => route.reason === "default-http")).toBe(true);
+    expect(target.runtimeStatus).toBe("unchecked");
+    expect(plan.deploymentReady).toBe(false);
+    expect(plan.digestScope).toBe("topology-only");
+    expect(formatDeliveryPlan(createDeliveryPlan(graph()))).toContain("not a build hash");
+  });
+
+  test("import closure does not expose dependency routes in the importing target", () => {
+    const fixture = graph(http("orders", ["shared"]), http("shared", ["storage"]), module("storage"));
+    const plan = successful(createDeliveryPlan(fixture, {
+      version: 1, targets: [{ name: "orders", kind: "api", modules: ["orders"] }],
+    }));
+    const orders = requireValue(plan.targets.find((target) => target.name === "orders"));
+    const api = requireValue(plan.targets.find((target) => target.name === "api"));
+    expect(orders.modules.map((item) => item.name)).toEqual(["orders", "shared", "storage"]);
+    expect(orders.modules.find((item) => item.name === "shared")).toEqual({
+      name: "shared", reason: "dependency", importedBy: ["orders"],
+    });
+    expect(orders.routes.map((item) => item.path)).toEqual(["/orders"]);
+    expect(api.routes.map((item) => item.path)).toEqual(["/shared"]);
+  });
+
+  test("jobs and HTTP in the same module have separate owners without changing HTTP semantics", () => {
+    const fixture = graph({ ...jobs, controllers: http("documents").controllers }, module("shared"));
+    const missing = createDeliveryPlan(fixture);
+    expect(missing.ok).toBe(false);
+    expect(missing.diagnostics.map((item) => item.code)).toContain("delivery-queue-required");
+    expect(missing.diagnostics.map((item) => item.code)).toContain("delivery-isolation-required");
+    const plan = successful(createDeliveryPlan(fixture, { version: 1, runtime }));
+    const api = requireValue(plan.targets.find((item) => item.name === "api"));
+    const worker = requireValue(plan.targets.find((item) => item.name === "jobs"));
+    expect(api.routes).toHaveLength(1);
+    expect(api.jobs).toEqual([]);
+    expect(worker.routes).toEqual([]);
+    expect(worker.jobs.map((item) => item.name)).toEqual(["documents.render"]);
+    expect(worker.isolation).toBe("process");
+    expect(worker.runtimeStatus).toBe("declared-compatible");
+  });
+
+  test("explicit webhook boundaries need capabilities but never change public paths", () => {
+    const delivery: DeliveryOptions = {
+      version: 1, targets: [{
+        name: "hooks", kind: "webhook", modules: ["hooks"],
+        isolation: "process", capabilities: ["payments.verify"],
+      }],
+    };
+    const missing = createDeliveryPlan(graph(http("hooks")), delivery);
+    expect(missing.diagnostics.map((item) => item.code)).toContain("delivery-capability-required");
+    const plan = successful(createDeliveryPlan(graph(http("hooks")), {
+      ...delivery, runtime: { ...runtime, capabilities: ["payments.verify"] },
+    }));
+    expect(requireValue(plan.targets[0]).routes.map((item) => item.path)).toEqual(["/hooks"]);
+  });
+
+  test("input ordering and source locations do not change the topology digest", () => {
+    const a = http("orders", ["storage", "shared"]);
+    const b = http("users", ["shared"]);
+    const shared = module("shared");
+    const storage = module("storage");
+    const config: DeliveryOptions = { version: 1, targets: [
+      { name: "shop", kind: "api", modules: ["users", "orders"] },
+    ] };
+    const before = JSON.stringify([a, b, shared, storage, config]);
+    const first = successful(createDeliveryPlan(graph(a, b, shared, storage), config));
+    const second = successful(createDeliveryPlan(graph(
+      storage, shared, b, { ...a, imports: [...a.imports].reverse(), file: "/another/checkout.ts", line: 9 },
+    ), { version: 1, targets: [{ name: "shop", kind: "api", modules: ["orders", "users"] }] }));
+    expect(second).toEqual(first);
+    expect(JSON.stringify([a, b, shared, storage, config])).toBe(before);
+    const changed = successful(createDeliveryPlan(graph(a, b, shared, storage)));
+    expect(changed.topologyDigest).not.toBe(first.topologyDigest);
+  });
+
+  test.each([
+    { targets: [
+      { name: "one", kind: "api", modules: ["orders"] },
+      { name: "two", kind: "webhook", modules: ["orders"] },
+    ], code: "delivery-ownership-conflict" },
+    { targets: [
+      { name: "one", kind: "api", modules: ["orders"] },
+      { name: "one", kind: "api", modules: ["orders"] },
+    ], code: "delivery-duplicate-target" },
+    { targets: [{ name: "one", kind: "api", modules: ["missing"] }], code: "delivery-unknown-module" },
+    { targets: [{ name: "jobs", kind: "api", modules: ["orders"] }], code: "delivery-reserved-target" },
+    { targets: [{ name: "one", kind: "jobs", modules: ["orders"] }], code: "delivery-empty-target" },
+  ])("rejects invalid ownership: $code", ({ targets, code }) => {
+    const result = createDeliveryPlan(graph(http("orders")), { version: 1, targets });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics.map((item) => item.code)).toContain(code);
+  });
+
+  test("rejects missing imports and cycles", () => {
+    expect(createDeliveryPlan(graph(http("orders", ["missing"]))).diagnostics.map((item) => item.code))
+      .toContain("delivery-missing-import");
+    expect(createDeliveryPlan(graph(http("orders", ["shared"]), module("shared", ["orders"]))).diagnostics.map((item) => item.code))
+      .toContain("delivery-import-cycle");
+  });
+
+  test("rejects public path parameter aliases and duplicate job names", () => {
+    const a = http("orders");
+    const controller = requireValue(a.controllers[0]);
+    const b: ModuleNode = { ...http("other"), controllers: [{
+      ...controller, className: "Other", routes: [{ method: "GET", path: "/:key", handler: "get" }],
+    }] };
+    a.controllers = [{ ...controller, routes: [{ method: "GET", path: "/:id", handler: "get" }] }];
+    const result = createDeliveryPlan(graph(a, b));
+    expect(result.diagnostics.map((item) => item.code)).toContain("delivery-route-conflict");
+    const duplicate = createDeliveryPlan(graph(jobs, { ...jobs, name: "other" }, module("shared")), { version: 1, runtime });
+    expect(duplicate.diagnostics.map((item) => item.code)).toContain("delivery-job-conflict");
+  });
+
+  test("analysis failures prevent a successful plan", () => {
+    const result = createDeliveryPlan({ ...graph(http("orders")), diagnostics: [{
+      severity: "error", code: "contract-rejected", message: "Invalid response schema",
+    }] });
+    expect(result.ok).toBe(false);
+    expect(result.plan).toBeNull();
+    expect(result.diagnostics.map((item) => item.code)).toContain("contract-rejected");
+  });
+});

--- a/packages/compiler/src/delivery-plan.ts
+++ b/packages/compiler/src/delivery-plan.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import { checkProject } from "./compile";
+import {
+  DeliveryConfigurationError, parseDeliveryOptions, parseDeliveryPlanResult,
+  type DeliveryDiagnostic, type DeliveryOptions, type DeliveryPlanResult, type DeliveryTarget,
+} from "./delivery-schema";
+import type { ApplicationGraph, CompileOptions, Diagnostic, ModuleNode } from "./types";
+import { joinRoutePaths } from "./util";
+import { validateGraph } from "./validate";
+
+type TargetDeclaration = NonNullable<DeliveryOptions["targets"]>[number];
+const compare = (a: string, b: string): number => a < b ? -1 : a > b ? 1 : 0;
+const sorted = (values: Iterable<string>): string[] => [...new Set(values)].sort(compare);
+
+function diagnostic(error: Diagnostic): DeliveryDiagnostic {
+  return {
+    severity: error.severity, code: error.code, message: error.message,
+    ...(error.file === undefined ? {} : { file: error.file }),
+    ...(error.line === undefined ? {} : { line: error.line }),
+    ...(error.suggestion === undefined ? {} : { suggestion: error.suggestion }),
+  };
+}
+
+/** Trusted compiler graph in, validated topology preview out. No file or remote writes. */
+export function createDeliveryPlan(
+  graph: ApplicationGraph,
+  input?: unknown,
+): DeliveryPlanResult {
+  let options: DeliveryOptions;
+  try {
+    options = parseDeliveryOptions(input);
+  } catch (error) {
+    if (!(error instanceof DeliveryConfigurationError)) throw error;
+    return { ok: false, plan: null, written: [], diagnostics: [{
+      severity: "error", code: error.code, message: error.message,
+      suggestion: "Use DeliveryOptionsSchema or defineSupacloudConfig({ delivery: ... }).",
+    }] };
+  }
+
+  const diagnostics: DeliveryDiagnostic[] = [
+    ...(graph.diagnostics ?? []).map(diagnostic),
+    ...validateGraph(graph, { strict: true }).map(diagnostic),
+  ];
+  const fail = (code: string, message: string, suggestion: string): void => {
+    diagnostics.push({ severity: "error", code, message, suggestion });
+  };
+  const modules = new Map(graph.modules.map((module) => [module.name, module]));
+  const declarations = new Map<string, TargetDeclaration>();
+  const httpOwners = new Map<string, string>();
+  const jobOwners = new Map<string, string>();
+
+  for (const target of [...options.targets ?? []].sort((a, b) => compare(a.name, b.name))) {
+    if (declarations.has(target.name)) {
+      fail("delivery-duplicate-target", `Target "${target.name}" is declared more than once.`, "Give each target a unique name.");
+      continue;
+    }
+    declarations.set(target.name, target);
+    if ((target.name === "api" && target.kind !== "api") || (target.name === "jobs" && target.kind !== "jobs")) {
+      fail("delivery-reserved-target", `"${target.name}" is reserved for its matching workload kind.`, "Rename the target or use the matching kind.");
+    }
+    for (const name of sorted(target.modules)) {
+      if (!modules.has(name)) {
+        fail("delivery-unknown-module", `Target "${target.name}" refers to unknown module "${name}".`, "Select a module name from the compiler graph.");
+        continue;
+      }
+      const owners = target.kind === "jobs" ? jobOwners : httpOwners;
+      const existing = owners.get(name);
+      if (existing !== undefined) {
+        fail("delivery-ownership-conflict", `Module "${name}" has competing ${target.kind === "jobs" ? "job" : "HTTP"} owners "${existing}" and "${target.name}".`,
+          "Assign each module's HTTP routes and jobs to at most one target of each workload category.");
+      } else owners.set(name, target.name);
+    }
+  }
+
+  const targets = new Map<string, DeliveryTarget>();
+  function getTarget(name: string, fallback: "api" | "jobs"): DeliveryTarget {
+    const existing = targets.get(name);
+    if (existing) return existing;
+    const declaration = declarations.get(name);
+    const kind = declaration?.kind ?? fallback;
+    const isolation = declaration?.isolation ?? (kind === "jobs" ? "process" : "shared");
+    const target: DeliveryTarget = {
+      name, kind, isolation, roots: [], modules: [], routes: [], jobs: [], externalTokens: [],
+      requirements: {
+        processIsolation: isolation === "process",
+        durableQueue: kind === "jobs",
+        capabilities: sorted(declaration?.capabilities ?? []),
+      },
+      runtimeStatus: options.runtime === undefined ? "unchecked" : "declared-compatible",
+    };
+    targets.set(name, target);
+    return target;
+  }
+
+  const publicRoutes = new Map<string, string>();
+  const publicJobs = new Map<string, string>();
+  for (const module of [...graph.modules].sort((a, b) => compare(a.name, b.name))) {
+    for (const controller of module.controllers) {
+      for (const route of controller.routes) {
+        const owner = httpOwners.get(module.name);
+        const target = getTarget(owner ?? "api", "api");
+        const path = joinRoutePaths(controller.path, route.path);
+        // Parameter names must not hide a routing collision across deployment targets.
+        const key = `${route.method} ${path.replace(/:[^/]+/g, ":param")}`;
+        const existing = publicRoutes.get(key);
+        if (existing !== undefined) {
+          fail("delivery-route-conflict", `Public route "${key}" is owned by both "${existing}" and "${target.name}".`,
+            "Give public routes unambiguous method/path contracts before splitting targets.");
+        }
+        publicRoutes.set(key, target.name);
+        target.roots.push(module.name);
+        target.routes.push({
+          module: module.name, controller: controller.className, handler: route.handler,
+          method: route.method, path,
+          ...(route.command === undefined ? {} : { command: route.command }),
+          reason: owner === undefined ? "default-http" : "explicit-module",
+        });
+      }
+    }
+    for (const job of module.jobs ?? []) {
+      const owner = jobOwners.get(module.name);
+      const target = getTarget(owner ?? "jobs", "jobs");
+      if (publicJobs.has(job.name)) {
+        fail("delivery-job-conflict", `Job "${job.name}" is declared more than once.`, "Use globally unique job names.");
+      }
+      publicJobs.set(job.name, target.name);
+      target.roots.push(module.name);
+      target.jobs.push({
+        module: module.name, name: job.name, className: job.className, serviceKey: job.serviceKey,
+        reason: owner === undefined ? "declared-job" : "explicit-module",
+      });
+    }
+  }
+
+  for (const declaration of declarations.values()) {
+    if (!targets.has(declaration.name)) {
+      fail("delivery-empty-target", `Target "${declaration.name}" owns no ${declaration.kind === "jobs" ? "jobs" : "HTTP routes"}.`,
+        "Select modules containing the intended workload or remove the target declaration.");
+    }
+  }
+  if (targets.size === 0 && declarations.size === 0) getTarget("api", "api");
+
+  for (const target of targets.values()) {
+    target.roots = sorted(target.roots);
+    // Module-granularity closure is deliberately conservative; no provider-level pruning.
+    const closure = new Map<string, ModuleNode>();
+    const visiting = new Set<string>();
+    function visit(name: string): void {
+      if (visiting.has(name)) {
+        fail("delivery-import-cycle", `Target "${target.name}" contains an import cycle at "${name}".`, "Remove cyclic module imports.");
+        return;
+      }
+      if (closure.has(name)) return;
+      const module = modules.get(name);
+      if (!module) {
+        fail("delivery-missing-import", `Target "${target.name}" requires missing module "${name}".`, "Declare or correct the imported module.");
+        return;
+      }
+      visiting.add(name);
+      for (const imported of sorted(module.imports)) visit(imported);
+      visiting.delete(name);
+      closure.set(name, module);
+    }
+    for (const root of target.roots) visit(root);
+    target.modules = sorted(closure.keys()).map((name) => ({
+      name, reason: target.roots.includes(name) ? "owner" : "dependency",
+      importedBy: sorted([...closure.values()].filter((module) => module.imports.includes(name)).map((module) => module.name)),
+    }));
+    const dependencies = new Set([...closure.values()].flatMap((module) => [
+      ...module.providers.flatMap((provider) => provider.deps),
+      ...module.controllers.flatMap((controller) => controller.deps),
+    ]));
+    target.externalTokens = sorted(graph.externalTokens.filter((token) => dependencies.has(token)));
+    target.routes.sort((a, b) => compare(JSON.stringify(a), JSON.stringify(b)));
+    target.jobs.sort((a, b) => compare(JSON.stringify(a), JSON.stringify(b)));
+    const runtime = options.runtime;
+    if (target.requirements.durableQueue && runtime?.durableQueue !== true) {
+      fail("delivery-queue-required", `Target "${target.name}" requires a declared durable queue.`,
+        "Configure a durable queue adapter and declare runtime.durableQueue; do not run jobs in an HTTP background Promise.");
+    }
+    if (target.requirements.processIsolation && runtime?.processIsolation !== true) {
+      fail("delivery-isolation-required", `Target "${target.name}" requires declared process isolation.`,
+        "Select a process-isolated host and declare runtime.processIsolation. A Worker or function name alone is insufficient.");
+    }
+    for (const capability of target.requirements.capabilities) {
+      if (!runtime?.capabilities.includes(capability)) {
+        fail("delivery-capability-required", `Target "${target.name}" requires capability reference "${capability}".`,
+          "Configure the named adapter or credential boundary and declare its reference, never its secret value.");
+      }
+    }
+  }
+
+  const canonicalDiagnostics = [...new Map(diagnostics.map((item) => [JSON.stringify(item), item])).values()]
+    .sort((a, b) => compare(JSON.stringify(a), JSON.stringify(b)));
+  if (canonicalDiagnostics.some((item) => item.severity === "error")) {
+    return parseDeliveryPlanResult({ ok: false, plan: null, diagnostics: canonicalDiagnostics, written: [] });
+  }
+  const topology = {
+    schemaVersion: 1, policyVersion: "module-workload-v1", digestScope: "topology-only",
+    deploymentReady: false, targets: [...targets.values()].sort((a, b) => compare(a.name, b.name)),
+  } as const;
+  const topologyDigest = createHash("sha256").update(JSON.stringify(topology)).digest("hex");
+  return parseDeliveryPlanResult({
+    ok: true, plan: { ...topology, topologyDigest }, diagnostics: canonicalDiagnostics, written: [],
+  });
+}
+
+/** Reuse all compiler gates without requiring generated files to already exist. */
+export async function planDeliveryProject(
+  options: CompileOptions,
+  delivery?: unknown,
+): Promise<DeliveryPlanResult> {
+  // Reject malformed configuration before reading or evaluating project sources.
+  try {
+    parseDeliveryOptions(delivery);
+  } catch (error) {
+    if (!(error instanceof DeliveryConfigurationError)) throw error;
+    return createDeliveryPlan({ modules: [], externalTokens: [] }, delivery);
+  }
+  const checked = await checkProject(options);
+  return createDeliveryPlan({ ...checked.graph, diagnostics: checked.diagnostics }, delivery);
+}
+
+export function formatDeliveryPlan(result: DeliveryPlanResult): string {
+  const lines = result.ok
+    ? [
+      `DELIVERY PLAN ${result.plan.topologyDigest}`,
+      "Preview only: topology digest is not a build hash or deployment approval.",
+      ...result.plan.targets.flatMap((target) => [
+        `${target.name} (${target.kind}, ${target.isolation}): ${target.routes.length} route(s), ${target.jobs.length} job(s)`,
+        `  modules: ${target.modules.map((module) => module.name).join(", ") || "-"}`,
+        ...target.routes.map((route) => `  ${route.method} ${route.path} [${route.reason}]`),
+        ...target.jobs.map((job) => `  job ${job.name} [${job.reason}]`),
+      ]),
+    ]
+    : ["Delivery planning failed; no files written."];
+  return [...lines, ...result.diagnostics.map((item) => `${item.severity} ${item.code}: ${item.message}`)].join("\n");
+}

--- a/packages/compiler/src/delivery-render.ts
+++ b/packages/compiler/src/delivery-render.ts
@@ -1,0 +1,31 @@
+import type { ApplicationGraph } from "./types";
+import type { DeliveryTarget } from "./delivery-schema";
+import { renderApplication, type GenerateOptions } from "./generate";
+import { joinRoutePaths } from "./util";
+
+/** Keep conservative service factories while restricting exposed route/job descriptors. */
+export function renderDeliveryTarget(
+  graph: ApplicationGraph,
+  target: DeliveryTarget,
+  options: GenerateOptions,
+) {
+  const included = new Set(target.modules.map((module) => module.name));
+  const projected: ApplicationGraph = {
+    ...graph,
+    modules: graph.modules.filter((module) => included.has(module.name)).map((module) => ({
+      ...module,
+      controllers: module.controllers.map((controller) => ({
+        ...controller,
+        routes: controller.routes.filter((route) => target.routes.some((owned) =>
+          owned.module === module.name && owned.controller === controller.className
+          && owned.handler === route.handler && owned.method === route.method
+          && owned.path === joinRoutePaths(controller.path, route.path))),
+      })),
+      jobs: (module.jobs ?? []).filter((job) => target.jobs.some((owned) =>
+        owned.module === module.name && owned.name === job.name && owned.className === job.className)),
+    })),
+    externalTokens: target.externalTokens,
+  };
+  // Existing root-provider pruning does not treat Jobs as roots; preserve all providers here.
+  return renderApplication(projected, { ...options, treeShakeUnusedProviders: false });
+}

--- a/packages/compiler/src/delivery-schema.ts
+++ b/packages/compiler/src/delivery-schema.ts
@@ -1,0 +1,142 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+const objectOptions = { additionalProperties: false } as const;
+const reference = Type.String({ minLength: 1, maxLength: 128, pattern: "^[A-Za-z][A-Za-z0-9_.:/-]*$" });
+const references = Type.Array(reference, { uniqueItems: true });
+const kind = Type.Union([Type.Literal("api"), Type.Literal("jobs"), Type.Literal("webhook")]);
+const isolation = Type.Union([Type.Literal("shared"), Type.Literal("process")]);
+export const DeliveryFilePathSchema = Type.String({
+  maxLength: 512,
+  pattern: "^(?:[A-Za-z0-9_-][A-Za-z0-9_.-]*/)*[A-Za-z0-9_-][A-Za-z0-9_.-]*$",
+});
+
+export const DeliveryOptionsSchema = Type.Object({
+  version: Type.Literal(1),
+  targets: Type.Optional(Type.Array(Type.Object({
+    name: Type.String({ pattern: "^[a-z][a-z0-9-]{0,62}$" }),
+    kind,
+    modules: Type.Array(reference, { minItems: 1, uniqueItems: true }),
+    isolation: Type.Optional(isolation),
+    capabilities: Type.Optional(references),
+  }, objectOptions))),
+  // These are declarations, never evidence that a remote host enforces isolation.
+  runtime: Type.Optional(Type.Object({
+    processIsolation: Type.Boolean(),
+    durableQueue: Type.Boolean(),
+    capabilities: references,
+  }, objectOptions)),
+  build: Type.Optional(Type.Object({
+    minify: Type.Optional(Type.Boolean()),
+    environmentContract: Type.Optional(reference),
+    assets: Type.Optional(Type.Array(Type.Object({
+      target: Type.String({ pattern: "^[a-z][a-z0-9-]{0,62}$" }),
+      source: DeliveryFilePathSchema,
+      path: DeliveryFilePathSchema,
+    }, objectOptions))),
+  }, objectOptions)),
+}, objectOptions);
+
+export type DeliveryOptions = Static<typeof DeliveryOptionsSchema>;
+
+export const DeliveryDiagnosticSchema = Type.Object({
+  severity: Type.Union([Type.Literal("error"), Type.Literal("warn")]),
+  code: Type.String(),
+  message: Type.String(),
+  suggestion: Type.Optional(Type.String()),
+  file: Type.Optional(Type.String()),
+  line: Type.Optional(Type.Integer({ minimum: 1 })),
+}, objectOptions);
+
+const routeSchema = Type.Object({
+  module: Type.String(),
+  controller: Type.String(),
+  handler: Type.String(),
+  method: Type.Union([
+    Type.Literal("GET"), Type.Literal("POST"), Type.Literal("PUT"), Type.Literal("PATCH"),
+    Type.Literal("DELETE"), Type.Literal("HEAD"), Type.Literal("OPTIONS"),
+  ]),
+  path: Type.String(),
+  command: Type.Optional(Type.String()),
+  reason: Type.Union([Type.Literal("default-http"), Type.Literal("explicit-module")]),
+}, objectOptions);
+
+const jobSchema = Type.Object({
+  module: Type.String(),
+  name: Type.String(),
+  className: Type.String(),
+  serviceKey: Type.String(),
+  reason: Type.Union([Type.Literal("declared-job"), Type.Literal("explicit-module")]),
+}, objectOptions);
+
+export const DeliveryTargetSchema = Type.Object({
+  name: Type.String(),
+  kind,
+  isolation,
+  roots: Type.Array(Type.String()),
+  modules: Type.Array(Type.Object({
+    name: Type.String(),
+    reason: Type.Union([Type.Literal("owner"), Type.Literal("dependency")]),
+    importedBy: Type.Array(Type.String()),
+  }, objectOptions)),
+  routes: Type.Array(routeSchema),
+  jobs: Type.Array(jobSchema),
+  externalTokens: Type.Array(Type.String()),
+  requirements: Type.Object({
+    processIsolation: Type.Boolean(),
+    durableQueue: Type.Boolean(),
+    capabilities: references,
+  }, objectOptions),
+  runtimeStatus: Type.Union([Type.Literal("unchecked"), Type.Literal("declared-compatible")]),
+}, objectOptions);
+
+export const DeliveryPlanSchema = Type.Object({
+  schemaVersion: Type.Literal(1),
+  policyVersion: Type.Literal("module-workload-v1"),
+  digestScope: Type.Literal("topology-only"),
+  topologyDigest: Type.String({ pattern: "^[a-f0-9]{64}$" }),
+  deploymentReady: Type.Literal(false),
+  targets: Type.Array(DeliveryTargetSchema),
+}, objectOptions);
+
+export const DeliveryPlanResultSchema = Type.Union([
+  Type.Object({
+    ok: Type.Literal(true),
+    plan: DeliveryPlanSchema,
+    diagnostics: Type.Array(DeliveryDiagnosticSchema),
+    written: Type.Array(Type.String(), { maxItems: 0 }),
+  }, objectOptions),
+  Type.Object({
+    ok: Type.Literal(false),
+    plan: Type.Null(),
+    diagnostics: Type.Array(DeliveryDiagnosticSchema),
+    written: Type.Array(Type.String(), { maxItems: 0 }),
+  }, objectOptions),
+]);
+
+export type DeliveryTarget = Static<typeof DeliveryTargetSchema>;
+export type DeliveryPlan = Static<typeof DeliveryPlanSchema>;
+export type DeliveryDiagnostic = Static<typeof DeliveryDiagnosticSchema>;
+export type DeliveryPlanResult = Static<typeof DeliveryPlanResultSchema>;
+
+export class DeliveryConfigurationError extends Error {
+  readonly code = "delivery-config-invalid";
+
+  constructor() {
+    // Never include rejected values: configuration may accidentally contain secrets.
+    super("Invalid delivery configuration. Expected version: 1, optional targets, runtime and build; unknown keys and invalid references are rejected.");
+    this.name = "DeliveryConfigurationError";
+  }
+}
+
+export function parseDeliveryOptions(value: unknown): DeliveryOptions {
+  if (value === undefined) return { version: 1 };
+  if (!Value.Check(DeliveryOptionsSchema, value)) throw new DeliveryConfigurationError();
+  return value;
+}
+
+/** Validate plans received from files/messages before using their typed contract. */
+export function parseDeliveryPlanResult(value: unknown): DeliveryPlanResult {
+  if (!Value.Check(DeliveryPlanResultSchema, value)) throw new Error("Invalid delivery plan result.");
+  return value;
+}

--- a/packages/compiler/src/fixtures/helpers.ts
+++ b/packages/compiler/src/fixtures/helpers.ts
@@ -1,6 +1,11 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+export function requireValue<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error("Required fixture value was not found");
+  return value;
+}
+
 /** Writes fixture files map to directory (auto-creates parent directories). */
 export async function writeFixtureProject(
   rootDir: string,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,4 +1,13 @@
 export { analyzeProject } from "./analyze";
+export { createDeliveryPlan, planDeliveryProject, formatDeliveryPlan } from "./delivery-plan";
+export { buildDeliveryProject } from "./delivery-build";
+export { DeliveryBuildManifestSchema, DeliveryBuildResultSchema, parseDeliveryBuildManifest, parseDeliveryBuildResult } from "./delivery-build-schema";
+export type { DeliveryBuildManifest, DeliveryBuildResult, DeliveryObject } from "./delivery-build-schema";
+export {
+  DeliveryOptionsSchema, DeliveryPlanSchema, DeliveryPlanResultSchema, DeliveryTargetSchema,
+  DeliveryConfigurationError, parseDeliveryOptions, parseDeliveryPlanResult,
+} from "./delivery-schema";
+export type { DeliveryOptions, DeliveryPlan, DeliveryPlanResult, DeliveryTarget, DeliveryDiagnostic } from "./delivery-schema";
 export { generateFeatureSource, validateFeatureSpec } from "./feature";
 export { applyDiagnosticFix } from "./fixes";
 export type { AppliedDiagnosticFix, ApplyDiagnosticFixOptions } from "./fixes";

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -12,10 +12,11 @@
     "declaration": true
   },
   "include": [
-    "src/index.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/**/*.test.ts"
   ]
 }

--- a/packages/compiler/tsconfig.test.json
+++ b/packages/compiler/tsconfig.test.json
@@ -7,5 +7,6 @@
   "include": [
     "src/**/*.test.ts",
     "src/**/*.d.ts"
-  ]
+  ],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Add validated, read-only delivery planning and independent local factory bundles.
- Preserve route and Job ownership, hash build inputs, reuse immutable artifacts, and publish the local manifest atomically.
- Document local-only guarantees; no remote deployment or activation is performed.

## Validation
- This exact commit previously passed 326 compiler tests, production/test type checks, build, six packaged consumer checks, and a built delivery CLI smoke test.
- Merge-time validation is limited to the directly related delivery-build test file and git diff --check.

## Scope
- 21 compiler/documentation files only.
- Shared working-directory changes are excluded.