### PR TITLE
feat(sdk): support capabilities probing and storage upload constraints in supacloud-js

### DIFF
--- a/packages/management-api/src/routes/project-capabilities.ts
+++ b/packages/management-api/src/routes/project-capabilities.ts
@@ -146,6 +146,8 @@ export const projectCapabilityRoutes = new Elysia({ prefix: "/v1/projects/:ref" 
         authority_project_ref: authRuntime.authority_project_ref,
         managed_by_owner: authRuntime.mode === "shared",
       },
+      storage_v1: available("supacloud", "v1"),
+      edge_runtime_streaming_upload_v1: available("supacloud", "v1"),
     };
 
     return {

--- a/packages/management-api/tests/unit/project-capabilities.routes.test.ts
+++ b/packages/management-api/tests/unit/project-capabilities.routes.test.ts
@@ -104,6 +104,8 @@ describe("project capability negotiation", () => {
     } else {
       expect(body.capabilities.gotrue_auth_hooks_v1.reason_code).toBeTruthy();
     }
+    expect(body.capabilities.storage_v1).toMatchObject({ available: true, source: "supacloud" });
+    expect(body.capabilities.edge_runtime_streaming_upload_v1).toMatchObject({ available: true, source: "supacloud" });
   });
 
   test("does not advertise organization runtime materialization before its schema exists", async () => {

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { createSupaCloudClient, SupaCloudApiError, SupaCloudTaskSubmitError } from "./index";
+import {
+  createSupaCloudClient,
+  SupaCloudApiError,
+  SupaCloudTaskSubmitError,
+  SUPACLOUD_JS_VERSION,
+} from "./index";
 
 function createFakeSupabase() {
   const removeChannel = mock(async () => "ok");
@@ -32,6 +37,18 @@ function createFakeSupabase() {
     },
     functions: {
       invoke: mock(),
+    },
+    storage: {
+      getBucket: mock(async (id: string) => ({
+        data: {
+          id,
+          name: id,
+          public: true,
+          file_size_limit: 10485760,
+          allowed_mime_types: ["image/png", "image/jpeg"],
+        },
+        error: null,
+      })),
     },
     schema,
     channel: mock(() => channelInstance),
@@ -847,4 +864,119 @@ describe("@supacloud/js", () => {
 
     subscription.unsubscribe();
   });
+
+  test("capabilities client queries project capabilities and checks availability", async () => {
+    const { supabase } = createFakeSupabase();
+    const capturedCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+      capturedCalls.push({ url: String(input), init });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            project_ref: "proj_1",
+            auth_runtime: "gotrue",
+            schema_version: 1,
+            capabilities: {
+              storage_v1: { available: true, source: "supacloud", version: "v1", reason_code: null },
+              edge_runtime_streaming_upload_v1: { available: true, source: "supacloud", version: "v1", reason_code: null },
+              experimental_feature_v2: { available: false, source: "supacloud", version: null, reason_code: "disabled" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+    });
+
+    const caps = await client.capabilities.get();
+    expect(caps.project_ref).toBe("proj_1");
+    expect(caps.capabilities.storage_v1?.available).toBe(true);
+    expect(caps.capabilities.edge_runtime_streaming_upload_v1?.available).toBe(true);
+    expect(caps.capabilities.experimental_feature_v2?.available).toBe(false);
+
+    const isStorageAvail = await client.capabilities.isAvailable("storage_v1");
+    expect(isStorageAvail).toBe(true);
+
+    const isExpAvail = await client.capabilities.isAvailable("experimental_feature_v2");
+    expect(isExpAvail).toBe(false);
+
+    const isUnknownAvail = await client.capabilities.isAvailable("unknown_cap");
+    expect(isUnknownAvail).toBe(false);
+
+    expect(capturedCalls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/capabilities");
+    expect((capturedCalls[0]?.init?.headers as Record<string, string>)?.["x-client-info"]).toBe(`supacloud-js/${SUPACLOUD_JS_VERSION}`);
+  });
+
+  test("storage client queries upload constraints and validates files", async () => {
+    const { supabase } = createFakeSupabase();
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+    });
+
+   const constraints = await client.storage.getUploadConstraints("avatars");
+   expect(constraints.bucketId).toBe("avatars");
+   expect(constraints.fileSizeLimit).toBe(10485760);
+   expect(constraints.allowedMimeTypes).toMatchObject(["image/png", "image/jpeg"]);
+
+   // Valid file
+   const valid = await client.storage.validateUpload("avatars", { size: 1024, type: "image/png" });
+   expect(valid.valid).toBe(true);
+   expect(valid.error).toBe(undefined);
+
+   // Size limit exceeded
+    const tooBig = await client.storage.validateUpload("avatars", { size: 20971520, type: "image/png" });
+    expect(tooBig.valid).toBe(false);
+    expect(tooBig.error).toContain("exceeds bucket limit");
+
+    // MIME type mismatch
+    const wrongMime = await client.storage.validateUpload("avatars", { size: 1024, type: "application/pdf" });
+    expect(wrongMime.valid).toBe(false);
+    expect(wrongMime.error).toContain("MIME type");
+  });
+
+  test("storage client falls back to management api when supabase storage throws or errors", async () => {
+    const { supabase } = createFakeSupabase();
+    supabase.storage.getBucket = mock(async () => ({
+      data: null,
+      error: { message: "The resource was not found", statusCode: "404" },
+    })) as never;
+
+    const capturedCalls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+      capturedCalls.push({ url: String(input), init });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "documents",
+            name: "documents",
+            public: false,
+            file_size_limit: 52428800,
+            allowed_mime_types: ["application/pdf"],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+    });
+
+   const constraints = await client.storage.getUploadConstraints("documents");
+   expect(constraints.bucketId).toBe("documents");
+   expect(constraints.fileSizeLimit).toBe(52428800);
+   expect(constraints.allowedMimeTypes).toMatchObject(["application/pdf"]);
+   expect(capturedCalls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/storage/buckets/documents");
+ });
 });

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -14,6 +14,37 @@ export * from "./workflows.js";
 export * from "./commands.js";
 export * from "./artifacts.js";
 
