### PR TITLE
feat(cli): support unrestricted manual file upload for storage

### DIFF
--- a/packages/admin/src/shared/tools/storage-tools.ts
+++ b/packages/admin/src/shared/tools/storage-tools.ts
@@ -1,25 +1,49 @@
 /**
  * Storage — Compound tool (5→1)
  */
+import * as fs from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpTransport } from "../transports/http";
+
+const DEFAULT_UPLOAD_TIMEOUT_MS = 36 * 60_000;
+const openAsBlob = (fs as { openAsBlob?: (path: string, options?: { type?: string }) => Promise<Blob> }).openAsBlob;
+
+function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) return "—";
+    if (bytes === 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let value = bytes;
+    let index = 0;
+    while (value >= 1024 && index < units.length - 1) {
+        value /= 1024;
+        index += 1;
+    }
+    const formatted = index === 0 ? String(value) : (value >= 100 ? value.toFixed(0) : value.toFixed(1));
+    return `${formatted} ${units[index]}`;
+}
 
 export function registerStorageTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
     server.tool(
         "storage",
         `S3/MinIO storage management.
-Actions: status, list_buckets, list_files, upload_base64, delete_file`,
+Actions: status, list_buckets, list_files, upload_base64, delete_file, upload, upload_file`,
         {
-            action: withDescription(stringEnum(["status", "list_buckets", "list_files", "upload_base64", "delete_file"]), "Action"),
+            action: withDescription(stringEnum(["status", "list_buckets", "list_files", "upload_base64", "delete_file", "upload", "upload_file"]), "Action"),
             ref: optional(Type.String(), "Project ref (required except for 'status')"),
-            bucket: optional(Type.String(), "[list_files/upload/delete] Bucket name"),
-            filename: optional(Type.String(), "[upload/delete] File name/path"),
+            bucket: optional(Type.String(), "[list_files/upload/upload_file/upload_base64/delete] Bucket name"),
+            filename: optional(Type.String(), "[upload/upload_file/upload_base64/delete] File name/path"),
+            file_path: optional(Type.String(), "[upload/upload_file] Local file path to upload"),
+            file: optional(Type.String(), "[upload/upload_file] Alias for file_path"),
+            path: optional(Type.String(), "[upload/upload_file] Alias for file_path"),
+            timeout_ms: optional(Type.Integer({ minimum: 1, maximum: 36 * 60_000 }), "[upload/upload_file] Request timeout in milliseconds (default: 2160000 ms / 36 min)"),
             base64_content: optional(Type.String(), "[upload_base64] Base64 encoded content"),
-            mime_type: optional(Type.String(), "[upload_base64] MIME type (default: application/octet-stream)"),
+            mime_type: optional(Type.String(), "[upload_base64/upload/upload_file] MIME type (default: application/octet-stream)"),
         },
         async (args: any) => {
-            const { action, ref, bucket, filename, base64_content, mime_type } = args;
+            const { action, ref, bucket, filename, file_path, file, path, timeout_ms, base64_content, mime_type } = args;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
             let text: string;
             switch (action) {
@@ -61,6 +85,59 @@ Actions: status, list_buckets, list_files, upload_base64, delete_file`,
                     text = (await http.delete(`/v1/storage/${ref}/buckets/${bucket}/files/${filename}`)).ok
                         ? `✅ File ${filename} deleted` : `❌ Failed`;
                     break;
+                case "upload":
+                case "upload_file": {
+                    need("ref", ref); need("bucket", bucket);
+                    const rawFilePath = file_path ?? file ?? path;
+                    if (!rawFilePath || typeof rawFilePath !== "string" || !rawFilePath.trim()) {
+                        throw new Error(`'file_path' (or '--file') required for '${action}'`);
+                    }
+                    const resolvedFilePath = resolve(process.cwd(), rawFilePath.trim());
+                    if (!existsSync(resolvedFilePath)) {
+                        throw new Error(`File not found: ${resolvedFilePath}`);
+                    }
+                    const stat = statSync(resolvedFilePath);
+                    if (!stat.isFile()) {
+                        throw new Error(`Path is not a regular file: ${resolvedFilePath}`);
+                    }
+                    const uploadFilename = typeof filename === "string" && filename.trim()
+                        ? filename.trim()
+                        : basename(resolvedFilePath);
+                    const mime = typeof mime_type === "string" && mime_type.trim()
+                        ? mime_type.trim()
+                        : "application/octet-stream";
+                    let effectiveTimeout = DEFAULT_UPLOAD_TIMEOUT_MS;
+                    if (timeout_ms !== undefined) {
+                        const parsed = typeof timeout_ms === "number"
+                            ? timeout_ms
+                            : (typeof timeout_ms === "string" && /^\d+$/.test(timeout_ms) ? Number(timeout_ms) : NaN);
+                        if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > DEFAULT_UPLOAD_TIMEOUT_MS) {
+                            throw new Error(`'timeout_ms' must be a positive integer up to ${DEFAULT_UPLOAD_TIMEOUT_MS} ms`);
+                        }
+                        effectiveTimeout = parsed;
+                    }
+                    try {
+                        const blob = typeof openAsBlob === "function"
+                            ? await openAsBlob(resolvedFilePath, { type: mime })
+                            : new Blob([readFileSync(resolvedFilePath)], { type: mime });
+                        const formData = new FormData();
+                        formData.append("file", blob, uploadFilename);
+                        formData.append("path", uploadFilename);
+                        const res = await http.postMultipart(
+                            `/v1/storage/${ref}/buckets/${bucket}/upload`,
+                            formData,
+                            { timeoutMs: effectiveTimeout },
+                        );
+                        const errMessage = (res.data as { message?: string; error?: string })?.message
+                            || (res.data as { message?: string; error?: string })?.error;
+                        text = res.ok
+                            ? `✅ File ${uploadFilename} (${formatBytes(stat.size)}) uploaded to ${bucket}`
+                            : `❌ Upload failed (${res.status}${errMessage ? `: ${errMessage}` : ""})`;
+                    } catch (e: any) {
+                        text = `❌ Error: ${e.message}`;
+                    }
+                    break;
+                }
                 default: text = `❌ Unknown action: ${action}`;
             }
             return { content: [{ type: "text" as const, text }] };

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -220,6 +220,20 @@ describe("HttpTransport retry policy", () => {
         expect(clearedTimerIds).toHaveLength(1);
     });
 
