### PR TITLE
fix(edge-runtime): honor configured upload limit in HTTP listener

### DIFF
--- a/packages/edge-runtime/http-body-limit.test.ts
+++ b/packages/edge-runtime/http-body-limit.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { request } from "node:http";
+import { Elysia } from "elysia";
+import { resolveMaxBodySizeBytes, resolveMaxHttpBodySizeBytes } from "./worker-pool";
+
+const mebibyte = 1024 * 1024;
+
+test("default and invalid settings preserve worker and listener limits", () => {
+  for (const value of ["", "invalid", "0", "-1", "Infinity"]) {
+    expect(resolveMaxBodySizeBytes(value)).toBe(30 * mebibyte);
+    expect(resolveMaxHttpBodySizeBytes(value)).toBe(128 * mebibyte);
+  }
+  expect(resolveMaxBodySizeBytes("16")).toBe(16 * mebibyte);
+  expect(resolveMaxHttpBodySizeBytes("16")).toBe(128 * mebibyte);
+});
+
+test("configured 501 MiB reaches both worker and listener", () => {
+  expect(resolveMaxBodySizeBytes("501")).toBe(501 * mebibyte);
+  expect(resolveMaxHttpBodySizeBytes("501")).toBe(501 * mebibyte);
+  const source = readFileSync(new URL("./server.ts", import.meta.url), "utf8");
+  expect(source).toContain("maxRequestBodySize: resolveMaxHttpBodySizeBytes()");
+});
+
+function probe(port: number, bytes: number): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const outgoing = request({
+      hostname: "127.0.0.1", port, path: "/upload", method: "POST",
+      headers: { "content-length": String(bytes), "content-type": "application/octet-stream" },
+    }, (response) => {
+      let body = "";
+      response.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+      response.on("end", () => {
+        resolve({ status: response.statusCode ?? 0, body });
+        outgoing.destroy();
+      });
+      response.on("error", reject);
+    });
+    outgoing.on("error", reject);
+    outgoing.setTimeout(3000, () => outgoing.destroy(new Error("listener did not respond")));
+    outgoing.flushHeaders();
+  });
+}
+
+test("real HTTP listener accepts large headers through 501 MiB and rejects one byte over", async () => {
+  const app = new Elysia()
+    .post("/upload", () => new Response("application gate reached", { status: 401 }), { parse: "none" })
+    .listen({ hostname: "127.0.0.1", port: 0, maxRequestBodySize: resolveMaxHttpBodySizeBytes("501") });
+  try {
+    const port = app.server?.port;
+    if (!port) throw new Error("missing test listener");
+    for (const size of [129 * mebibyte, 215 * mebibyte, 500 * mebibyte, 501 * mebibyte]) {
+      expect(await probe(port, size)).toEqual({ status: 401, body: "application gate reached" });
+    }
+    expect((await probe(port, 501 * mebibyte + 1)).status).toBe(413);
+  } finally {
+    await app.stop(true);
+  }
+});

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 import cors from "@elysiajs/cors";
 import {
   WorkerPool,
+  resolveMaxHttpBodySizeBytes,
   resolveWorkerReplacementBudget,
   type WorkerPoolPreheatResult,
   type WorkerPoolVersionPreheatResult,
@@ -1910,7 +1911,7 @@ const app = new Elysia()
     )
   )
 
-  .listen({ port: PORT, hostname: HOST });
+  .listen({ port: PORT, hostname: HOST, maxRequestBodySize: resolveMaxHttpBodySizeBytes() });
 
 console.log(`🚀 Edge Runtime on ${HOST}:${PORT} (${POOL_SIZE} workers)`);
 

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -65,12 +65,16 @@ type QueuedDispatch = {
 const DEFAULT_MAX_BODY_SIZE_MB = 30;
 const FUNCTION_VERSION_HEADER = "x-supacloud-function-version";
 
-function resolveMaxBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): number {
+export function resolveMaxBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): number {
   const configuredMb = Number(value);
   const maxBodySizeMb = Number.isFinite(configuredMb) && configuredMb > 0
     ? configuredMb
     : DEFAULT_MAX_BODY_SIZE_MB;
   return maxBodySizeMb * 1024 * 1024;
+}
+
+export function resolveMaxHttpBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): number {
+  return Math.max(128 * 1024 * 1024, resolveMaxBodySizeBytes(value));
 }
 
 function formatBodyLimit(bytes: number): string {


### PR DESCRIPTION
## Problem
FA 500 MiB original-document uploads still receive an empty HTTP 413 after EDGE_MAX_BODY_SIZE_MB=501. Direct runtime probing confirms the HTTP listener rejects bodies above its implicit 128 MiB ceiling before the configured worker limit is evaluated.

## Change
Wire the existing validated runtime limit into Elysia/Bun listen maxRequestBodySize. Preserve the previous 128 MiB listener default and 30 MiB worker default. No authentication, per-function limit, memory-budget, or application upload-policy relaxation.

## Validation
bun --no-env-file test packages/edge-runtime/http-body-limit.test.ts: 3 pass, 20 assertions. A real HTTP listener accepts declared 129/215/500/501 MiB bodies through to the application gate and rejects 501 MiB plus one byte; this header-boundary test is not a claim of full payload transfer. git diff --check passes. FA test/prod runtime configuration changes are authorized; real file acceptance remains pending.