### PR TITLE
feat: adopt Pigsty Silo MinIO fork, expose environment/version APIs, and storage upload constraints

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -764,7 +764,7 @@ jobs:
             --publish 9001:9000 \
             --env MINIO_ROOT_USER=minioadmin \
             --env MINIO_ROOT_PASSWORD=minioadmin \
-            quay.io/minio/minio:latest server /data
+            pgsty/silo:latest server /data
 
       # Management refuses to serve until the Caddy Admin API is reachable and
       # accepts its canonical JSON config, so this job needs a real Caddy. The

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -2,6 +2,7 @@ import { Elysia, status } from "elysia";
 import type { AnyElysia } from "elysia";
 import { logger } from "./utils/logger";
 import { runBootstrapOrExit } from "./runtime/bootstrap-fatal";
+import pkg from "../package.json";
 
 process.on("uncaughtException", (err: Error) => {
   logger.error("FATAL UNCAUGHT EXCEPTION:", {
@@ -415,6 +416,16 @@ const app = new Elysia({ strictPath: false })
 
   // Health check (no auth required)
   .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
+  .get("/version", () => ({
+    version: pkg.version || "unknown",
+    environment: process.env.NODE_ENV || "production",
+    api_version: "2024-01-01",
+  }))
+  .get("/v1/version", () => ({
+    version: pkg.version || "unknown",
+    environment: process.env.NODE_ENV || "production",
+    api_version: "2024-01-01",
+  }))
   .get("/metrics", ({ request, set }) => {
     const token = process.env.SUPACLOUD_METRICS_TOKEN?.trim();
     if (token && request.headers.get("authorization") !== `Bearer ${token}`) {

--- a/packages/management-api/src/routes/project-capabilities.ts
+++ b/packages/management-api/src/routes/project-capabilities.ts
@@ -10,6 +10,7 @@ import { normalizeProjectConfig } from "../utils/project-config";
 import { normalizeProjectRoutingConfig, resolveTenantPorts } from "../utils/project-routing";
 import { config } from "../config";
 import { detectOrganizationJitCapability } from "../services/organization-jit-capability.service";
+import pkg from "../../package.json";
 
 type Capability = {
   available: boolean;
@@ -152,11 +153,30 @@ export const projectCapabilityRoutes = new Elysia({ prefix: "/v1/projects/:ref" 
 
     return {
       project_ref: params.ref,
+      platform_version: (pkg as { version?: string })?.version || "unknown",
+      environment: process.env.NODE_ENV || "production",
       auth_runtime: "gotrue",
       schema_version: 1,
+      storage_backend: config.storageType || "s3",
       capabilities,
     };
   }, {
     params: t.Object({ ref: t.String() }),
     detail: { tags: ["projects"], summary: "Get project platform capabilities" },
+  })
+  .get("/environment", async ({ params }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "NOT_FOUND" });
+
+    return {
+      project_ref: params.ref,
+      platform_version: (pkg as { version?: string })?.version || "unknown",
+      environment: process.env.NODE_ENV || "production",
+      schema_version: 1,
+      auth_runtime: "gotrue",
+      storage_backend: config.storageType || "s3",
+    };
+  }, {
+    params: t.Object({ ref: t.String() }),
+    detail: { tags: ["projects"], summary: "Get project environment and platform version" },
   });

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -437,6 +437,17 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
         return await StorageService.getStatus();
     }, { detail: { tags: ["storage"], summary: "Get storage service status" } })
 
+    // GET /constraints â Storage upload size and protocol constraints
+    .get('/constraints', async () => {
+        return {
+            max_upload_size_bytes: STORAGE_UPLOAD_MAX_BYTES,
+            max_upload_size_mb: Math.floor(STORAGE_UPLOAD_MAX_BYTES / (1024 * 1024)),
+            tus_max_size_bytes: TUS_MAX_SIZE,
+            tus_chunk_max_size_bytes: TUS_MAX_CHUNK_SIZE,
+            streaming_upload_supported: true,
+        };
+    }, { detail: { tags: ["storage"], summary: "Get storage upload size and protocol constraints" } })
+
     // ════════════════════════════════════════════════════════
     // BUCKET Operations
     // ════════════════════════════════════════════════════════
@@ -690,7 +701,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
 
             // Check file size limit
             if (bucket.file_size_limit && size > Number(bucket.file_size_limit)) {
-                return status(413, { statusCode: "413", error: 'Payload too large', message: 'The object exceeded the maximum allowed size' });
+                return status(413, { statusCode: "413", error: 'Payload too large', message: 'The object exceeded the maximum allowed size', max_bytes: Number(bucket.file_size_limit) });
             }
             
             // Check allowed mime types
@@ -734,7 +745,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
             };
         } catch (err: unknown) {
             if (err instanceof Error && err.message === "UPLOAD_TOO_LARGE") {
-                return status(413, { statusCode: "413", error: 'Payload too large', message: `Upload is limited to ${STORAGE_UPLOAD_MAX_BYTES} bytes` });
+                return status(413, { statusCode: "413", error: 'Payload too large', message: `Upload is limited to ${STORAGE_UPLOAD_MAX_BYTES} bytes`, max_bytes: STORAGE_UPLOAD_MAX_BYTES });
             }
             logger.error('SDK upload error:', { error: err instanceof Error ? err.message : String(err) });
             return status(500, { statusCode: "500", error: 'Internal', message: 'Upload failed' });
@@ -775,7 +786,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
             };
         } catch (err: unknown) {
             if (err instanceof Error && err.message === "UPLOAD_TOO_LARGE") {
-                return status(413, { statusCode: "413", error: 'Payload too large', message: `Upload is limited to ${STORAGE_UPLOAD_MAX_BYTES} bytes` });
+                return status(413, { statusCode: "413", error: 'Payload too large', message: `Upload is limited to ${STORAGE_UPLOAD_MAX_BYTES} bytes`, max_bytes: STORAGE_UPLOAD_MAX_BYTES });
             }
             return status(500, { statusCode: "500", error: 'Internal', message: 'Upsert failed' });
         }
@@ -1614,7 +1625,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
         }
 
         if (uploadLength > TUS_MAX_SIZE) {
-            return status(413, { statusCode: "413", error: 'Payload too large', message: `TUS uploads are limited to ${TUS_MAX_SIZE / (1024 * 1024)}MB. Use standard upload for larger files.` });
+            return status(413, { statusCode: "413", error: 'Payload too large', message: `TUS uploads are limited to ${TUS_MAX_SIZE / (1024 * 1024)}MB. Use standard upload for larger files.`, max_bytes: TUS_MAX_SIZE });
         }
         const metadataHeader = headers['upload-metadata'] || '';
 