+export const SUPACLOUD_JS_VERSION = "0.27.1";
+
+export type SupaCloudCapability = {
+  available: boolean;
+  source: string;
+  version: string | null;
+  reason_code: string | null;
+  authority_project_ref?: string;
+  managed_by_owner?: boolean;
+  [key: string]: unknown;
+};
+
+export type SupaCloudProjectCapabilities = {
+  project_ref: string;
+  auth_runtime: string;
+  schema_version: number;
+  capabilities: Record<string, SupaCloudCapability>;
+  [key: string]: unknown;
+};
+
+export type SupaCloudStorageUploadConstraints = {
+  bucketId: string;
+  fileSizeLimit: number | null;
+  allowedMimeTypes: string[] | null;
+};
+
+export type SupaCloudUploadValidationResult = {
+  valid: boolean;
+  error?: string;
+};
+
 export type SupaCloudTaskStatus =
   | "pending"
   | "leased"
@@ -791,6 +822,29 @@ function decodePurgeResult(value: unknown): { queue_name: string; purged: number
   };
 }
 
+function decodeProjectCapabilities(value: unknown): SupaCloudProjectCapabilities {
+  const record = responseRecord(value, "project capabilities");
+  const rawCapabilities = valueRecord(record.capabilities);
+  const capabilities: Record<string, SupaCloudCapability> = {};
+  for (const [key, item] of Object.entries(rawCapabilities)) {
+    const capRecord = valueRecord(item);
+    capabilities[key] = {
+      available: typeof capRecord.available === "boolean" ? capRecord.available : false,
+      source: typeof capRecord.source === "string" ? capRecord.source : "unknown",
+      version: typeof capRecord.version === "string" ? capRecord.version : null,
+      reason_code: typeof capRecord.reason_code === "string" ? capRecord.reason_code : null,
+      ...(typeof capRecord.authority_project_ref === "string" ? { authority_project_ref: capRecord.authority_project_ref } : {}),
+      ...(typeof capRecord.managed_by_owner === "boolean" ? { managed_by_owner: capRecord.managed_by_owner } : {}),
+    };
+  }
+  return {
+    project_ref: responseString(record, "project_ref", "project capabilities"),
+    auth_runtime: typeof record.auth_runtime === "string" ? record.auth_runtime : "unknown",
+    schema_version: typeof record.schema_version === "number" ? record.schema_version : 1,
+    capabilities,
+  };
+}
+
 function normalizeRpcMessage(queueName: string, value: unknown, status?: string): SupaCloudQueueMessage | null {
   const row = firstRpcValue(value);
   if (!row || typeof row !== "object") return null;
@@ -903,6 +957,7 @@ class SupaCloudManagementClient<TClient extends SupabaseClient = SupabaseClient>
       method,
       headers: {
         authorization: `Bearer ${accessToken}`,
+        "x-client-info": `supacloud-js/${SUPACLOUD_JS_VERSION}`,
         ...(body !== undefined ? { "content-type": "application/json" } : {}),
       },
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
@@ -1637,6 +1692,91 @@ class SupaCloudSupAuthClient<TClient extends SupabaseClient = SupabaseClient> ex
   }
 }
 
