### PR TITLE
fix(edge-functions): recover unacknowledged activation begin

### DIFF
--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -2528,10 +2528,11 @@ async function commitFunctionActivation(
   commit: FunctionActivationCommit,
 ): Promise<{ config: EdgeFunctionConfigSnapshot; preheat: EdgeFunctionPreheatResult | null }> {
   const activation = await preparedFunctionActivation(commit);
-  const fence = await beginPreparedFunctionActivation(activation);
   let preheat: EdgeFunctionPreheatResult | null = null;
   let published = false;
   try {
+    // 开始激活可能已建立隔离但丢失响应，必须走同一中止或提交恢复流程。
+    const fence = await beginPreparedFunctionActivation(activation);
     preheat = await preheatPreparedFunctionActivation(activation, fence);
     try {
       await publishPreparedFunctionActivation(activation);

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1863,6 +1863,46 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(await edgeFunctionService.readSource(ref, targetSlug)).toBeNull();
   });
 
+  test.each(["lost response", "invalid acknowledgement"])(
+    "aborts an established candidate fence after begin has an %s",
+    async (failureMode) => {
+      const ref = `proj_begin_${failureMode.replaceAll(" ", "_")}`;
+      const slug = "begin-recovery";
+      await deployConditionalRelease({
+        ref, slug, code: "export default { fetch: () => new Response('original') };",
+      });
+      const current = await edgeFunctionService.getConfig(ref, slug);
+      const runtimeFetch = runtimeSuccessFetch();
+      let candidateId: string | null = null;
+      let aborted = false;
+      globalThis.fetch = (async (input, init) => {
+        const url = new URL(String(input));
+        const activationId = new Headers(init?.headers).get("x-supacloud-activation-id");
+        // 先让运行时执行 begin，再模拟控制端无法接收响应；旧版本 status 不受影响。
+        const response = await runtimeFetch(input, init);
+        if (activationId !== current.activation_id
+          && (url.pathname.endsWith("/begin") || url.pathname.endsWith("/status"))) {
+          candidateId = activationId;
+          if (failureMode === "lost response") throw new Error("Control response lost");
+          return Response.json({ malformed: true });
+        }
+        if (url.pathname.endsWith("/abort")) {
+          expect(activationId).toBe(candidateId);
+          const body = await response.clone().json() as { state: string };
+          aborted = body.state === "aborted";
+        }
+        return response;
+      }) as typeof fetch;
+      const result = await deployConditionalRelease({
+        ref, slug, code: "export default { fetch: () => new Response('candidate') };",
+      });
+      expect(result.success).toBe(false);
+      expect(aborted).toBe(true);
+      expect(await edgeFunctionService.getConfig(ref, slug)).toEqual(current);
+      expect(await edgeFunctionService.getActiveVersion(ref, slug)).toBe(current.version!);
+    },
+  );
+
   test("preserves the active authority when delete fencing is not acknowledged", async () => {
     const ref = "proj_delete_unconfirmed";
     const slug = "delete-unconfirmed";


### PR DESCRIPTION
## Problem
During FA issue 2237 production release, activation begin established a runtime fence but management could not validate its acknowledgement. The manifest stayed at the previous active version while requests returned FUNCTION_ACTIVATION_FENCED (503). A targeted internal abort restored the previous version.

## Fix
Move beginPreparedFunctionActivation inside the existing activation recovery try/catch. Lost or malformed begin acknowledgements now follow the same candidate-specific abort/commit reconciliation as preheat failures. No CAS, readiness, identity, or durability checks are relaxed.

## Validation
bun test tests/unit/edge-function.service.bundle-metadata.test.ts: 57 passed, 298 assertions. Added two tests that let the runtime establish a fence before losing or corrupting begin/status responses, then verify exact-candidate abort and unchanged prior authority. git diff --check passed.

This fixes orphaned fencing on begin failure; it does not claim to explain every transient readiness/control failure. Not deployed to either environment.