@@ -1634,7 +1645,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
         if (!logicalBucket) return status(404, { statusCode: "404", error: 'Not Found', message: 'Bucket not found' });
 
         if (logicalBucket.file_size_limit && uploadLength > Number(logicalBucket.file_size_limit)) {
-            return status(413, { statusCode: "413", error: 'Payload too large', message: 'The object exceeded the maximum allowed size' });
+            return status(413, { statusCode: "413", error: 'Payload too large', message: 'The object exceeded the maximum allowed size', max_bytes: Number(logicalBucket.file_size_limit) });
         }
 
         const allowedMimes = logicalBucket.allowed_mime_types as string[] | null;
@@ -1706,7 +1717,7 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
 
         const chunkLength = parseContentLength(headers['content-length']);
         if (chunkLength !== null && chunkLength > TUS_MAX_CHUNK_SIZE) {
-            return status(413, { statusCode: "413", error: 'Payload too large', message: `TUS chunks are limited to ${TUS_MAX_CHUNK_SIZE} bytes` });
+            return status(413, { statusCode: "413", error: 'Payload too large', message: `TUS chunks are limited to ${TUS_MAX_CHUNK_SIZE} bytes`, max_bytes: TUS_MAX_CHUNK_SIZE });
         }
 
         const clientOffset = Number(headers['upload-offset'] || 0);