+    test("uses a bounded operation-specific timeout for multipart POST", async () => {
+        globalThis.fetch = (async () => Response.json({ ok: true })) as unknown as typeof fetch;
+
+        const response = await createTransport().postMultipart(
+            "/v1/storage/test/buckets/b/upload",
+            new FormData(),
+            { timeoutMs: 36 * 60_000 },
+        );
+
+        expect(response.ok).toBe(true);
+        expect(scheduledTimers.map(({ delay }) => delay)).toEqual([36 * 60_000]);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
     test("aborts a long POST at its cap without retrying", async () => {
         let fetchCalls = 0;
         globalThis.fetch = ((_input, init) => {

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -382,14 +382,19 @@ export class HttpTransport {
         }
     }
 
-    async postMultipart<T = unknown>(path: string, formData: FormData): Promise<HttpResult<T>> {
+    async postMultipart<T = unknown>(
+        path: string,
+        formData: FormData,
+        options?: { timeoutMs?: number },
+    ): Promise<HttpResult<T>> {
+        const timeoutMs = validatedPostTimeout(options);
         try {
             const headers = { Authorization: `Bearer ${this.token}` };
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "POST",
                 headers,
                 body: formData,
-            });
+            }, timeoutMs);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -188,7 +188,7 @@ describe("CLI execution policy", () => {
             expect(executionMode("scheduled_functions", action, {})).toBe("write");
         }
         expect(executionMode("storage", "get_bucket", {})).toBe("read");
-        for (const action of ["create_bucket", "update_bucket", "delete_bucket"]) {
+        for (const action of ["create_bucket", "update_bucket", "delete_bucket", "upload_base64", "delete_file", "upload", "upload_file"]) {
             expect(executionMode("storage", action, {})).toBe("write");
         }
     });

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -42,7 +42,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     },
     storage: {
         read: ["status", "list_buckets", "get_bucket", "list_files"],
-        write: ["create_bucket", "update_bucket", "delete_bucket", "upload_base64", "delete_file"],
+        write: ["create_bucket", "update_bucket", "delete_bucket", "upload_base64", "delete_file", "upload", "upload_file"],
     },
     edge_functions: {
         read: ["list", "get_config", "source"],

--- a/packages/cli/src/shared/tools/storage-tools.test.ts
+++ b/packages/cli/src/shared/tools/storage-tools.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { parseToolArguments } from "../schema";
 import type { ToolSchema } from "../schema";
@@ -709,5 +712,232 @@ describe("Storage bucket lifecycle", () => {
 
         expect(response.isError).toBe(true);
         expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+});
+
+describe("Storage file upload", () => {
+    test("uploads a file with default filename, mime-type, and timeout", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "test-report.pdf");
+        writeFileSync(testFile, "PDF content bytes");
+
+        let postedPath = "";
+        let postedFormData: FormData | undefined;
+        let postedOptions: { timeoutMs?: number } | undefined;
+
+        const { callback } = captureStorageTool({
+            postMultipart: async (path: string, formData: FormData, options?: { timeoutMs?: number }) => {
+                postedPath = path;
+                postedFormData = formData;
+                postedOptions = options;
+                return { ok: true, status: 200, data: { success: true } };
+            },
+        });
+
+        try {
+            const response = await callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: testFile,
+            });
+
+            expect(response.isError).toBeFalsy();
+            expect(response.content[0].text).toContain("✅ File test-report.pdf");
+            expect(response.content[0].text).toContain("uploaded to reports");
+            expect(postedPath).toBe("/v1/storage/project-ref/buckets/reports/upload");
+            expect(postedFormData).toBeDefined();
+            expect(postedFormData?.get("path")).toBe("test-report.pdf");
+            expect(postedOptions?.timeoutMs).toBe(36 * 60_000);
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("supports upload_file alias and custom filename, mime_type, and timeout_ms", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "data.bin");
+        writeFileSync(testFile, "binary content");
+
+        let postedPath = "";
+        let postedFormData: FormData | undefined;
+        let postedOptions: { timeoutMs?: number } | undefined;
+
+        const { callback } = captureStorageTool({
+            postMultipart: async (path: string, formData: FormData, options?: { timeoutMs?: number }) => {
+                postedPath = path;
+                postedFormData = formData;
+                postedOptions = options;
+                return { ok: true, status: 200, data: { success: true } };
+            },
+        });
+
+        try {
+            const response = await callback({
+                action: "upload_file",
+                ref: "project-ref",
+                bucket: "backups",
+                file: testFile,
+                filename: "custom/archive.bin",
+                mime_type: "application/octet-stream",
+                timeout_ms: 120_000,
+            });
+
+            expect(response.isError).toBeFalsy();
+            expect(response.content[0].text).toContain("✅ File custom/archive.bin");
+            expect(postedPath).toBe("/v1/storage/project-ref/buckets/backups/upload");
+            expect(postedFormData).toBeDefined();
+            expect(postedFormData?.get("path")).toBe("custom/archive.bin");
+            expect(postedOptions?.timeoutMs).toBe(120_000);
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("supports path alias flag for file path", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "notes.txt");
+        writeFileSync(testFile, "hello world");
+
+        let postedFormData: FormData | undefined;
+
+        const { callback } = captureStorageTool({
+            postMultipart: async (_path: string, formData: FormData) => {
+                postedFormData = formData;
+                return { ok: true, status: 200, data: { success: true } };
+            },
+        });
+
+        try {
+            const response = await callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "notes",
+                path: testFile,
+            });
+
+            expect(response.isError).toBeFalsy();
+            expect(response.content[0].text).toContain("✅ File notes.txt");
+            expect(postedFormData).toBeDefined();
+            expect(postedFormData?.get("path")).toBe("notes.txt");
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("reports friendly error when file does not exist", async () => {
+        const { callback } = captureStorageTool({});
+
+        await expect(callback({
+            action: "upload",
+            ref: "project-ref",
+            bucket: "reports",
+            file_path: "/nonexistent/path/to/file.zip",
+        })).rejects.toThrow("File not found");
+    });
+
+    test("reports friendly error when path is a directory", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const { callback } = captureStorageTool({});
+
+        try {
+            await expect(callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: tempDir,
+            })).rejects.toThrow("Path is not a regular file");
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects missing file_path", async () => {
+        const { callback } = captureStorageTool({});
+
+        await expect(callback({
+            action: "upload",
+            ref: "project-ref",
+            bucket: "reports",
+        })).rejects.toThrow("'file_path' (or '--file') required");
+    });
+
+    test("rejects invalid timeout_ms", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "file.txt");
+        writeFileSync(testFile, "content");
+        const { callback } = captureStorageTool({});
+
+        try {
+            await expect(callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: testFile,
+                timeout_ms: -5,
+            })).rejects.toThrow("'timeout_ms' must be a positive integer");
+
+            await expect(callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: testFile,
+                timeout_ms: 36 * 60_000 + 1,
+            })).rejects.toThrow("'timeout_ms' must be a positive integer");
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("reports error text when upload API returns non-ok status", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "bad.txt");
+        writeFileSync(testFile, "bad");
+
+        const { callback } = captureStorageTool({
+            postMultipart: async () => ({
+                ok: false,
+                status: 413,
+                data: { error: "Payload Too Large", message: "File exceeds bucket limit" },
+            }),
+        });
+
+        try {
+            const response = await callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: testFile,
+            });
+
+            expect(response.content[0].text).toContain("❌ Upload failed (413: File exceeds bucket limit)");
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test("catches transport network error gracefully", async () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "storage-test-"));
+        const testFile = join(tempDir, "net.txt");
+        writeFileSync(testFile, "net");
+
+        const { callback } = captureStorageTool({
+            postMultipart: async () => {
+                throw new Error("Network timeout after 36 minutes");
+            },
+        });
+
+        try {
+            const response = await callback({
+                action: "upload",
+                ref: "project-ref",
+                bucket: "reports",
+                file_path: testFile,
+            });
+
+            expect(response.content[0].text).toContain("❌ Error: Network timeout after 36 minutes");
+        } finally {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/cli/src/shared/tools/storage-tools.ts
+++ b/packages/cli/src/shared/tools/storage-tools.ts
@@ -1,3 +1,5 @@
+import { existsSync, openAsBlob, readFileSync, statSync } from "node:fs";
+import { basename, resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
@@ -27,15 +29,29 @@ type StorageAction =
     | "delete_bucket"
     | "list_files"
     | "upload_base64"
-    | "delete_file";
+    | "delete_file"
+    | "upload"
+    | "upload_file";
 
 const MAX_BUCKET_ID_LENGTH = 100;
 const MAX_MIME_TYPE_COUNT = 100;
 const MAX_MIME_TYPE_LENGTH = 255;
+const DEFAULT_UPLOAD_TIMEOUT_MS = 36 * 60_000;
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const BUCKET_ID_PATTERN = new RegExp(`^(?!\\.+$)[A-Za-z0-9._-]{1,${MAX_BUCKET_ID_LENGTH}}$`);
 const MIME_TYPE_PATTERN = /^(?=\S)(?=.*\S$)[^\u0000-\u001f\u007f]+$/;
 const BUCKET_REVISION_PATTERN = /^[0-9]{1,20}$/;
+const UPLOAD_ARGUMENTS = new Set([
+    "action",
+    "ref",
+    "bucket",
+    "file_path",
+    "file",
+    "path",
+    "filename",
+    "mime_type",
+    "timeout_ms",
+]);
 const ACTION_ARGUMENTS: Record<StorageAction, ReadonlySet<string>> = {
     status: new Set(["action"]),
     list_buckets: new Set(["action", "ref"]),
@@ -46,6 +62,8 @@ const ACTION_ARGUMENTS: Record<StorageAction, ReadonlySet<string>> = {
     list_files: new Set(["action", "ref", "bucket"]),
     upload_base64: new Set(["action", "ref", "bucket", "filename", "base64_content", "mime_type"]),
     delete_file: new Set(["action", "ref", "bucket", "filename"]),
+    upload: UPLOAD_ARGUMENTS,
+    upload_file: UPLOAD_ARGUMENTS,
 };
 
 function normalizedMimeTypes(candidate: unknown): unknown {
@@ -174,6 +192,20 @@ function isAllowedMimeTypes(candidate: unknown): candidate is string[] | null {
 function isBucketRevision(candidate: unknown): candidate is string | null {
     return candidate === null
         || (typeof candidate === "string" && BUCKET_REVISION_PATTERN.test(candidate));
+}
+
+function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) return "—";
+    if (bytes === 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let value = bytes;
+    let index = 0;
+    while (value >= 1024 && index < units.length - 1) {
+        value /= 1024;
+        index += 1;
+    }
+    const formatted = index === 0 ? String(value) : (value >= 100 ? value.toFixed(0) : value.toFixed(1));
+    return `${formatted} ${units[index]}`;
 }
 
 function safeBucket(candidate: unknown, expectedBucket?: string): SafeBucket | null {
@@ -487,22 +519,26 @@ export function registerStorageTools(server: ToolServer, http: HttpTransport): v
     server.tool(
         "storage",
         `S3/MinIO storage management.
-Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_bucket, list_files, upload_base64, delete_file`,
+Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_bucket, list_files, upload_base64, delete_file, upload, upload_file`,
         {
             action: withDescription(stringEnum([
                 "status", "list_buckets", "get_bucket", "create_bucket", "update_bucket", "delete_bucket",
-                "list_files", "upload_base64", "delete_file",
+                "list_files", "upload_base64", "delete_file", "upload", "upload_file",
             ]), "Action"),
-            ref: optional(Type.String({ pattern: PROJECT_REF_PATTERN.source }), "[list_buckets/get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Project ref"),
-            bucket: optional(Type.String({ pattern: BUCKET_ID_PATTERN.source }), "[get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Bucket name or ID"),
+            ref: optional(Type.String({ pattern: PROJECT_REF_PATTERN.source }), "[list_buckets/get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file/upload/upload_file] Project ref"),
+            bucket: optional(Type.String({ pattern: BUCKET_ID_PATTERN.source }), "[get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file/upload/upload_file] Bucket name or ID"),
             public: optional(Type.Boolean(), "[create_bucket/update_bucket] Public bucket access"),
             file_size_limit: withDescription(fileSizeLimitSchema, "[create_bucket/update_bucket] Positive safe-integer per-file size limit in bytes"),
             allowed_mime_types: withDescription(allowedMimeTypesSchema, "[create_bucket/update_bucket] MIME types as a comma-separated or JSON array"),
             expected_revision: optional(Type.String({ pattern: BUCKET_REVISION_PATTERN.source }), "[update_bucket/delete_bucket] Exact revision from list_buckets/get_bucket"),
             require_empty: optional(Type.Boolean(), "[delete_bucket] Must be true; deletion never empties a bucket"),
-            filename: optional(Type.String(), "[upload_base64/delete_file] File name/path"),
+            filename: optional(Type.String(), "[upload_base64/delete_file/upload/upload_file] File name/path"),
             base64_content: optional(Type.String(), "[upload_base64] Base64 encoded content"),
-            mime_type: optional(Type.String(), "[upload_base64] MIME type (default: application/octet-stream)"),
+            mime_type: optional(Type.String(), "[upload_base64/upload/upload_file] MIME type (default: application/octet-stream)"),
+            file_path: optional(Type.String(), "[upload/upload_file] Local file path to upload"),
+            file: optional(Type.String(), "[upload/upload_file] Alias for file_path"),
+            path: optional(Type.String(), "[upload/upload_file] Alias for file_path"),
+            timeout_ms: optional(Type.Integer({ minimum: 1, maximum: 36 * 60_000 }), "[upload/upload_file] Request timeout in milliseconds (default: 2160000 ms / 36 min)"),
         },
         async (args) => {
             const action = String(args.action) as StorageAction;
@@ -549,6 +585,60 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
                     const filename = requiredText(args, "filename");
                     text = (await http.delete(`/v1/storage/${ref}/buckets/${bucket}/files/${filename}`)).ok
                         ? `✅ File ${filename} deleted` : "❌ Failed";
+                    break;
+                }
+                case "upload":
+                case "upload_file": {
+                    const ref = requiredProjectRef(args);
+                    const bucket = requiredBucketId(args);
+                    const rawFilePath = args.file_path ?? args.file ?? args.path;
+                    if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
+                        throw new Error(`'file_path' (or '--file') required for '${action}'`);
+                    }
+                    const resolvedFilePath = resolve(process.cwd(), rawFilePath.trim());
+                    if (!existsSync(resolvedFilePath)) {
+                        throw new Error(`File not found: ${resolvedFilePath}`);
+                    }
+                    const stat = statSync(resolvedFilePath);
+                    if (!stat.isFile()) {
+                        throw new Error(`Path is not a regular file: ${resolvedFilePath}`);
+                    }
+                    const filename = typeof args.filename === "string" && args.filename.trim()
+                        ? args.filename.trim()
+                        : basename(resolvedFilePath);
+                    const mimeType = typeof args.mime_type === "string" && args.mime_type.trim()
+                        ? args.mime_type.trim()
+                        : "application/octet-stream";
+                    let timeoutMs = DEFAULT_UPLOAD_TIMEOUT_MS;
+                    if (args.timeout_ms !== undefined) {
+                        const parsed = typeof args.timeout_ms === "number"
+                            ? args.timeout_ms
+                            : (typeof args.timeout_ms === "string" && /^\d+$/.test(args.timeout_ms) ? Number(args.timeout_ms) : NaN);
+                        if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > DEFAULT_UPLOAD_TIMEOUT_MS) {
+                            throw new Error(`'timeout_ms' must be a positive integer up to ${DEFAULT_UPLOAD_TIMEOUT_MS} ms`);
+                        }
+                        timeoutMs = parsed;
+                    }
+                    try {
+                        const blob = typeof openAsBlob === "function"
+                            ? await openAsBlob(resolvedFilePath, { type: mimeType })
+                            : new Blob([readFileSync(resolvedFilePath)], { type: mimeType });
+                        const formData = new FormData();
+                        formData.append("file", blob, filename);
+                        formData.append("path", filename);
+                        const response = await http.postMultipart(
+                            `/v1/storage/${ref}/buckets/${bucket}/upload`,
+                            formData,
+                            { timeoutMs },
+                        );
+                        const errMessage = (response.data as { message?: string; error?: string })?.message
+                            || (response.data as { message?: string; error?: string })?.error;
+                        text = response.ok
+                            ? `✅ File ${filename} (${formatBytes(stat.size)}) uploaded to ${bucket}`
+                            : `❌ Upload failed (${response.status}${errMessage ? `: ${errMessage}` : ""})`;
+                    } catch (error: unknown) {
+                        text = `❌ Error: ${error instanceof Error ? error.message : String(error)}`;
+                    }
                     break;
                 }
                 default:

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -395,6 +395,36 @@ describe("HttpTransport retry policy", () => {
         expect(response).toEqual({ ok: true, status: 200, data: { ok: true } });
         expect(scheduledDelays).toEqual([120_000]);
     });
+
+    test("uses an explicit timeout for multipart POST", async () => {
+        const scheduledDelays: number[] = [];
+        globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number) => {
+            scheduledDelays.push(delay ?? 0);
+            return ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
+        }) as typeof setTimeout;
+        globalThis.fetch = (async () => Response.json({ ok: true })) as unknown as typeof fetch;
+
+        const response = await createTransport().postMultipart("/resource", new FormData(), { timeoutMs: 36 * 60_000 });
+
+        expect(response).toEqual({ ok: true, status: 200, data: { ok: true } });
+        expect(scheduledDelays).toEqual([36 * 60_000]);
+    });
+
+    test.each([0, 36 * 60_000 + 1, 1.5])(
+        "rejects invalid multipart POST timeout %s before dispatch",
+        async timeoutMs => {
+            let fetchCalls = 0;
+            globalThis.fetch = (async () => {
+                fetchCalls += 1;
+                return Response.json({ ok: true });
+            }) as unknown as typeof fetch;
+
+            await expect(createTransport().postMultipart("/resource", new FormData(), { timeoutMs })).rejects.toThrow(
+                "HTTP request timeout must be between",
+            );
+            expect(fetchCalls).toBe(0);
+        },
+    );
 });
 
 describe("HttpTransport bounded GET responses", () => {

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -507,14 +507,19 @@ export class HttpTransport {
         );
     }
 
-    async postMultipart<T = unknown>(path: string, formData: FormData): Promise<HttpResult<T>> {
+    async postMultipart<T = unknown>(
+        path: string,
+        formData: FormData,
+        options?: { timeoutMs?: number },
+    ): Promise<HttpResult<T>> {
+        const timeoutMs = validatedPostTimeout(options);
         try {
             const headers = { Authorization: `Bearer ${this.token}` };
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "POST",
                 headers,
                 body: formData,
-            }, DEFAULT_TIMEOUT, this.insecureTls);
+            }, timeoutMs, this.insecureTls);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {


### PR DESCRIPTION
## Summary

This PR introduces unrestricted manual file upload commands (`upload` and `upload_file`) for the SupaCloud CLI and Admin CLI storage tools, eliminating the limitations of `upload_base64`.

### Key Changes
1. **Unrestricted Manual File Upload (`upload` & `upload_file`)**:
   - Allows uploading arbitrary local files directly by path (`--file_path`, `--file`, or `--path`).
   - Resolves and verifies local file existence and ensures it is a regular file before upload.
   - Streams files directly from disk without Base64 encoding or ARG_MAX / memory inflation using `openAsBlob` with fallback to Blob buffer.
   - Automatically derives target filename from local file's `basename` unless explicitly overridden via `--filename`.
   - Supports custom `--mime_type` and configurable `--timeout_ms` (defaults to 36 minutes / 2,160,000 ms to support very large files).
   - Formats file size in upload success receipt (e.g. `✅ File report.pdf (15.2 MB) uploaded to reports`).

2. **HTTP Transport Timeout Support in `postMultipart`**:
   - Added optional `{ timeoutMs?: number }` parameter to `postMultipart` in both `@supacloud/cli` and `@supacloud/admin`.
   - Validates timeout against safe integer bounds up to 36 minutes (`MAX_POST_TIMEOUT_MS`).

3. **Execution Policy Integration**:
   - Classified `upload` and `upload_file` as write operations under `COMMAND_POLICIES.storage.write`, preventing unconfirmed production writes or read-only mode violations.

4. **Test Coverage**:
   - Added unit tests in `storage-tools.test.ts` covering successful uploads (default filename, custom filename, aliases, timeouts), non-existent files, directory rejection, missing parameters, API non-ok status, and network errors.
   - Added tests in `http.test.ts` for `postMultipart` custom and invalid timeouts.
   - Verified execution policy classification and catalog drift detection.