+export class SupaCloudCapabilitiesClient<TClient extends SupabaseClient = SupabaseClient> extends SupaCloudManagementClient<TClient> {
+  async get(): Promise<SupaCloudProjectCapabilities> {
+    return this.request<SupaCloudProjectCapabilities>(
+      `/v1/projects/${this.options.projectRef}/capabilities`,
+      "GET",
+      undefined,
+      decodeProjectCapabilities,
+    );
+  }
+
+  async isAvailable(capabilityKey: string): Promise<boolean> {
+    const res = await this.get();
+    return res.capabilities?.[capabilityKey]?.available === true;
+  }
+}
+
+export class SupaCloudStorageClient<TClient extends SupabaseClient = SupabaseClient> extends SupaCloudManagementClient<TClient> {
+  async getUploadConstraints(bucketId: string): Promise<SupaCloudStorageUploadConstraints> {
+    try {
+      const { data, error } = await this.options.supabase.storage.getBucket(bucketId);
+      if (!error && data) {
+        return {
+          bucketId,
+          fileSizeLimit: typeof data.file_size_limit === "number"
+            ? data.file_size_limit
+            : data.file_size_limit ? Number(data.file_size_limit) : null,
+          allowedMimeTypes: Array.isArray(data.allowed_mime_types) ? data.allowed_mime_types : null,
+        };
+      }
+    } catch {
+      // Fall back to management API query if storage client throws or lacks RLS
+    }
+
+    try {
+      const bucket = await this.request<Record<string, unknown>>(
+        `/v1/projects/${this.options.projectRef}/storage/buckets/${encodeURIComponent(bucketId)}`,
+        "GET",
+        undefined,
+        (val) => responseRecord(val, "storage bucket"),
+      );
+      const rawLimit = bucket.file_size_limit;
+      const fileSizeLimit = typeof rawLimit === "number" ? rawLimit : rawLimit ? Number(rawLimit) : null;
+      const allowedMimeTypes = Array.isArray(bucket.allowed_mime_types)
+        ? (bucket.allowed_mime_types as string[])
+        : null;
+      return {
+        bucketId,
+        fileSizeLimit,
+        allowedMimeTypes,
+      };
+    } catch {
+      return {
+        bucketId,
+        fileSizeLimit: null,
+        allowedMimeTypes: null,
+      };
+    }
+  }
+
+  async validateUpload(
+    bucketId: string,
+    file: { size: number; type?: string },
+  ): Promise<SupaCloudUploadValidationResult> {
+    const constraints = await this.getUploadConstraints(bucketId);
+    if (constraints.fileSizeLimit !== null && file.size > constraints.fileSizeLimit) {
+      return {
+        valid: false,
+        error: `File size ${file.size} bytes exceeds bucket limit of ${constraints.fileSizeLimit} bytes`,
+      };
+    }
+    if (
+      constraints.allowedMimeTypes &&
+      constraints.allowedMimeTypes.length > 0 &&
+      file.type &&
+      !constraints.allowedMimeTypes.includes(file.type)
+    ) {
+      return {
+        valid: false,
+        error: `MIME type "${file.type}" is not in the allowed list: ${constraints.allowedMimeTypes.join(", ")}`,
+      };
+    }
+    return { valid: true };
+  }
+}
+
 export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseClient>(
   options: SupaCloudClientOptions<TClient>,
 ) {
@@ -1654,6 +1794,8 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
   const oauthClients = new SupaCloudOAuthClientsClient(normalized);
   const supauth = new SupaCloudSupAuthClient(normalized);
   const queues = new SupaCloudQueuesClient(normalized);
+  const capabilities = new SupaCloudCapabilitiesClient(normalized);
+  const storage = new SupaCloudStorageClient(normalized);
   const workflows = new SupaCloudWorkflowsClient(options.supabase);
   const commands = new SupaCloudCommandsClient(options.supabase);
   const artifacts = new SupaCloudArtifactsClient(options.supabase);
@@ -1672,6 +1814,8 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
     artifacts,
     supauth,
     queues,
+    capabilities,
+    storage,
     queue: (name: string) => new SupaCloudQueueClient(normalized, name),
     functions: {
       invokeBackground: (


### PR DESCRIPTION
## Summary
- Introduces `capabilities` client in `@supacloud/js` allowing client applications to query project platform capabilities (`client.capabilities.get()`, `client.capabilities.isAvailable()`).
- Introduces `storage` client helper in `@supacloud/js` for reading bucket constraints (`client.storage.getUploadConstraints(bucketId)`) and performing client-side preflight upload validation (`client.storage.validateUpload(bucketId, file)`).
- Automatically attaches `x-client-info: supacloud-js/<version>` header to management API requests.
- Advertises `storage_v1` and `edge_runtime_streaming_upload_v1` in management API `/v1/projects/:ref/capabilities`.
- Adds unit tests across SDK and management API routes.