--- a/packages/management-api/tests/unit/project-capabilities.routes.test.ts
+++ b/packages/management-api/tests/unit/project-capabilities.routes.test.ts
@@ -82,6 +82,8 @@ describe("project capability negotiation", () => {
     expect(response.status).toBe(200);
     const body = await response.json() as any;
     expect(body.auth_runtime).toBe("gotrue");
+    expect(body.platform_version).toBeTruthy();
+    expect(body.environment).toBeTruthy();
     expect(body.capabilities.webhook_delivery_v2).toMatchObject({ available: true, source: "supacloud" });
     expect(body.capabilities.business_organizations_v1).toMatchObject({
       available: true,
@@ -106,6 +108,17 @@ describe("project capability negotiation", () => {
     }
     expect(body.capabilities.storage_v1).toMatchObject({ available: true, source: "supacloud" });
     expect(body.capabilities.edge_runtime_streaming_upload_v1).toMatchObject({ available: true, source: "supacloud" });
+  });
+
+  test("serves project environment and platform version", async () => {
+    const response = await request("/v1/projects/proj_1/environment");
+    expect(response.status).toBe(200);
+    const body = await response.json() as any;
+    expect(body.project_ref).toBe("proj_1");
+    expect(body.platform_version).toBeTruthy();
+    expect(body.environment).toBeTruthy();
+    expect(body.schema_version).toBe(1);
+    expect(body.auth_runtime).toBe("gotrue");
   });
 
   test("does not advertise organization runtime materialization before its schema exists", async () => {

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -1025,4 +1025,22 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     assembleSpy.mockRestore();
     uploadSpy.mockRestore();
   });
+
+  test("serves storage upload and protocol constraints", async () => {
+    const res = await request("/storage/v1/constraints", {
+      method: "GET",
+      headers: {
+        "x-project-ref": "test_mock",
+        apikey: "test-token",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.max_upload_size_bytes).toBeGreaterThan(0);
+    expect(body.max_upload_size_mb).toBeGreaterThan(0);
+    expect(body.tus_max_size_bytes).toBeGreaterThan(0);
+    expect(body.tus_chunk_max_size_bytes).toBeGreaterThan(0);
+    expect(body.streaming_upload_supported).toBe(true);
+  });
 });

--- a/packages/management-api/tests/unit/version-endpoints.test.ts
+++ b/packages/management-api/tests/unit/version-endpoints.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import pkg from "../../package.json";
+
+const app = new Elysia()
+  .get("/version", () => ({
+    version: pkg.version || "unknown",
+    environment: process.env.NODE_ENV || "production",
+    api_version: "2024-01-01",
+  }))
+  .get("/v1/version", () => ({
+    version: pkg.version || "unknown",
+    environment: process.env.NODE_ENV || "production",
+    api_version: "2024-01-01",
+  }));
+
+describe("public version routes", () => {
+  test("GET /version returns package version and environment", async () => {
+    const res = await app.handle(new Request("http://localhost/version"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.version).toBe(pkg.version);
+    expect(body.api_version).toBe("2024-01-01");
+    expect(body.environment).toBeTruthy();
+  });
+
+  test("GET /v1/version returns package version and environment", async () => {
+    const res = await app.handle(new Request("http://localhost/v1/version"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.version).toBe(pkg.version);
+    expect(body.api_version).toBe("2024-01-01");
+    expect(body.environment).toBeTruthy();
+  });
+});

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -875,6 +875,8 @@ describe("@supacloud/js", () => {
         new Response(
           JSON.stringify({
             project_ref: "proj_1",
+            platform_version: "0.79.0",
+            environment: "production",
             auth_runtime: "gotrue",
             schema_version: 1,
             capabilities: {
@@ -896,9 +898,17 @@ describe("@supacloud/js", () => {
 
     const caps = await client.capabilities.get();
     expect(caps.project_ref).toBe("proj_1");
+    expect(caps.platform_version).toBe("0.79.0");
+    expect(caps.environment).toBe("production");
     expect(caps.capabilities.storage_v1?.available).toBe(true);
     expect(caps.capabilities.edge_runtime_streaming_upload_v1?.available).toBe(true);
     expect(caps.capabilities.experimental_feature_v2?.available).toBe(false);
+
+    expect(await client.getVersion()).toBe("0.79.0");
+    const env = await client.getEnvironment();
+    expect(env.platformVersion).toBe("0.79.0");
+    expect(env.environment).toBe("production");
+    expect(env.projectRef).toBe("proj_1");
 
     const isStorageAvail = await client.capabilities.isAvailable("storage_v1");
     expect(isStorageAvail).toBe(true);
@@ -979,4 +989,39 @@ describe("@supacloud/js", () => {
    expect(constraints.allowedMimeTypes).toMatchObject(["application/pdf"]);
    expect(capturedCalls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/storage/buckets/documents");
  });
+
+  test("storage client queries platform upload constraints", async () => {
+    const { supabase } = createFakeSupabase();
+    const capturedCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+      capturedCalls.push({ url: String(input), init });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            max_upload_size_bytes: 524288000,
+            max_upload_size_mb: 500,
+            tus_max_size_bytes: 524288000,
+            tus_chunk_max_size_bytes: 6291456,
+            streaming_upload_supported: true,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as typeof fetch;
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+    });
+
+    const constraints = await client.storage.getPlatformConstraints();
+    expect(constraints.max_upload_size_bytes).toBe(524288000);
+    expect(constraints.max_upload_size_mb).toBe(500);
+    expect(constraints.tus_max_size_bytes).toBe(524288000);
+    expect(constraints.tus_chunk_max_size_bytes).toBe(6291456);
+    expect(constraints.streaming_upload_supported).toBe(true);
+    expect(capturedCalls[0]?.url).toBe("https://admin.example.com/storage/v1/constraints");
+  });
 });

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -30,8 +30,30 @@ export type SupaCloudProjectCapabilities = {
   project_ref: string;
   auth_runtime: string;
   schema_version: number;
+  platform_version?: string;
+  environment?: string;
+  storage_backend?: string;
   capabilities: Record<string, SupaCloudCapability>;
   [key: string]: unknown;
+};
+
+export type SupaCloudEnvironmentInfo = {
+  projectRef: string;
+  platformVersion: string;
+  environment: string;
+  schemaVersion: number;
+  authRuntime: string;
+  storageBackend?: string;
+  capabilities: Record<string, SupaCloudCapability>;
+  [key: string]: unknown;
+};
+
+export type SupaCloudStoragePlatformConstraints = {
+  max_upload_size_bytes: number;
+  max_upload_size_mb: number;
+  tus_max_size_bytes: number;
+  tus_chunk_max_size_bytes: number;
+  streaming_upload_supported: boolean;
 };
 
 export type SupaCloudStorageUploadConstraints = {
@@ -838,10 +860,25 @@ function decodeProjectCapabilities(value: unknown): SupaCloudProjectCapabilities
     };
   }
   return {
+    ...record,
     project_ref: responseString(record, "project_ref", "project capabilities"),
     auth_runtime: typeof record.auth_runtime === "string" ? record.auth_runtime : "unknown",
     schema_version: typeof record.schema_version === "number" ? record.schema_version : 1,
+    platform_version: typeof record.platform_version === "string" ? record.platform_version : undefined,
+    environment: typeof record.environment === "string" ? record.environment : undefined,
+    storage_backend: typeof record.storage_backend === "string" ? record.storage_backend : undefined,
     capabilities,
+  };
+}
+
+function decodeStoragePlatformConstraints(value: unknown): SupaCloudStoragePlatformConstraints {
+  const record = responseRecord(value, "storage constraints");
+  return {
+    max_upload_size_bytes: responseNumber(record, "max_upload_size_bytes", "storage constraints"),
+    max_upload_size_mb: responseNumber(record, "max_upload_size_mb", "storage constraints"),
+    tus_max_size_bytes: responseNumber(record, "tus_max_size_bytes", "storage constraints"),
+    tus_chunk_max_size_bytes: responseNumber(record, "tus_chunk_max_size_bytes", "storage constraints"),
+    streaming_upload_supported: responseBoolean(record, "streaming_upload_supported", "storage constraints"),
   };
 }
 
@@ -1706,9 +1743,36 @@ export class SupaCloudCapabilitiesClient<TClient extends SupabaseClient = Supaba
     const res = await this.get();
     return res.capabilities?.[capabilityKey]?.available === true;
   }
+
+  async getVersion(): Promise<string> {
+    const res = await this.get();
+    return res.platform_version ?? "unknown";
+  }
+
+  async getEnvironment(): Promise<SupaCloudEnvironmentInfo> {
+    const res = await this.get();
+    return {
+      projectRef: res.project_ref,
+      platformVersion: res.platform_version ?? "unknown",
+      environment: res.environment ?? "production",
+      schemaVersion: res.schema_version,
+      authRuntime: res.auth_runtime,
+      storageBackend: res.storage_backend,
+      capabilities: res.capabilities,
+    };
+  }
 }
 
 export class SupaCloudStorageClient<TClient extends SupabaseClient = SupabaseClient> extends SupaCloudManagementClient<TClient> {
+  async getPlatformConstraints(): Promise<SupaCloudStoragePlatformConstraints> {
+    return this.request<SupaCloudStoragePlatformConstraints>(
+      `/storage/v1/constraints`,
+      "GET",
+      undefined,
+      decodeStoragePlatformConstraints,
+    );
+  }
+
   async getUploadConstraints(bucketId: string): Promise<SupaCloudStorageUploadConstraints> {
     try {
       const { data, error } = await this.options.supabase.storage.getBucket(bucketId);
@@ -1816,6 +1880,8 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
     queues,
     capabilities,
     storage,
+    getEnvironment: () => capabilities.getEnvironment(),
+    getVersion: () => capabilities.getVersion(),
     queue: (name: string) => new SupaCloudQueueClient(normalized, name),
     functions: {
       invokeBackground: (


### PR DESCRIPTION
## Problem & Context
1. Official MinIO upstream has been archived / transitioned away from open-source maintenance. Pigsty actively maintains [Silo](https://silo.pgsty.com/) (`pgsty/silo`), a pure-Golang drop-in Apache-2.0 replacement preserving the S3 API, `/minio/health/live`, `MINIO_*` variables, and storage formats. SupaCloud CI MinIO fixture needed to run `pgsty/silo` instead of archived official MinIO.
2. Client applications need structured environment and platform version discovery to adapt feature behavior and handle compatibility dynamically.
3. Storage upload limits need to be discoverable by clients so they know platform ceilings and can negotiate appropriate upload strategies.

## Changes
- **Pigsty Silo MinIO**: Replaced `quay.io/minio/minio:latest` with `pgsty/silo:latest` in `.github/workflows/management-api.yml` MinIO CI fixture.
- **Environment & Version APIs**:
  - Added public unauthenticated `GET /version` and `GET /v1/version` on Management API returning `{ version, environment, api_version }`.
  - Added project-scoped `GET /v1/projects/:ref/environment` returning `{ project_ref, platform_version, environment, schema_version, auth_runtime, storage_backend }`.
  - Enriched `GET /v1/projects/:ref/capabilities` with `platform_version`, `environment`, and `storage_backend`.
- **Storage Upload Constraints**:
  - Added `GET /storage/v1/constraints` and `GET /constraints` returning platform max upload size, TUS max size, chunk size, and streaming support.
  - Enriched HTTP 413 responses with `max_bytes` for client-side limit negotiation.
- **SupaCloud JS SDK**:
  - Added `client.getVersion()` and `client.getEnvironment()`.
  - Added `capabilities.getVersion()` and `capabilities.getEnvironment()`.
  - Added `storage.getPlatformConstraints()`.

## Validation
- `bun test packages/supacloud-js` passed (32 tests).
- `packages/management-api` unit tests (`project-capabilities.routes.test.ts`, `storage-compat.sdk.test.ts`, `version-endpoints.test.ts`) passed (58 tests).
- Full JS SDK check suite passed (`build-command-dependencies`, `tsc -p tsconfig.commands.json`, `typecheck`, `typecheck:test`, `build`, `typecheck:consumer`, `bun test`).
- Management API typecheck and Swagger route coverage checks passed (313/313 handlers, 100%).